### PR TITLE
Ref-020 As an MC leader, I can see the percentage of those that attended [total number of people who attended MC / total number of people in MCs] for my MC

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -23,7 +23,7 @@ export class EventsService {
 
   async findAll(req: SearchDto): Promise<GroupEventDto[]> {
     const data = await this.repository.find({
-      relations: ['category'],
+      relations: ['category', 'group', 'group.members', 'attendance'],
       skip: req.skip,
       take: req.limit,
     });


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows MC Leaders to view attendance of a particular event, as a percentage.

**Description of tasks?**

- MC Leaders will now be able to see what percentage of its members have attended each recorded event.

[Link to Frontend Pull Request](https://github.com/kanzucode/angie-client/pull/43)