### PR TITLE
As a church member, I can view generic church metrics

### DIFF
--- a/src/events/dto/group-event-search.dto.ts
+++ b/src/events/dto/group-event-search.dto.ts
@@ -4,6 +4,8 @@ export default class GroupEventSearchDto extends SearchDto {
     parentId?: number;
     groupId?: number;
     categoryId?:string;
+    periodStart?: Date;
+    periodEnd?: Date;
 }
 
 

--- a/src/events/dto/group-event.dto.ts
+++ b/src/events/dto/group-event.dto.ts
@@ -29,6 +29,7 @@ export default class GroupEventDto {
     id: number;
     name: string;
     parentId?: number;
+    members: any;
   };
 
   metaData?: any;

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindConditions, Repository } from 'typeorm';
+import { FindConditions, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { GoogleService } from '../vendor/google.service';
 import GooglePlaceDto from '../vendor/google-place.dto';
 import ClientFriendlyException from '../shared/exceptions/client-friendly.exception';
@@ -29,10 +29,13 @@ export class EventsService {
     if (hasValue(req.parentId)) filter.parentId = req.parentId;
     if (hasValue(req.groupId)) filter.groupId = req.groupId;
     if (hasValue(req.categoryId)) filter.categoryId = req.categoryId;
-
+    if(hasValue(req.periodStart) && hasValue(req.periodEnd)) {
+      filter.startDate = MoreThanOrEqual(req.periodStart);
+      filter.endDate = LessThanOrEqual(req.periodEnd);
+    }
+     
     const data = await this.repository.find({
       relations: ['category', 'group', 'group.members', 'attendance'],
-
       skip: req.skip,
       take: req.limit,
       where: filter,
@@ -48,6 +51,7 @@ export class EventsService {
         id: group.id,
         name: group.name,
         parentId: group.parentId,
+        members: group.members,
       },
     };
   }


### PR DESCRIPTION
**What does this PR do?**

- This PR adds a feature that allows users to see church metrics

**Description of tasks?**

- Users can now see church metrics on the Angie dashboard. Every week, the metrics are updated to highlight the metrics for that current week. A percentage change of the previous and current week is also calculated and displayed on the dashboard.

Link to frontend pull request