### PR TITLE
View User Group Memberships Feature

### DIFF
--- a/src/groups/dto/membership/group-membership-search.dto.ts
+++ b/src/groups/dto/membership/group-membership-search.dto.ts
@@ -1,6 +1,6 @@
 import SearchDto from '../../../shared/dto/search.dto';
 
 export default class GroupMembershipSearchDto extends SearchDto {
-  groupId: number;
-  contactId: number;
+  groupId?: number;
+  contactId?: number;
 }

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -88,3 +88,8 @@ export class GroupsMembershipService {
     await this.repository.delete(id);
   }
 }
+
+
+
+
+

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -53,3 +53,7 @@ export class UsersController {
   }
 }
 
+
+
+
+

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -14,3 +14,7 @@ import { crmEntities } from '../crm/crm.helpers';
 })
 export class UsersModule {
 }
+
+
+
+

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@nestjs/common';
+import {Injectable, HttpException} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {Repository} from 'typeorm';
 import {User} from './user.entity';
@@ -101,4 +101,11 @@ export class UsersService {
         const count = await this.repository.count({where: {username}});
         return count > 0;
     }
+
 }
+
+
+
+
+
+


### PR DESCRIPTION
**What does this PR do?** 

- Adds a feature that allows the user to view a list of groups that they are a member of.

**Description of tasks?**

- Users are able to view the groups that they are members of.

**How can you test this manually?**

- Send a request to the page `localhost:4002/api/users/user-groups/{:id}` where `:id` is the userID.
- Response will include a message, `"message": "Group Memberships for <user> [<count> group(s)]"`, and a list of groups the user is a member of.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/102324050-5643ef80-3f92-11eb-95c8-90366f7e327f.png)
