### PR TITLE
Fix-004 As an admin, I'd like an error on adding user's new phone number and addresses fixed on user details.

### DIFF
--- a/src/crm/addresses.service.spec.ts
+++ b/src/crm/addresses.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AddressesService } from './addresses.service';
+
+describe('AddressesService', () => {
+  let service: AddressesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AddressesService],
+    }).compile();
+
+    service = module.get<AddressesService>(AddressesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/crm/addresses.service.ts
+++ b/src/crm/addresses.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { hasValue } from 'src/utils/validation';
+import GooglePlaceDto from 'src/vendor/google-place.dto';
+import { GoogleService } from 'src/vendor/google.service';
+import { Repository } from 'typeorm';
+import Address from './entities/address.entity';
+
+@Injectable()
+export class AddressesService {
+    constructor(
+        @InjectRepository(Address) private readonly repository: Repository<Address>,
+        private googleService: GoogleService,
+    ){}
+
+    async create(data: Address): Promise<Address> {
+        let place: GooglePlaceDto;
+        if (hasValue(data.placeId)) {
+            place = await this.googleService.getPlaceDetails(
+                data.placeId,
+            );
+          }
+
+          const getIsPrimary = await this.repository.find({
+            where: [{ contactId: data.contactId, isPrimary: true }],
+          });
+      
+          if (data.isPrimary === true) {
+            if (getIsPrimary.length > 0) {
+              await getIsPrimary.map((it) => {
+                const addresses = { ...it, isPrimary: false };
+                this.repository.save(addresses);
+              });
+            }
+          } else {
+            if (getIsPrimary.length < 1) {
+              data.isPrimary = true;
+            } else if (getIsPrimary.length > 1) {
+              await getIsPrimary.map((it) => {
+                const addresses = { ...it, isPrimary: false };
+                data.isPrimary = true;
+                this.repository.save(addresses);
+              });
+            }
+          }
+          //Get new Address details
+          const newAddress = {...data, ...place}
+        return await this.repository.save(newAddress);
+      }
+}

--- a/src/crm/contollers/addresses.controller.ts
+++ b/src/crm/contollers/addresses.controller.ts
@@ -15,6 +15,7 @@ import Address from '../entities/address.entity';
 import { Repository } from 'typeorm';
 import SearchDto from '../../shared/dto/search.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AddressesService } from '../addresses.service';
 
 @UseGuards(JwtAuthGuard)
 @ApiTags('Crm Addresses')
@@ -22,6 +23,8 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 export class AddressesController {
   constructor(
     @InjectRepository(Address) private readonly repository: Repository<Address>,
+
+    private readonly service:AddressesService
   ) {}
 
   @Get()
@@ -34,7 +37,7 @@ export class AddressesController {
 
   @Post()
   async create(@Body() data: Address): Promise<Address> {
-    return await this.repository.save(data);
+    return await this.service.create(data);
   }
 
   @Put()

--- a/src/crm/contollers/phones.controller.ts
+++ b/src/crm/contollers/phones.controller.ts
@@ -16,6 +16,7 @@ import { Repository } from 'typeorm';
 import SearchDto from '../../shared/dto/search.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { PhoneDto } from '../dto/phone.dto';
+import {PhonesService} from "../phones.service"
 
 @UseGuards(JwtAuthGuard)
 @ApiTags('Crm Phones')
@@ -23,6 +24,7 @@ import { PhoneDto } from '../dto/phone.dto';
 export class PhonesController {
   constructor(
     @InjectRepository(Phone) private readonly repository: Repository<Phone>,
+    private readonly service: PhonesService
   ) {}
 
   @Get()
@@ -34,8 +36,8 @@ export class PhonesController {
   }
 
   @Post()
-  async create(@Body() data: PhoneDto): Promise<Phone> {
-    return await this.repository.save(data);
+  async create(@Body() data: PhoneDto): Promise<Phone[]> {
+    return this.service.create(data);
   }
 
   @Put()

--- a/src/crm/crm.module.ts
+++ b/src/crm/crm.module.ts
@@ -19,6 +19,7 @@ import { ContactImportController } from './contollers/contact-import.controller'
 import { GroupFinderService } from './group-finder/group-finder.service';
 import { appEntities } from '../config';
 import { PhonesService } from './phones.service';
+import { AddressesService } from './addresses.service';
 
 @Global()
 @Module({
@@ -29,6 +30,7 @@ import { PhonesService } from './phones.service';
     PrismaService,
     GroupFinderService,
     PhonesService,
+    AddressesService,
   ],
   controllers: [
     ContactsController,

--- a/src/crm/crm.module.ts
+++ b/src/crm/crm.module.ts
@@ -18,6 +18,7 @@ import { PrismaService } from '../shared/prisma.service';
 import { ContactImportController } from './contollers/contact-import.controller';
 import { GroupFinderService } from './group-finder/group-finder.service';
 import { appEntities } from '../config';
+import { PhonesService } from './phones.service';
 
 @Global()
 @Module({
@@ -27,6 +28,7 @@ import { appEntities } from '../config';
     GoogleService,
     PrismaService,
     GroupFinderService,
+    PhonesService,
   ],
   controllers: [
     ContactsController,

--- a/src/crm/phones.service.spec.ts
+++ b/src/crm/phones.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PhonesService } from './phones.service';
+
+describe('PhonesService', () => {
+  let service: PhonesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PhonesService],
+    }).compile();
+
+    service = module.get<PhonesService>(PhonesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/crm/phones.service.ts
+++ b/src/crm/phones.service.ts
@@ -28,6 +28,7 @@ export class PhonesService {
       } else if (getIsPrimary.length > 1) {
         await getIsPrimary.map((it) => {
           const phones = { ...it, isPrimary: false };
+          data.isPrimary = true;
           this.repository.save(phones);
         });
       }
@@ -37,8 +38,6 @@ export class PhonesService {
     const getCurrentPhones = await this.repository.find({
       where: [{ contactId: data.contactId }],
     });
-    await this.repository.save(data);
     return getCurrentPhones;
   }
-
 }


### PR DESCRIPTION
**What does this PR do?**

- This PR removes the country and district and populates that information using data from google maps.
- It also changes the Address text box to a select box with location addresses from google maps
- Limits the number of addresses and phone numbers a user can enter to four.
- Handles the logic of making a phone number or address primary/default input

**Description of tasks.**

- Users can now use the address text box to add an address and the rest of the information will be picked from google place
- Users can only enter numbers in the phones input

**How to manually test this**

- When logged in, select your profile and edit or add an address or phone number
- Try adding more than four addresses or phone numbers as well
- Try making an address or phone number primary and vice versa

[Link](https://github.com/kanzucode/angie-client/pull/62) to the Client PR