### PR TITLE
Ref-011 Activate/Block User Feature

### DIFF
--- a/src/auth/auth.helpers.ts
+++ b/src/auth/auth.helpers.ts
@@ -14,5 +14,6 @@ export const createUserDto = (user: User): UserDto => {
     fullName: getPersonFullName(user.contact.person),
     id: user.id,
     roles: user.roles,
+    isActive: user.isActive,
   };
 };

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -24,6 +24,12 @@ export class AuthService {
       Logger.warn('invalid username: ', username);
       return null;
     }
+
+    if(!user.isActive) {
+      Logger.warn('User Inactive', username);
+      return null;
+    }
+
     const valid = await user.validatePassword(pass);
     if (valid) {
       cleanUpUser(user);
@@ -78,7 +84,8 @@ export class AuthService {
     const data: UpdateUserDto = {
       id: decodedToken.id,
       password: newPassword,
-      roles: (await this.usersService.findOne(decodedToken.userId)).roles
+      roles: (await this.usersService.findOne(decodedToken.userId)).roles,
+      isActive: (await this.usersService.findOne(decodedToken.userId)).isActive,
     }
     const user = await this.usersService.update(data);
     if(!user) {

--- a/src/auth/dto/user.dto.ts
+++ b/src/auth/dto/user.dto.ts
@@ -13,4 +13,6 @@ export class UserDto {
   fullName: string;
   @ApiProperty()
   roles: string[];
+  @ApiProperty()
+  isActive: boolean;
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -10,4 +10,6 @@ export class CreateUserDto {
   password: string;
   @IsNotEmpty()
   roles: string[];
+  @IsNotEmpty()
+  isActive: boolean;
 }

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -7,6 +7,6 @@ export class UpdateUserDto {
 
     @IsNotEmpty()
     roles: string[];
-
     password?: string;
+    isActive?: boolean;
 }

--- a/src/users/dto/user-list.dto.ts
+++ b/src/users/dto/user-list.dto.ts
@@ -6,4 +6,5 @@ export class UserListDto {
     contact: any
     avatar: string
     roles: string[]
+    isActive: boolean
 }

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -29,6 +29,9 @@ export class User {
     @Column("simple-array",{nullable: false})
     roles: string[];
 
+    @Column()
+    isActive: boolean;
+
     hashPassword() {
         if (hasValue(this.password)) {
             this.password = bcrypt.hashSync(this.password, hashCost);

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -16,12 +16,13 @@ export class UsersController {
     private readonly service: UsersService) {
   }
 
+  
   @Get()
   async findAll(@Query() req: SearchDto): Promise<UserListDto[]> {
     return this.service.findAll(req);
   }
 
-  @Post('create-user')
+  @Post()
   async create(@Body() data: CreateUserDto): Promise<CreateUserResponseDto> {
     return await this.service.createUser(data);
   }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, HttpException} from '@nestjs/common';
+import {Injectable, HttpException, Logger} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {Repository} from 'typeorm';
 import {User} from './user.entity';
@@ -51,6 +51,7 @@ export class UsersService {
             },
             id: user.id,
             roles: user.roles,
+            isActive: user.isActive,
             username: user.username,
             contactId: user.contactId,
             fullName
@@ -78,6 +79,7 @@ export class UsersService {
         toSave.contactId = data.contactId;
         toSave.password = data.password;
         toSave.roles = data.roles;
+        toSave.isActive = data.isActive;
         toSave.hashPassword();
 
         const saveUser = await this.create(toSave);
@@ -99,7 +101,8 @@ export class UsersService {
                 username: user.username,
                 email: user.username,
                 fullName: user.fullName,
-                roles: user.roles
+                roles: user.roles,
+                isActive: user.isActive,
             })
         ).token;
 
@@ -126,7 +129,8 @@ export class UsersService {
         user.username = dto.email;
         user.password = dto.password;
         user.contact = Contact.ref(contact.id);
-        user.roles = dto.roles
+        user.roles = dto.roles;
+        user.isActive = true;
         user.hashPassword();
         return await this.repository.save(user);
     }
@@ -140,7 +144,8 @@ export class UsersService {
 
     async update(data: UpdateUserDto): Promise<UserListDto> {
         const update: QueryDeepPartialEntity<User> = {
-            roles: data.roles
+            roles: data.roles,
+            isActive: data.isActive
         }
 
         if (hasValue(data.password)) {


### PR DESCRIPTION
**What does this PR do?**

- This PR adds the feature that allows administrators to activate or block users.

**Description of tasks?**

- Admins can now approve and block users. Blocked users will not be able to sign in with their credentials.

**How can I test this manually?**
- In Postman or Insomnia, make a `PUT request` to `localhost:4000/api/users` and give the request body: 
```json
{
  "id": 0,
  "roles": [
    "string"
  ],
  "password": "string",
  "isActive": true
}
``` 
- Database should update to make user active or inactive.

**ScreenShot(s)**

- Before Update
![image](https://user-images.githubusercontent.com/68650343/106250437-af0ad700-6224-11eb-9b01-41f3854d087b.png)

- PUT request
![image](https://user-images.githubusercontent.com/68650343/106250473-bdf18980-6224-11eb-9a8b-59af390b4f4c.png)

- After Update
![image](https://user-images.githubusercontent.com/68650343/106250493-c34ed400-6224-11eb-9c15-e38371424a58.png)
