### PR TITLE
Ref-032, As a location pastor, I can see the total attendance for my Location

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -54,7 +54,7 @@ export class EventsService {
     }
 
     const data = await this.repository.find({
-      relations: ['category', 'group'],
+      relations: ['category', 'group', 'attendance'],
       skip: req.skip,
       take: req.limit,
       where: filter,
@@ -98,16 +98,16 @@ export class EventsService {
   }
 
   toDto(data: GroupEvent): GroupEventDto {
-    const { group, ...rest } = data;
+    const { group, attendance, ...rest } = data;
     return {
       ...rest,
       group: {
         id: group.id,
         name: group.name,
         parentId: group.parentId,
-        members: [],
+        members: group.members,
       },
-      attendance: [],
+      attendance: attendance,
     };
   }
 

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -15,12 +15,14 @@ import { ContactsService } from 'src/crm/contacts.service';
 import { crmEntities } from 'src/crm/crm.helpers';
 import { GoogleService } from '../vendor/google.service';
 import { PrismaService } from '../shared/prisma.service';
+import { EventsService } from 'src/events/events.service';
+import { eventEntities } from 'src/events/events.helpers';
 
 @Module({
   imports: [
     VendorModule,
     HttpModule,
-    TypeOrmModule.forFeature([...groupEntities, ...crmEntities]),
+    TypeOrmModule.forFeature([...groupEntities, ...crmEntities, ...eventEntities]),
   ],
   providers: [
     GroupsService,
@@ -30,6 +32,7 @@ import { PrismaService } from '../shared/prisma.service';
     ContactsService,
     GoogleService,
     PrismaService,
+    EventsService,
   ],
   controllers: [
     GroupController,


### PR DESCRIPTION
**What does this PR do?**
This PR adds the feature that allows group leaders to see the total attendance and percentage attendance of the events held by groups under their group for the current month.

**Description of tasks?**
Group leaders can now see their group’s, and their children groups’, total and percentage attendance for the current month.

**How can I test this manually?**
In the groups details page, there will be a line displaying the groups total/percentage attendance. These numbers will change as group leaders add events and edit attendance for said events.

[Link to Frontend PR](https://github.com/kanzucode/angie-client/pull/53)