### PR TITLE
Ref-012. As MC admin, I can view the people who've signed up for an MC

### DIFF
--- a/src/crm/dto/create-request.dto.ts
+++ b/src/crm/dto/create-request.dto.ts
@@ -1,0 +1,13 @@
+export default class CreateRequestDto {
+
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    churchLocation: number;
+    residencePlaceId: string;
+    residenceDescription: string;
+
+}
+
+

--- a/src/groups/controllers/group-membership-request.contoller.ts
+++ b/src/groups/controllers/group-membership-request.contoller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import {ApiTags} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import GroupMembershipRequestDto from '../dto/membershipRequest/group-membership-request.dto';
+import NewRequestDto from '../dto/membershipRequest/new-request.dto';
+import GroupMembershipRequestSearchDto from '../dto/membershipRequest/search-request.dto';
+import { GroupMembershipRequestService } from '../services/group-membership-request.service';
+
+@UseGuards(JwtAuthGuard)
+@ApiTags('Groups Membership Request')
+@Controller('api/groups/request')
+export class GroupMembershipReqeustController {
+    constructor(
+        private readonly service: GroupMembershipRequestService) {
+    }
+
+    @Get()
+    async findAll(@Query() req: GroupMembershipRequestSearchDto): Promise<GroupMembershipRequestDto[]> {
+        return await this.service.findAll(req);
+    }
+
+    @Post()
+    async create(@Body() data: NewRequestDto): Promise<GroupMembershipRequestDto | any> {
+        return await this.service.create(data);
+    }
+
+    @Put()
+    async update(): Promise<any> {
+        return await this.service.update;
+    }
+
+    @Get(':id')
+    async findOne(@Param('id') id: number): Promise<any> {
+        return await this.service.findOne(id);
+    }
+
+    @Delete(':id')
+    async remove(@Param('id') id: number): Promise<any> {
+        return await this.service.remove(id);
+    }
+}
+
+
+

--- a/src/groups/dto/membershipRequest/group-membership-request.dto.ts
+++ b/src/groups/dto/membershipRequest/group-membership-request.dto.ts
@@ -1,0 +1,20 @@
+export default class GroupMembershipRequestDto {
+
+    id: number;
+    contactId: number;
+    parentId?: number;
+    groupId: number;
+    distanceKm?: number;
+    group: {
+        id: number;
+        name: string;
+        parentId?: number;
+    };
+    contact: {
+        id: number;
+        fullName: string;
+        avatar: string;
+    }
+}
+
+

--- a/src/groups/dto/membershipRequest/new-request.dto.ts
+++ b/src/groups/dto/membershipRequest/new-request.dto.ts
@@ -1,0 +1,16 @@
+import { IsNotEmpty, IsNumber } from "class-validator";
+
+
+export default class NewRequestDto {
+
+    contactId: number;
+    email: string;
+    phone: string;
+    churchLocation: number;
+    residencePlaceId: string;
+    residenceDescription: string;
+
+}
+
+
+

--- a/src/groups/dto/membershipRequest/search-request.dto.ts
+++ b/src/groups/dto/membershipRequest/search-request.dto.ts
@@ -1,0 +1,9 @@
+import SearchDto from '../../../shared/dto/search.dto';
+
+export default class GroupMembershipRequestSearchDto extends SearchDto {
+    parentId?: number;
+    groupId?: number;
+    contactId?: number;
+}
+
+

--- a/src/groups/entities/group.entity.ts
+++ b/src/groups/entities/group.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColum
 import { GroupPrivacy } from '../enums/groupPrivacy';
 import GroupCategory from './groupCategory.entity';
 import GroupMembership from './groupMembership.entity';
