### PR TITLE
Fix-001. As an admin, I'd like to have reports filter by user roles, currently they're view by anyone.

### DIFF
--- a/src/events/dto/group-event.dto.ts
+++ b/src/events/dto/group-event.dto.ts
@@ -17,7 +17,7 @@ export default class GroupEventDto {
   submittedAt?: Date;
 
   submittedById?: number;
-  submittedBy: {
+  submittedBy?: {
     firstName: string;
     lastName: string;
     middleName?: string;

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -158,6 +158,13 @@ export class GroupsService {
         select: ['contactId'],
       });
       groupData.leaders = membership.map((it) => it.contactId);
+
+      groupData.reports = await this.eventRepository.find({
+        relations: ['category', 'attendance'],
+        where: {groupId: In(groupData.children)},
+        select: ['id', 'name', 'startDate'],
+      });
+    
       return groupData;
     }
     return this.toListView(data);


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a feature that allows users, with report viewing privileges, to see the reports of groups associated with the group they are a leader in.

**Description of tasks?**
- Logged in users will now have will now have a list of reports created by groups that they are linked to, i.e. descendants of the logged in user's group.

[Link to frontend PR](https://github.com/kanzucode/angie-client/pull/63)