### PR TITLE
Fix INSERT column mismatch in tenant migration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { eventEntities } from "./events/events.helpers";
 import { helpEntities } from "./help/help.helpers";
 import { reportsEntities } from "./reports/reports.helpers";
 import { botEntities } from "./bot/bot.helpers";
+import { tenantsEntities } from "./tenants/tenants.helpers";
 
 require("dotenv").config();
 
@@ -56,5 +57,6 @@ export const appEntities: any[] = [
   ...reportsEntities,
   ...helpEntities,
   ...botEntities,
+  ...tenantsEntities,
 ];
 console.log("#################appEntities#########", appEntities);

--- a/src/groups/entities/groupCategory.entity.ts
+++ b/src/groups/entities/groupCategory.entity.ts
@@ -1,5 +1,12 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import Group from "./group.entity";
+import { Tenant } from "../../tenants/entities/tenant.entity";
 
 @Entity()
 export default class GroupCategory {
@@ -9,6 +16,12 @@ export default class GroupCategory {
 
   @Column({ length: 200 })
   name: string;
+
+  @ManyToOne(() => Tenant, { nullable: false })
+  tenant: Tenant;
+
+  @Column({ nullable: false })
+  tenantId: number;
 
   @OneToMany((type) => Group, (it) => it.category, {
     cascade: ["insert", "remove"],

--- a/src/tenants/tenants.helpers.ts
+++ b/src/tenants/tenants.helpers.ts
@@ -1,0 +1,3 @@
+import { Tenant } from "./entities/tenant.entity";
+
+export const tenantsEntities = [Tenant];


### PR DESCRIPTION
- Added tenantId column and Tenant relationship to GroupCategory entity
- Created tenants.helpers.ts to export Tenant entity for TypeORM
- Updated config.ts to include Tenant entity in appEntities array

This fixes the migration error "INSERT has more expressions than target columns" when migrating from schema-based to row-level tenancy.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here