+import GroupMembershipRequest from './groupMembershipRequest.entity';
 
 @Entity()
 export default class Group {
@@ -60,4 +61,8 @@ export default class Group {
   @JoinColumn()
   @OneToMany(type => GroupMembership, it => it.group)
   members: GroupMembership[];
+
+  @JoinColumn()
+  @OneToMany(type => GroupMembershipRequest, it => it.group)
+  groupMembershipRequests: GroupMembershipRequest[];
 }

--- a/src/groups/entities/groupMembershipRequest.entity.ts
+++ b/src/groups/entities/groupMembershipRequest.entity.ts
@@ -1,5 +1,6 @@
 import Contact from "src/crm/entities/contact.entity";
 import { PrimaryGeneratedColumn, Column, Entity, JoinColumn, ManyToOne } from "typeorm";
+import Group from "./group.entity";
 
 @Entity()
 export default class GroupMembershipRequest{
@@ -16,11 +17,15 @@ export default class GroupMembershipRequest{
     @Column({ nullable: true })
     parentId?: number;
 
-    @Column()
-    closestCellGroupId: number;
+    @JoinColumn()
+    @ManyToOne(type => Group, it => it.groupMembershipRequests)
+    group: Group;
 
     @Column()
-    distanceKm: number;
+    groupId: number;
+    
+    @Column()
+    distanceKm?: number | null;
 
 }
 

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -9,14 +9,18 @@ import { GroupComboController } from './controllers/group-combo.controller';
 import { GroupsMembershipService } from './services/group-membership.service';
 import { GroupMembershipController } from './controllers/group-membership.controller';
 import { VendorModule } from '../vendor/vendor.module';
+import { GroupMembershipReqeustController } from './controllers/group-membership-request.contoller';
+import { GroupMembershipRequestService } from './services/group-membership-request.service';
+import { ContactsService } from 'src/crm/contacts.service';
+import { crmEntities } from 'src/crm/crm.helpers';
 
 @Module({
   imports: [
     VendorModule,HttpModule,
-    TypeOrmModule.forFeature([...groupEntities])
+    TypeOrmModule.forFeature([...groupEntities, ...crmEntities])
   ],
-  providers: [GroupsService, GroupCategoriesService, GroupsMembershipService],
-  controllers: [GroupController, GroupCategoryController, GroupComboController, GroupMembershipController],
+  providers: [GroupsService, GroupCategoriesService, GroupsMembershipService, GroupMembershipRequestService, ContactsService],
+  controllers: [GroupController, GroupCategoryController, GroupComboController, GroupMembershipController, GroupMembershipReqeustController],
   exports: [GroupsService, GroupCategoriesService],
 })
 export class GroupsModule {

--- a/src/groups/services/group-membership-request.service.ts
+++ b/src/groups/services/group-membership-request.service.ts
@@ -1,0 +1,108 @@
+import { HttpException, Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { FindConditions } from 'typeorm/find-options/FindConditions';
+import { Repository } from "typeorm";
+import GroupMembershipRequestSearchDto from "../dto/membershipRequest/search-request.dto";
+import GroupMembershipRequest from "../entities/groupMembershipRequest.entity";
+import { hasValue } from '../../utils/basicHelpers';
+import GroupMembershipRequestDto from "../dto/membershipRequest/group-membership-request.dto";
+import NewRequestDto from "../dto/membershipRequest/new-request.dto";
+import { getPersonFullName } from "src/crm/crm.helpers";
+import { ContactsService } from "src/crm/contacts.service";
+import CreateRequestDto from "src/crm/dto/create-request.dto";
+import Contact from "src/crm/entities/contact.entity";
+
+@Injectable()
+export class GroupMembershipRequestService {
+    constructor (
+        @InjectRepository(GroupMembershipRequest)
+        private readonly repository: Repository<GroupMembershipRequest>,
+        @InjectRepository(Contact)
+        private readonly contactRepository: Repository<Contact>,
+        private readonly contactService: ContactsService,
+    ) {
+    }
+
+    async findAll(req: GroupMembershipRequestSearchDto): Promise<GroupMembershipRequestDto[]> {
+
+        const filter: FindConditions<GroupMembershipRequest> = {};
+
+        if (hasValue(req.contactId)) filter.contactId = req.contactId;
+        if (hasValue(req.parentId)) filter.parentId = req.parentId;
+        if (hasValue(req.groupId)) filter.groupId = req.groupId;
+
+        const data = await this.repository.find({
+            relations: ['contact', 'contact.person', 'group'],
+            skip: req.skip,
+            take: req.limit,
+            where: filter,
+        })
+        return data.map(this.toDto);
+    }
+
+    toDto(data: GroupMembershipRequest): GroupMembershipRequestDto {
+        const {group, contact, ...rest} = data;
+        return {
+            ...rest,
+            group: {
+                id: group.id,
+                name: group.name,
+                parentId: group.parentId,
+            },
+            contact: {
+                id: contact.id,
+                fullName: getPersonFullName(contact.person), 
+                avatar: contact.person.avatar,
+            },
+        }
+    }
+
+    async create(data: NewRequestDto): Promise<GroupMembershipRequestDto | any> {
+
+        const user = await this.contactRepository.findOne(data.contactId, {
+            relations: ['person']
+        });
+
+        const isPendingRequest = await this.repository.count({where: {contactId: data.contactId}});
+        if (isPendingRequest > 0) {
+            throw new HttpException("User already has a pending request", 400)
+        }
+
+        const info: CreateRequestDto = {
+            firstName: user.person.firstName,
+            lastName: user.person.lastName,
+            email: data.phone,
+            phone: data.email,
+            churchLocation: data.churchLocation,
+            residencePlaceId: data.residencePlaceId,
+            residenceDescription: data.residenceDescription
+        }
+
+        await this.contactService.createRequest(info);
+
+        return (await this.repository.find({
+            where: {contactId: data.contactId},
+            relations: ['contact', 'contact.person', 'group'],
+        })).map(this.toDto)
+    }
+
+    async update(): Promise<any>  {
+        return "Not Yet Implemented"
+    }
+
+    async findOne(id: number): Promise<GroupMembershipRequestDto> {
+        return this.toDto(await this.repository.findOne(id, {
+            relations: ['contact', 'contact.person', 'group']
+        }));
+    }
+
+    async remove(id: number): Promise<void> {
+        await this.repository.delete(id);
+    } 
+
+}
+
+
+
+
+

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -58,7 +58,7 @@ export class GroupsService {
   async combo(req: GroupSearchDto): Promise<Group[]> {
     const findOps: FindConditions<Group> = {};
     if (hasValue(req.categories)) {
-      findOps.categoryId = In(req.categories);
+      findOps.categoryId = String(In(req.categories));
     }
     if (hasValue(req.query)) {
       findOps.name = Like(`%${req.query}%`);


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows users to make actions to the contacts in the `group-membership-request` table.

**Description of tasks?**

- We can now do the following to contacts in the `group-membership-request` table:
1. Return a list of contacts in the table. These results can also be filtered by `groupId`, `parentId` and `contactId`.
2. Create a new request
3. Retrieve a contact in the table, given an ID
4. Delete a contact from the table, for when the user has been approved to join the MC they requested to join.

**How can I test this manually?**

- In Postman, we can make a `GET`, `POST` and `DELETE` request to `localhost:4000/api/groups/request`

**Screenshot(s)**

- `GET` request -> return all requests from table

![image](https://user-images.githubusercontent.com/68650343/107704019-a529af00-6ccd-11eb-8a94-6a2836d74b5f.png)

- `POST` request -> create  new request

![image](https://user-images.githubusercontent.com/68650343/107703897-65fb5e00-6ccd-11eb-80f3-423a383c8f64.png)

- `GET` request - > get request with id = {id} from table

![image](https://user-images.githubusercontent.com/68650343/107704131-d1453000-6ccd-11eb-84d2-9995e62ffd29.png)

- `DELETE` request -> delete request from table

![image](https://user-images.githubusercontent.com/68650343/107704206-ede16800-6ccd-11eb-83f1-3d172d939380.png)
