### PR TITLE
Users and Team Leaders View Groups Feature

### DIFF
--- a/src/groups/dto/membership/group-membership.dto.ts
+++ b/src/groups/dto/membership/group-membership.dto.ts
@@ -5,6 +5,7 @@ export default class GroupMembershipDto {
     id: number;
     group: ComboDto;
     groupId: number;
+    groupDetails: string;
     contact: ComboDto;
     contactId: number;
     role: GroupRole;

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -7,7 +7,6 @@ import GroupMembership from '../entities/groupMembership.entity';
 import GroupMembershipDto from '../dto/membership/group-membership.dto';
 import { getPersonFullName } from '../../crm/crm.helpers';
 import GroupMembershipSearchDto from '../dto/membership/group-membership-search.dto';
-
 import ClientFriendlyException from '../../shared/exceptions/client-friendly.exception';
 import UpdateGroupMembershipDto from '../dto/membership/update-group-membership.dto';
 import BatchGroupMembershipDto from '../dto/membership/batch-group-membership.dto';
@@ -33,7 +32,7 @@ export class GroupsMembershipService {
     if (hasNoValue(filter))
       throw  new ClientFriendlyException('Please groupID or contactId');
     const data = await this.repository.find({
-      relations: ['contact', 'contact.person'],
+      relations: ['contact', 'contact.person', 'group'],
       skip: req.skip,
       take: req.limit,
       where: filter,
@@ -46,6 +45,7 @@ export class GroupsMembershipService {
     return {
       ...rest,
       group: group ? { name: group.name, id: group.id } : null,
+      groupDetails: group.details,
       contact: { name: getPersonFullName(contact.person), id: contact.id },
     };
   }


### PR DESCRIPTION
**What does this PR do?**

- Adds feature that allows users and team leaders to view teams/groups they are a part of.

**Description of tasks?**

- Team leaders and users are able to view a list of teams/groups they are members of.

**How can you test this manually?**

- In Postman, run `localhost:4002/api/groups/member?contactId={contactId}`.
- In response, we will receive an array of objects populated with details about the user's memberships

**Screenshot(s)**

![image](https://user-images.githubusercontent.com/68650343/103872705-d0721a80-50df-11eb-9179-103579fc8e04.png)
