### PR TITLE
User Account Status

### DIFF
--- a/src/users/dto/create-user-response.dto.ts
+++ b/src/users/dto/create-user-response.dto.ts
@@ -1,0 +1,12 @@
+import { User } from "../user.entity";
+import { UserListDto } from "./user-list.dto";
+
+export class CreateUserResponseDto {
+    token: string;
+    mailURL: string;
+    user: UserListDto;
+}
+
+
+
+

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,23 +1,19 @@
 import { Body, Controller, Delete, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import SearchDto from '../shared/dto/search.dto';
-import { User } from './user.entity';
 import { ApiTags } from '@nestjs/swagger';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserListDto } from './dto/user-list.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { InjectRepository } from '@nestjs/typeorm';
-import Email from '../crm/entities/email.entity';
-import { Repository } from 'typeorm';
+import { CreateUserResponseDto } from './dto/create-user-response.dto';
 
 @UseGuards(JwtAuthGuard)
 @ApiTags('Users')
 @Controller('api/users')
 export class UsersController {
-  constructor(@InjectRepository(Email)
-              private readonly emailRepository: Repository<Email>,
-              private readonly service: UsersService) {
+  constructor(
+    private readonly service: UsersService) {
   }
 
   @Get()
@@ -25,20 +21,13 @@ export class UsersController {
     return this.service.findAll(req);
   }
 
-  @Post()
-  async create(@Body()data: CreateUserDto): Promise<User> {
-    const email = await this.emailRepository.findOne({ where: { contactId: data.contactId } });
-    const toSave = new User();
-    toSave.username = email.value;
-    toSave.contactId = data.contactId ;
-    toSave.password = data.password;
-    toSave.roles = data.roles;
-    toSave.hashPassword();
-    return await this.service.create(toSave);
+  @Post('create-user')
+  async create(@Body() data: CreateUserDto): Promise<CreateUserResponseDto> {
+    return await this.service.createUser(data);
   }
 
   @Put()
-  async update(@Body()data: UpdateUserDto): Promise<UserListDto> {
+  async update(@Body() data: UpdateUserDto): Promise<UserListDto> {
     return await this.service.update(data);
   }
 

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -5,10 +5,20 @@ import { usersEntities } from './users.helpers';
 import { UsersController } from './users.controller';
 import { CrmModule } from '../crm/crm.module';
 import { crmEntities } from '../crm/crm.helpers';
+import { AppService } from 'src/app.service';
+import { JwtStrategy } from 'src/auth/strategies/jwt.strategy';
+import { JwtModule } from '@nestjs/jwt';
+import { jwtConstants } from 'src/auth/constants';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([...usersEntities,...crmEntities]), CrmModule],
-  providers: [UsersService],
+  imports: [
+    TypeOrmModule.forFeature([...usersEntities,...crmEntities]), 
+    CrmModule,
+    JwtModule.register({
+      secret: jwtConstants.secret,
+      signOptions: { expiresIn: '60m' },
+    }),],
+  providers: [UsersService, AppService, JwtStrategy],
   exports: [UsersService],
   controllers: [UsersController],
 })

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,8 @@
-import {Injectable} from '@nestjs/common';
+import {HttpException, Injectable} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {Repository} from 'typeorm';
 import {User} from './user.entity';
+import Email from 'src/crm/entities/email.entity';
 import {RegisterUserDto} from '../auth/dto/register-user.dto';
 import SearchDto from '../shared/dto/search.dto';
 import {ContactsService} from '../crm/contacts.service';
@@ -11,12 +12,22 @@ import {UserListDto} from "./dto/user-list.dto";
 import {getPersonFullName} from "../crm/crm.helpers";
 import {hasValue} from "../utils/basicHelpers";
 import {QueryDeepPartialEntity} from "typeorm/query-builder/QueryPartialEntity";
+import {CreateUserDto} from './dto/create-user.dto';
+import {CreateUserResponseDto} from './dto/create-user-response.dto';
+import {IEmail, sendEmail} from 'src/utils/mailerTest';
+import {JwtService} from '@nestjs/jwt';
+import {UserDto} from 'src/auth/dto/user.dto';
+import {LoginResponseDto} from 'src/auth/dto/login-response.dto';
+
 
 @Injectable()
 export class UsersService {
     constructor(
         @InjectRepository(User)
         private readonly repository: Repository<User>,
+        @InjectRepository(Email)
+        private readonly emailRepository: Repository<Email>,
+        private readonly jwtService: JwtService,
         private readonly contactsService: ContactsService,
     ) {
     }
@@ -46,9 +57,67 @@ export class UsersService {
         }
     }
 
+    async generateToken(user: UserDto): Promise<LoginResponseDto> {
+        const payload = { ...user, sub: user.id };
+        const token = await this.jwtService.signAsync(payload);
+        return { token, user };
+    }
+
     async create(data: User): Promise<User> {
         data.hashPassword();
         return await this.repository.save(data);
+    }
+
+    async createUser(data: CreateUserDto): Promise<CreateUserResponseDto> {
+        if (!(await(this.contactsService.findOne(data.contactId)))) {
+            throw new HttpException("Visitor Not Found", 404);
+        }
+        const email = await this.emailRepository.findOne({where: {contactId: data.contactId}});
+        const toSave = new User();
+        toSave.username = email.value;
+        toSave.contactId = data.contactId;
+        toSave.password = data.password;
+        toSave.roles = data.roles;
+        toSave.hashPassword();
+
+        const saveUser = await this.create(toSave);
+        if (!saveUser) {
+            this.remove(saveUser.id);
+            throw new HttpException("User Not Created", 400);
+        }
+
+        const user = await this.findOne(saveUser.id);
+        if (!user) {
+            this.remove(user.id);
+            throw new HttpException("Failed To Create User", 400);
+        }
+        
+        const token = (
+            await this.generateToken({
+                id: user.id,
+                contactId: user.contactId,
+                username: user.username,
+                email: user.username,
+                fullName: user.fullName,
+                roles: user.roles
+            })
+        ).token;
+
+        const resetLink = `http://localhost:4002/resetPassword/`;
+        const mailerData: IEmail = {
+            to: `${(await user).username}`,
+            subject: "Account Activated!",
+            html:
+            `
+                <h3>Hello ${user.fullName}</h3></br>
+                <h4>Your Account Has Been Activated!!<h4></br>
+                <h4>Follow This <a href=${resetLink}>Link</a> To Reset Your Password</h5>
+                <p>This link should expire in 10 minutes</p>
+            `
+        } 
+        const mailURL = await sendEmail(mailerData);
+
+        return {token, mailURL, user};
     }
 
     async register(dto: RegisterUserDto): Promise<User> {

--- a/src/utils/mailerTest.ts
+++ b/src/utils/mailerTest.ts
@@ -1,0 +1,35 @@
+const nodemailer = require("nodemailer");
+
+export interface IEmail {
+    to: string
+    subject: string
+    html: string
+}
+
+export async function sendEmail(data: IEmail): Promise<string> {
+    const testAccount = await nodemailer.createTestAccount();
+
+    const transporter = nodemailer.createTransport({
+        host: "smtp.ethereal.email",
+        port: 587,
+        secure: false,
+        auth: {
+            user: testAccount.user,
+            pass: testAccount.pass
+        }
+    });
+    const mailOptions = {
+        from: testAccount.user,
+        to: data.to,
+        subject: data.subject,
+        html: data.html
+    };
+    const info = await transporter.sendMail(mailOptions)
+    return nodemailer.getTestMessageUrl(info);
+}
+
+
+
+
+
+


### PR DESCRIPTION
**What does this PR do?**

- Adds the feature that allows users to their account status via email.

**Description of tasks?**

- When a visitor is made a user, an email is sent to notifying them that they are now a user. The email will also have a link to allow the user to change the password that was temporarily set.

**How can you test this manually?**

- A visitor would have to exist already by sending a request to `localhost:4002/api/register`.
- Run `localhost:4002/api/users/create-user` and provide body: 
`{         "contactId": "number",
            "username": "string",
            "password": "string",
            "roles": [
                     "string"
             ]
}`
- The response will be an authentication token, the link to the test email and the user created.

**Screenshot(s)**
![image](https://user-images.githubusercontent.com/68650343/102494357-9932bf80-4085-11eb-9de1-6da4691a172a.png)
