### PR TITLE
Ref-028, As a location pastor, I can see a list of MC reports in my location 

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -17,7 +17,7 @@ import GroupEventDto from './dto/group-event.dto';
 import CreateEventDto from './dto/create-event.dto';
 import InternalAddress from '../shared/entity/InternalAddress';
 import GroupEventSearchDto from './dto/group-event-search.dto';
-import { hasValue } from 'src/utils/validation';
+import { hasValue, getArray } from 'src/utils/validation';
 import { UserDto } from '../auth/dto/user.dto';
 import EventMetricsDto from './dto/event-metrics-search.dto';
 
@@ -39,10 +39,9 @@ export class EventsService {
 
     // TODO use user object to filter reports
     if (hasValue(req.categoryIdList))
-      filter.categoryId = In(req.categoryIdList);
-    if (hasValue(req.groupIdList)) filter.groupId = In(req.groupIdList);
-    if (hasValue(req.parentIdList)) filter.parentId = In(req.parentIdList);
-
+      filter.categoryId = In(getArray(req.categoryIdList));
+    if (hasValue(req.groupIdList)) filter.groupId = In(getArray(req.groupIdList));
+    if (hasValue(req.parentIdList)) filter.parentId = In(getArray(req.parentIdList));
     if (hasValue(req.from)) {
       filter.startDate = MoreThanOrEqual(req.from);
     }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -16,6 +16,11 @@ export const isValidNumber = (data: any) => {
 export const isArray = (data: any) => {
   return _isArray(data);
 };
+
+export function getArray(data: any) {
+  return Array.isArray(data) ? data : [data]; 
+} 
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const PasswordValidator = require('password-validator');
 


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a feature that allows location pastors to view a list of reports of Missional Community events under their Location
- This PR fixes an array issue in the `findAll` events endpoint 

**Description of tasks?**
- Location pastors can now see a list of reports created by missional community leaders under their location
- The findAll events endpoint now works with arrays that have one value in them

**How can I manually test this?**
- Go to a location group’s details page. Under the `Reports` tab there should be a list of reports created by missional communities under the location.

[Link to Frontend PR](https://github.com/kanzucode/angie-client/pull/52)
