### PR TITLE
feat(seed): rebuild WHM group tree with full FOB/region structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1164,7 +1164,6 @@
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2326,7 +2325,6 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -2337,7 +2335,6 @@
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
       "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2350,7 +2347,6 @@
     },
     "node_modules/@npmcli/move-file/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -2363,7 +2359,6 @@
     "node_modules/@npmcli/move-file/node_modules/rimraf": {
       "version": "3.0.2",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -2647,7 +2642,6 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3418,7 +3412,6 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3430,7 +3423,6 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4208,7 +4200,6 @@
     },
     "node_modules/cacache": {
       "version": "15.3.0",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4237,7 +4228,6 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4249,7 +4239,6 @@
     },
     "node_modules/cacache/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4261,7 +4250,6 @@
     },
     "node_modules/cacache/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -4274,7 +4262,6 @@
     "node_modules/cacache/node_modules/rimraf": {
       "version": "3.0.2",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4547,7 +4534,6 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5856,7 +5842,6 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5865,7 +5850,6 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7139,6 +7123,20 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -7606,7 +7604,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7806,7 +7804,6 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true
     },
@@ -7830,7 +7827,6 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7863,7 +7859,6 @@
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7967,7 +7962,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7975,7 +7970,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7983,7 +7978,6 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -8079,7 +8073,6 @@
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8303,7 +8296,6 @@
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10060,7 +10052,6 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10087,7 +10078,6 @@
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10099,7 +10089,6 @@
     },
     "node_modules/make-fetch-happen/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10350,7 +10339,6 @@
     },
     "node_modules/minipass-collect": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10362,7 +10350,6 @@
     },
     "node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10374,7 +10361,6 @@
     },
     "node_modules/minipass-fetch": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10391,7 +10377,6 @@
     },
     "node_modules/minipass-fetch/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10403,7 +10388,6 @@
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10415,7 +10399,6 @@
     },
     "node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10427,7 +10410,6 @@
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10439,7 +10421,6 @@
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10451,7 +10432,6 @@
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10463,7 +10443,6 @@
     },
     "node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10857,7 +10836,6 @@
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10882,7 +10860,6 @@
     "node_modules/node-gyp/node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10896,7 +10873,6 @@
     "node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10916,7 +10892,6 @@
     "node_modules/node-gyp/node_modules/npmlog": {
       "version": "6.0.2",
       "deprecated": "This package is no longer supported.",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10932,7 +10907,6 @@
     "node_modules/node-gyp/node_modules/rimraf": {
       "version": "3.0.2",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -11244,7 +11218,6 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11710,13 +11683,11 @@
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12168,7 +12139,6 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12692,7 +12662,6 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12752,7 +12721,6 @@
     },
     "node_modules/socks": {
       "version": "2.8.7",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12766,7 +12734,6 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "6.2.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12897,7 +12864,6 @@
     },
     "node_modules/ssri": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -12909,7 +12875,6 @@
     },
     "node_modules/ssri/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14059,7 +14024,6 @@
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14068,7 +14032,6 @@
     },
     "node_modules/unique-slug": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "seed:comprehensive": "ts-node --transpile-only -r tsconfig-paths/register src/commands/seed-comprehensive.ts",
     "seed:clear": "ts-node --transpile-only -r tsconfig-paths/register src/commands/seed-comprehensive.ts --clear",
     "seed:reset": "ts-node --transpile-only -r tsconfig-paths/register src/commands/seed-comprehensive.ts --clear --seed",
+    "seed:whm:production": "ts-node --transpile-only -r tsconfig-paths/register src/commands/seed-whm-production.ts",
     "seed:whm:reports": "ts-node --transpile-only -r tsconfig-paths/register src/commands/seed-whm-reports.ts",
     "seed:whm:groups": "ts-node --transpile-only -r tsconfig-paths/register src/commands/seed-whm-groups.ts",
     "import:whm:pga": "ts-node --transpile-only -r tsconfig-paths/register src/commands/import-whm-pga.ts",

--- a/src/commands/seed-whm-production.ts
+++ b/src/commands/seed-whm-production.ts
@@ -1,0 +1,107 @@
+/**
+ * Production reset + seed for Worship Harvest.
+ *
+ * Steps:
+ *   1. Clears ALL data (groups, users, contacts, reports, roles, categories)
+ *   2. Seeds baseline: tenant → roles → group categories
+ *   3. Seeds WHM group tree: Worship Harvest (Movement) → 6 Regions → 37 FOBs → locations
+ *   4. Creates your personal admin account (prompted at runtime — nothing hardcoded)
+ *
+ * Usage:
+ *   npm run seed:whm:production
+ *   npm run seed:whm:production -- --dry-run   (skip clear; add/update on top of existing data)
+ */
+
+import * as readline from 'readline';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+import { ComprehensiveSeedService } from '../seed/comprehensive-seed.service';
+import { WhmGroupTreeSeedService } from '../seed/whm/whm-group-tree.seed';
+import { Logger } from '@nestjs/common';
+
+async function promptAdminCredentials(): Promise<{
+  email: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+}> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const ask = (q: string): Promise<string> =>
+    new Promise((resolve) => rl.question(q, (a) => resolve(a.trim())));
+
+  console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(' Create your admin account');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+
+  const firstName = await ask('  First name  : ');
+  const lastName  = await ask('  Last name   : ');
+  const email     = await ask('  Email       : ');
+  const password  = await ask('  Password    : ');
+
+  rl.close();
+  console.log('');
+
+  if (!firstName || !lastName || !email || !password) {
+    throw new Error('All admin fields are required');
+  }
+  return { firstName, lastName, email, password };
+}
+
+async function run() {
+  const isDryRun = process.argv.includes('--dry-run');
+  const skipAdmin = process.argv.includes('--no-admin');
+
+  // Collect admin credentials before starting the app (keeps stdin clean)
+  let adminCredentials: Awaited<ReturnType<typeof promptAdminCredentials>> | null = null;
+  if (!skipAdmin) {
+    adminCredentials = await promptAdminCredentials();
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const comprehensiveSeed = app.get(ComprehensiveSeedService);
+  const groupTreeSeed = app.get(WhmGroupTreeSeedService);
+
+  try {
+    if (isDryRun) {
+      Logger.log('🔍 DRY RUN — skipping clear step');
+    } else {
+      Logger.log('🧹 Clearing all existing data...');
+      await comprehensiveSeed.clearAll();
+      Logger.log('✅ Database cleared');
+    }
+
+    Logger.log('🏢 Seeding tenant...');
+    await comprehensiveSeed.ensureDefaultTenant();
+
+    Logger.log('🔐 Seeding roles...');
+    await comprehensiveSeed.seedRoles();
+
+    Logger.log('📂 Seeding group categories...');
+    await comprehensiveSeed.seedGroupCategories();
+
+    Logger.log('🌲 Seeding group tree (Movement → Regions → FOBs → Locations)...');
+    await groupTreeSeed.seedGroupTree();
+
+    if (adminCredentials) {
+      Logger.log('👤 Creating admin account...');
+      await comprehensiveSeed.seedAdminUser(adminCredentials);
+      await groupTreeSeed.assignAdminToMovement(adminCredentials.email);
+    }
+
+    Logger.log('\n✅ Production seed complete.');
+    Logger.log('   Worship Harvest → 6 Regions → 37 FOBs → locations');
+    if (adminCredentials) {
+      Logger.log(`   Admin login: ${adminCredentials.email}`);
+    }
+  } catch (error) {
+    Logger.error('❌ Production seed failed:', error);
+    process.exit(1);
+  } finally {
+    await app.close();
+  }
+}
+
+run();

--- a/src/commands/seed-whm-production.ts
+++ b/src/commands/seed-whm-production.ts
@@ -9,7 +9,8 @@
  *
  * Usage:
  *   npm run seed:whm:production
- *   npm run seed:whm:production -- --dry-run   (skip clear; add/update on top of existing data)
+ *   npm run seed:whm:production -- --no-clear   (skip wipe; add/update on top of existing data)
+ *   npm run seed:whm:production -- --no-admin   (skip admin account creation)
  */
 
 import * as readline from 'readline';
@@ -37,9 +38,9 @@ async function promptAdminCredentials(): Promise<{
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
   const firstName = await ask('  First name  : ');
-  const lastName  = await ask('  Last name   : ');
-  const email     = await ask('  Email       : ');
-  const password  = await ask('  Password    : ');
+  const lastName = await ask('  Last name   : ');
+  const email = await ask('  Email       : ');
+  const password = await ask('  Password    : ');
 
   rl.close();
   console.log('');
@@ -51,11 +52,13 @@ async function promptAdminCredentials(): Promise<{
 }
 
 async function run() {
-  const isDryRun = process.argv.includes('--dry-run');
+  const noClear = process.argv.includes('--no-clear');
   const skipAdmin = process.argv.includes('--no-admin');
 
   // Collect admin credentials before starting the app (keeps stdin clean)
-  let adminCredentials: Awaited<ReturnType<typeof promptAdminCredentials>> | null = null;
+  let adminCredentials: Awaited<
+    ReturnType<typeof promptAdminCredentials>
+  > | null = null;
   if (!skipAdmin) {
     adminCredentials = await promptAdminCredentials();
   }
@@ -65,8 +68,10 @@ async function run() {
   const groupTreeSeed = app.get(WhmGroupTreeSeedService);
 
   try {
-    if (isDryRun) {
-      Logger.log('🔍 DRY RUN — skipping clear step');
+    if (noClear) {
+      Logger.log(
+        '⏭️  --no-clear: skipping database wipe, adding/updating on top of existing data',
+      );
     } else {
       Logger.log('🧹 Clearing all existing data...');
       await comprehensiveSeed.clearAll();
@@ -82,7 +87,9 @@ async function run() {
     Logger.log('📂 Seeding group categories...');
     await comprehensiveSeed.seedGroupCategories();
 
-    Logger.log('🌲 Seeding group tree (Movement → Regions → FOBs → Locations)...');
+    Logger.log(
+      '🌲 Seeding group tree (Movement → Regions → FOBs → Locations)...',
+    );
     await groupTreeSeed.seedGroupTree();
 
     if (adminCredentials) {
@@ -94,11 +101,13 @@ async function run() {
     Logger.log('\n✅ Production seed complete.');
     Logger.log('   Worship Harvest → 6 Regions → 37 FOBs → locations');
     if (adminCredentials) {
-      Logger.log(`   Admin login: ${adminCredentials.email}`);
+      Logger.log(
+        '   Admin account ready — use the credentials you entered to log in.',
+      );
     }
   } catch (error) {
     Logger.error('❌ Production seed failed:', error);
-    process.exit(1);
+    process.exitCode = 1; // let finally run so app.close() still executes
   } finally {
     await app.close();
   }

--- a/src/seed/comprehensive-seed.service.ts
+++ b/src/seed/comprehensive-seed.service.ts
@@ -122,6 +122,7 @@ export class ComprehensiveSeedService {
   }
 
   async ensureDefaultTenant(): Promise<Tenant> {
+    this.initializeRepositories();
     let tenant = await this.tenantRepository.findOne({
       where: { name: 'worshipharvest' },
     });
@@ -139,6 +140,7 @@ export class ComprehensiveSeedService {
   }
 
   async seedRoles(): Promise<void> {
+    this.initializeRepositories();
     Logger.log('🔐 Seeding roles...');
 
     const tenant = await this.tenantRepository.findOne({
@@ -264,6 +266,7 @@ export class ComprehensiveSeedService {
   }
 
   async seedGroupCategories(): Promise<void> {
+    this.initializeRepositories();
     Logger.log('📂 Seeding group categories...');
 
     const tenant = await this.tenantRepository.findOne({
@@ -708,66 +711,81 @@ export class ComprehensiveSeedService {
     password: string;
   }): Promise<void> {
     this.initializeRepositories();
-    Logger.log(`👤 Creating admin user: ${credentials.email}`);
+    Logger.log('👤 Seeding admin user...');
 
     const tenant = await this.tenantRepository.findOne({
       where: { name: 'worshipharvest' },
     });
     if (!tenant) throw new Error('Tenant not found — run base seed first');
 
-    const existing = await this.userRepository.findOne({
-      where: { username: credentials.email },
-    });
-    if (existing) {
-      Logger.log(`[Admin] User ${credentials.email} already exists — skipping`);
-      return;
-    }
-
-    // Contact + Person
-    const contact = await this.contactRepository.save(
-      this.contactRepository.create({ category: ContactCategory.Person, tenant }),
-    );
-    const person = await this.personRepository.save(
-      this.personRepository.create({
-        firstName: credentials.firstName,
-        lastName: credentials.lastName,
-        contactId: contact.id,
-      }),
-    );
-    contact.person = person;
-    await this.contactRepository.save(contact);
-
-    // Email
-    const emailRecord = this.emailRepository.create({
-      category: EmailCategory.Personal,
-      value: credentials.email,
-      isPrimary: true,
-      contact,
-    });
-    await this.emailRepository.save(emailRecord);
-
-    // User
-    const user = await this.userRepository.save(
-      this.userRepository.create({
-        username: credentials.email,
-        password: bcrypt.hashSync(credentials.password, hashCost),
-        contactId: contact.id,
-        isActive: true,
-        tenant,
-      }),
-    );
-
-    // RoleAdmin role
+    // Tenant-scoped role lookup
     const adminRole = await this.rolesRepository.findOne({
-      where: { role: 'RoleAdmin' },
+      where: { role: 'RoleAdmin', tenant: { id: tenant.id } },
     });
-    if (adminRole) {
-      await this.userRolesRepository.save(
-        this.userRolesRepository.create({ user, roles: adminRole }),
+
+    let user = await this.userRepository.findOne({
+      where: { username: credentials.email, tenant: { id: tenant.id } },
+    });
+
+    if (user) {
+      Logger.log(
+        '[Admin] User already exists — ensuring RoleAdmin is assigned',
       );
+    } else {
+      // Contact + Person
+      const contact = await this.contactRepository.save(
+        this.contactRepository.create({
+          category: ContactCategory.Person,
+          tenant,
+        }),
+      );
+      const person = await this.personRepository.save(
+        this.personRepository.create({
+          firstName: credentials.firstName,
+          lastName: credentials.lastName,
+          contactId: contact.id,
+        }),
+      );
+      contact.person = person;
+      await this.contactRepository.save(contact);
+
+      // Email
+      await this.emailRepository.save(
+        this.emailRepository.create({
+          category: EmailCategory.Personal,
+          value: credentials.email,
+          isPrimary: true,
+          contact,
+        }),
+      );
+
+      // User
+      user = await this.userRepository.save(
+        this.userRepository.create({
+          username: credentials.email,
+          password: bcrypt.hashSync(credentials.password, hashCost),
+          contactId: contact.id,
+          isActive: true,
+          tenant,
+        }),
+      );
+      Logger.log('👤 Admin user created');
     }
 
-    Logger.log(`✅ Admin user created: ${credentials.email}`);
+    // Idempotent role assignment — ensure RoleAdmin regardless of path taken above
+    if (adminRole) {
+      const hasRole = await this.userRolesRepository.findOne({
+        where: { user: { id: user.id }, roles: { id: adminRole.id } },
+      });
+      if (!hasRole) {
+        await this.userRolesRepository.save(
+          this.userRolesRepository.create({ user, roles: adminRole }),
+        );
+        Logger.log('[Admin] RoleAdmin assigned');
+      }
+    }
+
+    Logger.log('✅ Admin user ready');
   }
 
   async clearAll(): Promise<void> {

--- a/src/seed/comprehensive-seed.service.ts
+++ b/src/seed/comprehensive-seed.service.ts
@@ -294,6 +294,7 @@ export class ComprehensiveSeedService {
         name: 'Garage Team',
         purpose: GroupCategoryPurpose.SERVING_TEAM,
       },
+      { id: 8, name: 'Region', purpose: GroupCategoryPurpose.STRUCTURE },
     ];
 
     for (const catData of categories) {
@@ -698,6 +699,75 @@ export class ComprehensiveSeedService {
         }
       }
     }
+  }
+
+  async seedAdminUser(credentials: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    password: string;
+  }): Promise<void> {
+    this.initializeRepositories();
+    Logger.log(`👤 Creating admin user: ${credentials.email}`);
+
+    const tenant = await this.tenantRepository.findOne({
+      where: { name: 'worshipharvest' },
+    });
+    if (!tenant) throw new Error('Tenant not found — run base seed first');
+
+    const existing = await this.userRepository.findOne({
+      where: { username: credentials.email },
+    });
+    if (existing) {
+      Logger.log(`[Admin] User ${credentials.email} already exists — skipping`);
+      return;
+    }
+
+    // Contact + Person
+    const contact = await this.contactRepository.save(
+      this.contactRepository.create({ category: ContactCategory.Person, tenant }),
+    );
+    const person = await this.personRepository.save(
+      this.personRepository.create({
+        firstName: credentials.firstName,
+        lastName: credentials.lastName,
+        contactId: contact.id,
+      }),
+    );
+    contact.person = person;
+    await this.contactRepository.save(contact);
+
+    // Email
+    const emailRecord = this.emailRepository.create({
+      category: EmailCategory.Personal,
+      value: credentials.email,
+      isPrimary: true,
+      contact,
+    });
+    await this.emailRepository.save(emailRecord);
+
+    // User
+    const user = await this.userRepository.save(
+      this.userRepository.create({
+        username: credentials.email,
+        password: bcrypt.hashSync(credentials.password, hashCost),
+        contactId: contact.id,
+        isActive: true,
+        tenant,
+      }),
+    );
+
+    // RoleAdmin role
+    const adminRole = await this.rolesRepository.findOne({
+      where: { role: 'RoleAdmin' },
+    });
+    if (adminRole) {
+      await this.userRolesRepository.save(
+        this.userRolesRepository.create({ user, roles: adminRole }),
+      );
+    }
+
+    Logger.log(`✅ Admin user created: ${credentials.email}`);
   }
 
   async clearAll(): Promise<void> {

--- a/src/seed/whm/whm-group-tree.seed.ts
+++ b/src/seed/whm/whm-group-tree.seed.ts
@@ -43,7 +43,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHBUSK', name: 'WH Busiika' },
   { code: 'WHBWBJ', name: 'WH Bwebajja' },
   { code: 'WHBWGA', name: 'WH Bwerenga' },
-  { code: 'WHBWMB', name: 'WH Buwambo' },        // new 2026-06-25
+  { code: 'WHBWMB', name: 'WH Buwambo' }, // new 2026-06-25
   { code: 'WHBWNG', name: 'WH Buwenge' },
   { code: 'WHBWYA', name: 'WH Buwaya' },
   { code: 'WHBYGR', name: 'WH Bweyogerere' },
@@ -103,7 +103,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHKMLI', name: 'WH Kamuli' },
   { code: 'WHKMNY', name: 'WH Kimwanyi' },
   { code: 'WHKRCH', name: 'WH Kericho' },
-  { code: 'WHKRKU', name: 'WH Kireku' },          // new 2026-06-25
+  { code: 'WHKRKU', name: 'WH Kireku' }, // new 2026-06-25
   { code: 'WHKRNY', name: 'WH Kirinya' },
   { code: 'WHKSAS', name: 'WH Kisaasi' },
   { code: 'WHKSBI', name: 'WH Kasubi' },
@@ -162,7 +162,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHMPGI', name: 'WH Mpigi' },
   { code: 'WHMPRW', name: 'WH Mpererwe' },
   { code: 'WHMSDY', name: 'WH Misindye' },
-  { code: 'WHMSJJ', name: 'WH Masajja' },         // new 2026-06-25
+  { code: 'WHMSJJ', name: 'WH Masajja' }, // new 2026-06-25
   { code: 'WHMSKA', name: 'WH Masaka' },
   { code: 'WHMSLT', name: 'WH Masulita' },
   { code: 'WHMSND', name: 'WH Masindi' },
@@ -200,7 +200,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHNMGR', name: 'WH Namagera' },
   { code: 'WHNMLG', name: 'WH Namulonge' },
   { code: 'WHNMNV', name: 'WH Namanve' },
-  { code: 'WHNMPG', name: 'WH Nampunge' },  // unassigned — no FOB in current list
+  { code: 'WHNMPG', name: 'WH Nampunge' }, // unassigned — no FOB in current list
   { code: 'WHNMTB', name: 'WH Namataba' },
   { code: 'WHNMWD', name: 'WH Namwendwa' },
   { code: 'WHNMWG', name: 'WH Namuwongo' },
@@ -221,7 +221,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHONGR', name: 'WH Ongata Rongai' },
   { code: 'WHPDHA', name: 'WH Paidha' },
   { code: 'WHPKCH', name: 'WH Pakwach' },
-  { code: 'WHPLSA', name: 'WH Pallisa' },  // unassigned — no FOB in current list
+  { code: 'WHPLSA', name: 'WH Pallisa' }, // unassigned — no FOB in current list
   { code: 'WHRBGA', name: 'WH Rubaga' },
   { code: 'WHRUIR', name: 'WH Ruiru' },
   { code: 'WHSEGK', name: 'WH Seguku' },
@@ -230,7 +230,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHSNTM', name: 'WH Sentema' },
   { code: 'WHSOND', name: 'WH Sonde' },
   { code: 'WHSROT', name: 'WH Soroti' },
-  { code: 'WHSTMG', name: 'WH Seeta-Magere' },    // new 2026-06-25
+  { code: 'WHSTMG', name: 'WH Seeta-Magere' }, // new 2026-06-25
   { code: 'WHTEXS', name: 'WH Texas' },
   { code: 'WHTHKA', name: 'WH Thika' },
   { code: 'WHTRRO', name: 'WH Tororo' },
@@ -265,11 +265,29 @@ const REGION_FOB_LOCATION_MAP: {
       },
       {
         name: 'Mukono FOB',
-        codes: ['WHKBMB', 'WHKYNG', 'WHKITO', 'WHLUGZ', 'WHMKNO', 'WHMCTY', 'WHNKFM', 'WHNTWO'],
+        codes: [
+          'WHKBMB',
+          'WHKYNG',
+          'WHKITO',
+          'WHLUGZ',
+          'WHMKNO',
+          'WHMCTY',
+          'WHNKFM',
+          'WHNTWO',
+        ],
       },
       {
         name: 'Kitukutwe FOB',
-        codes: ['WHKLGI', 'WHKJBJ', 'WHKTKT', 'WHNBSG', 'WHNKSJ', 'WHNKWR', 'WHNSSA', 'WHKMNY'],
+        codes: [
+          'WHKLGI',
+          'WHKJBJ',
+          'WHKTKT',
+          'WHNBSG',
+          'WHNKSJ',
+          'WHNKWR',
+          'WHNSSA',
+          'WHKMNY',
+        ],
       },
       {
         name: 'Makerere FOB',
@@ -289,7 +307,15 @@ const REGION_FOB_LOCATION_MAP: {
       },
       {
         name: 'Sonde FOB',
-        codes: ['WHBYGR', 'WHKWGA', 'WHMSDY', 'WHNTDA', 'WHSOND', 'WHSETA', 'WHBLID'],
+        codes: [
+          'WHBYGR',
+          'WHKWGA',
+          'WHMSDY',
+          'WHNTDA',
+          'WHSOND',
+          'WHSETA',
+          'WHBLID',
+        ],
       },
     ],
   },
@@ -299,14 +325,33 @@ const REGION_FOB_LOCATION_MAP: {
       {
         name: 'Kansanga FOB',
         codes: [
-          'WHBSBL', 'WHBZGA', 'WHDWTN', 'WHGBRD', 'WHKBLI', 'WHKBYE',
-          'WHMKND', 'WHMTND', 'WHMYNG', 'WHNDJE', 'WHRBGA', 'WHSLRD',
-          'WHNSBY', 'WHMSJJ',
+          'WHBSBL',
+          'WHBZGA',
+          'WHDWTN',
+          'WHGBRD',
+          'WHKBLI',
+          'WHKBYE',
+          'WHMKND',
+          'WHMTND',
+          'WHMYNG',
+          'WHNDJE',
+          'WHRBGA',
+          'WHSLRD',
+          'WHNSBY',
+          'WHMSJJ',
         ],
       },
       {
         name: 'Bugolobi FOB',
-        codes: ['WHBGLB', 'WHBKSA', 'WHKRNY', 'WHLZRA', 'WHMTGB', 'WHNMWG', 'WHKRKU'],
+        codes: [
+          'WHBGLB',
+          'WHBKSA',
+          'WHKRNY',
+          'WHLZRA',
+          'WHMTGB',
+          'WHNMWG',
+          'WHKRKU',
+        ],
       },
       {
         name: 'Nakawa FOB',
@@ -322,7 +367,15 @@ const REGION_FOB_LOCATION_MAP: {
       },
       {
         name: 'Kajjansi FOB',
-        codes: ['WHBNMY', 'WHBWBJ', 'WHKJNS', 'WHKITD', 'WHSEGK', 'WHNLMY', 'WHBWGA'],
+        codes: [
+          'WHBNMY',
+          'WHBWBJ',
+          'WHKJNS',
+          'WHKITD',
+          'WHSEGK',
+          'WHNLMY',
+          'WHBWGA',
+        ],
       },
       {
         name: 'Nakawuka FOB',
@@ -335,13 +388,30 @@ const REGION_FOB_LOCATION_MAP: {
     fobs: [
       {
         name: 'Gayaza FOB',
-        codes: ['WHGYZA', 'WHKSAS', 'WHKYBD', 'WHLSNJ', 'WHMGRE', 'WHMPRW', 'WHNGBO'],
+        codes: [
+          'WHGYZA',
+          'WHKSAS',
+          'WHKYBD',
+          'WHLSNJ',
+          'WHMGRE',
+          'WHMPRW',
+          'WHNGBO',
+        ],
       },
       {
         name: 'Wakiso FOB',
         codes: [
-          'WHBULB', 'WHBSGA', 'WHKKRI', 'WHKSGJ', 'WHKYGW',
-          'WHMSLT', 'WHMTYN', 'WHNSNA', 'WHNGND', 'WHWKSO', 'WHNYSA',
+          'WHBULB',
+          'WHBSGA',
+          'WHKKRI',
+          'WHKSGJ',
+          'WHKYGW',
+          'WHMSLT',
+          'WHMTYN',
+          'WHNSNA',
+          'WHNGND',
+          'WHWKSO',
+          'WHNYSA',
         ],
       },
       {
@@ -350,15 +420,39 @@ const REGION_FOB_LOCATION_MAP: {
       },
       {
         name: 'Matugga FOB',
-        codes: ['WHKVLE', 'WHMTUG', 'WHNKSK', 'WHNDJB', 'WHWTBA', 'WHWBLZ', 'WHLWRO'],
+        codes: [
+          'WHKVLE',
+          'WHMTUG',
+          'WHNKSK',
+          'WHNDJB',
+          'WHWTBA',
+          'WHWBLZ',
+          'WHLWRO',
+        ],
       },
       {
         name: 'Mpigi FOB',
-        codes: ['WHBUDO', 'WHGOMB', 'WHKTND', 'WHKYGR', 'WHMPGI', 'WHNSGI', 'WHMAYA'],
+        codes: [
+          'WHBUDO',
+          'WHGOMB',
+          'WHKTND',
+          'WHKYGR',
+          'WHMPGI',
+          'WHNSGI',
+          'WHMAYA',
+        ],
       },
       {
         name: 'Kiti FOB',
-        codes: ['WHKWND', 'WHKWMP', 'WHKLMZ', 'WHKITI', 'WHLGBA', 'WHMGJO', 'WHTULA'],
+        codes: [
+          'WHKWND',
+          'WHKWMP',
+          'WHKLMZ',
+          'WHKITI',
+          'WHLGBA',
+          'WHMGJO',
+          'WHTULA',
+        ],
       },
       {
         name: 'Sentema FOB',
@@ -372,8 +466,17 @@ const REGION_FOB_LOCATION_MAP: {
       {
         name: 'Jinja FOB',
         codes: [
-          'WHBDND', 'WHBGMB', 'WHBWNG', 'WHJNJA', 'WHKBBI',
-          'WHMBKO', 'WHMTAI', 'WHNJRU', 'WHNWPD', 'WHNMGR', 'WHMFBR',
+          'WHBDND',
+          'WHBGMB',
+          'WHBWNG',
+          'WHJNJA',
+          'WHKBBI',
+          'WHMBKO',
+          'WHMTAI',
+          'WHNJRU',
+          'WHNWPD',
+          'WHNMGR',
+          'WHMFBR',
         ],
       },
       {
@@ -403,7 +506,15 @@ const REGION_FOB_LOCATION_MAP: {
     fobs: [
       {
         name: 'Arua FOB',
-        codes: ['WHARUA', 'WHKBKO', 'WHNEBB', 'WHPDHA', 'WHPKCH', 'WHWNDI', 'WHBNDO'],
+        codes: [
+          'WHARUA',
+          'WHKBKO',
+          'WHNEBB',
+          'WHPDHA',
+          'WHPKCH',
+          'WHWNDI',
+          'WHBNDO',
+        ],
       },
       {
         name: 'Masaka FOB',
@@ -411,7 +522,16 @@ const REGION_FOB_LOCATION_MAP: {
       },
       {
         name: 'Mbarara FOB',
-        codes: ['WHBHRW', 'WHIBND', 'WHISHK', 'WHKBLE', 'WHKKBA', 'WHMBRA', 'WHNTGM', 'WHBSHY'],
+        codes: [
+          'WHBHRW',
+          'WHIBND',
+          'WHISHK',
+          'WHKBLE',
+          'WHKKBA',
+          'WHMBRA',
+          'WHNTGM',
+          'WHBSHY',
+        ],
       },
       {
         name: 'Fort Portal FOB',
@@ -428,7 +548,18 @@ const REGION_FOB_LOCATION_MAP: {
     fobs: [
       {
         name: 'Kenya FOB',
-        codes: ['WHJUJA', 'WHKEOL', 'WHKRCH', 'WHKMBU', 'WHKTGL', 'WHNRBI', 'WHONGR', 'WHRUIR', 'WHTHKA', 'WHMBSA'],
+        codes: [
+          'WHJUJA',
+          'WHKEOL',
+          'WHKRCH',
+          'WHKMBU',
+          'WHKTGL',
+          'WHNRBI',
+          'WHONGR',
+          'WHRUIR',
+          'WHTHKA',
+          'WHMBSA',
+        ],
       },
       {
         name: 'Rest of Africa FOB',
@@ -436,7 +567,18 @@ const REGION_FOB_LOCATION_MAP: {
       },
       {
         name: 'Europe & Oceania FOB',
-        codes: ['WHAUST', 'WHEONL', 'WHGNVA', 'WHGMNY', 'WHLEDS', 'WHLUTN', 'WHNWLS', 'WHUKDM', 'WHKFLD', 'WHWGAN'],
+        codes: [
+          'WHAUST',
+          'WHEONL',
+          'WHGNVA',
+          'WHGMNY',
+          'WHLEDS',
+          'WHLUTN',
+          'WHNWLS',
+          'WHUKDM',
+          'WHKFLD',
+          'WHWGAN',
+        ],
       },
       {
         name: 'Americas FOB',
@@ -457,77 +599,120 @@ const WHKTKT_ZONES: { name: string; mcs: { name: string }[] }[] = [
   {
     name: 'Cathedral Zone',
     mcs: [
-      { name: 'Beloved (A)' }, { name: 'Beyond Self (A)' }, { name: 'Blessed Kids (C)' },
-      { name: 'Feathers of Greatness (T)' }, { name: 'Hopeful (T)' }, { name: 'Matthew (A)' },
-      { name: 'Miraculous (A)' }, { name: 'Obedience (A)' }, { name: 'Revelation (T)' },
-      { name: 'Righteous (T)' }, { name: 'Zion (C)' },
+      { name: 'Beloved (A)' },
+      { name: 'Beyond Self (A)' },
+      { name: 'Blessed Kids (C)' },
+      { name: 'Feathers of Greatness (T)' },
+      { name: 'Hopeful (T)' },
+      { name: 'Matthew (A)' },
+      { name: 'Miraculous (A)' },
+      { name: 'Obedience (A)' },
+      { name: 'Revelation (T)' },
+      { name: 'Righteous (T)' },
+      { name: 'Zion (C)' },
     ],
   },
   {
     name: 'Kazinga',
     mcs: [
-      { name: "Be'zri (A)" }, { name: 'Divine (C)' }, { name: 'Grace (A)' }, { name: 'Nissi (C)' },
+      { name: "Be'zri (A)" },
+      { name: 'Divine (C)' },
+      { name: 'Grace (A)' },
+      { name: 'Nissi (C)' },
     ],
   },
   {
     name: 'Kijabijjo',
     mcs: [
-      { name: 'Bethel (T)' }, { name: 'Christ The King (T)' }, { name: 'Faithful (A)' },
-      { name: 'Galatians (T)' }, { name: 'Gates of Heaven (T)' }, { name: 'Genesis (T)' },
-      { name: 'Glory (C)' }, { name: 'Justified (T)' }, { name: 'Majesty (T)' },
-      { name: 'Mulungi (A)' }, { name: 'Overcomers (A)' }, { name: 'Peace (C)' },
-      { name: 'Peniel (T)' }, { name: 'True Star (C)' }, { name: 'Victory (T)' },
+      { name: 'Bethel (T)' },
+      { name: 'Christ The King (T)' },
+      { name: 'Faithful (A)' },
+      { name: 'Galatians (T)' },
+      { name: 'Gates of Heaven (T)' },
+      { name: 'Genesis (T)' },
+      { name: 'Glory (C)' },
+      { name: 'Justified (T)' },
+      { name: 'Majesty (T)' },
+      { name: 'Mulungi (A)' },
+      { name: 'Overcomers (A)' },
+      { name: 'Peace (C)' },
+      { name: 'Peniel (T)' },
+      { name: 'True Star (C)' },
+      { name: 'Victory (T)' },
     ],
   },
   {
     name: 'Kira',
     mcs: [
-      { name: 'Glorious (C)' }, { name: 'Icons (A)' },
-      { name: 'Kira Kapeera (A)' }, { name: 'Sufficient (A)' },
+      { name: 'Glorious (C)' },
+      { name: 'Icons (A)' },
+      { name: 'Kira Kapeera (A)' },
+      { name: 'Sufficient (A)' },
     ],
   },
   {
     name: 'Kitukutwe',
     mcs: [
-      { name: 'Arrows (C)' }, { name: 'Beautiful (A)' }, { name: 'Gratitude (A)' },
-      { name: 'Multitudes (A)' }, { name: 'Rooted (A)' }, { name: 'Shalom (C)' },
+      { name: 'Arrows (C)' },
+      { name: 'Beautiful (A)' },
+      { name: 'Gratitude (A)' },
+      { name: 'Multitudes (A)' },
+      { name: 'Rooted (A)' },
+      { name: 'Shalom (C)' },
     ],
   },
   {
     name: 'Kitukutwe 2',
     mcs: [
-      { name: 'Agape (A)' }, { name: 'Beacon of Power (A)' },
-      { name: 'Kwagala (A)' }, { name: 'Zoe (A)' },
+      { name: 'Agape (A)' },
+      { name: 'Beacon of Power (A)' },
+      { name: 'Kwagala (A)' },
+      { name: 'Zoe (A)' },
     ],
   },
   {
     name: 'Kiwologoma',
     mcs: [
-      { name: 'Harvest (T)' }, { name: 'Little Lighters (C)' }, { name: 'Redemption (A)' },
-      { name: 'Redemption Kids (C)' }, { name: 'Restoration (A)' },
-      { name: 'Solomon (A)' }, { name: 'Zion Wave (A)' },
+      { name: 'Harvest (T)' },
+      { name: 'Little Lighters (C)' },
+      { name: 'Redemption (A)' },
+      { name: 'Redemption Kids (C)' },
+      { name: 'Restoration (A)' },
+      { name: 'Solomon (A)' },
+      { name: 'Zion Wave (A)' },
     ],
   },
   {
     name: 'Najjera',
     mcs: [
-      { name: 'Faraja (A)' }, { name: "God's Will (A)" }, { name: 'Heirs of The Promise (A)' },
-      { name: 'Hosanna (A)' }, { name: 'Hosanna Kids (C)' }, { name: 'New Life (A)' },
+      { name: 'Faraja (A)' },
+      { name: "God's Will (A)" },
+      { name: 'Heirs of The Promise (A)' },
+      { name: 'Hosanna (A)' },
+      { name: 'Hosanna Kids (C)' },
+      { name: 'New Life (A)' },
     ],
   },
   {
     name: 'Namirembe rd',
     mcs: [
-      { name: 'Cubs of Judah(C)' }, { name: 'Lion of Judah (A)' },
-      { name: "Messiah's Own (T)" }, { name: 'Tendo (C)' },
+      { name: 'Cubs of Judah(C)' },
+      { name: 'Lion of Judah (A)' },
+      { name: "Messiah's Own (T)" },
+      { name: 'Tendo (C)' },
     ],
   },
   {
     name: 'Nsasa',
     mcs: [
-      { name: 'Abundance (A)' }, { name: 'Called to Greatness (C)' }, { name: 'Glory MC (A)' },
-      { name: "Heaven's little Heroes (C)" }, { name: 'Renaissance (T)' },
-      { name: 'Shalac (T)' }, { name: 'Shape (A)' }, { name: 'Steadfast (T)' },
+      { name: 'Abundance (A)' },
+      { name: 'Called to Greatness (C)' },
+      { name: 'Glory MC (A)' },
+      { name: "Heaven's little Heroes (C)" },
+      { name: 'Renaissance (T)' },
+      { name: 'Shalac (T)' },
+      { name: 'Shape (A)' },
+      { name: 'Steadfast (T)' },
     ],
   },
 ];
@@ -554,25 +739,41 @@ export class WhmGroupTreeSeedService {
     this.init();
     Logger.log('🌲 [WHM] Seeding group tree...');
 
-    const tenant = await this.tenantRepo.findOne({ where: { name: 'worshipharvest' } });
+    const tenant = await this.tenantRepo.findOne({
+      where: { name: 'worshipharvest' },
+    });
     if (!tenant) throw new Error('WHM tenant not found — run base seed first');
 
-    const movementCat  = await this.cat(tenant, 'Movement');
-    const regionCat    = await this.cat(tenant, 'Region');
-    const fobCat       = await this.cat(tenant, 'Forward Operating Base');
-    const locationCat  = await this.cat(tenant, 'Location');
-    const zoneCat      = await this.cat(tenant, 'Zone');
-    const mcCat        = await this.cat(tenant, 'Missional Community');
+    const movementCat = await this.cat(tenant, 'Movement');
+    const regionCat = await this.cat(tenant, 'Region');
+    const fobCat = await this.cat(tenant, 'Forward Operating Base');
+    const locationCat = await this.cat(tenant, 'Location');
+    const zoneCat = await this.cat(tenant, 'Zone');
+    const mcCat = await this.cat(tenant, 'Missional Community');
 
-    if (!movementCat || !regionCat || !fobCat || !locationCat || !zoneCat || !mcCat) {
-      throw new Error('Required group categories missing — run seedGroupCategories first');
+    if (
+      !movementCat ||
+      !regionCat ||
+      !fobCat ||
+      !locationCat ||
+      !zoneCat ||
+      !mcCat
+    ) {
+      throw new Error(
+        'Required group categories missing — run seedGroupCategories first',
+      );
     }
 
     // Build code → definition lookup
     const locationDefs = new Map(WHM_LOCATIONS.map((l) => [l.code, l]));
 
     // 1. Movement root
-    const movement = await this.findOrCreate('Worship Harvest', movementCat, tenant, null);
+    const movement = await this.findOrCreate(
+      'Worship Harvest',
+      movementCat,
+      tenant,
+      null,
+    );
 
     let fobCount = 0;
     let locCreated = 0;
@@ -582,21 +783,37 @@ export class WhmGroupTreeSeedService {
 
     // 2. Regions → FOBs → Locations
     for (const regionDef of REGION_FOB_LOCATION_MAP) {
-      const region = await this.findOrCreate(regionDef.region, regionCat, tenant, movement);
+      const region = await this.findOrCreate(
+        regionDef.region,
+        regionCat,
+        tenant,
+        movement,
+      );
 
       for (const fobDef of regionDef.fobs) {
-        const fob = await this.findOrCreate(fobDef.name, fobCat, tenant, region);
+        const fob = await this.findOrCreate(
+          fobDef.name,
+          fobCat,
+          tenant,
+          region,
+        );
         fobCount++;
 
         for (const code of fobDef.codes) {
           assignedCodes.add(code);
           const def = locationDefs.get(code);
           if (!def) {
-            Logger.warn(`[WHM] Code ${code} (${fobDef.name}) not in location master list`);
+            Logger.warn(
+              `[WHM] Code ${code} (${fobDef.name}) not in location master list`,
+            );
             continue;
           }
           const [loc, created] = await this.findOrCreateLocation(
-            def.code, def.name, locationCat, tenant, fob,
+            def.code,
+            def.name,
+            locationCat,
+            tenant,
+            fob,
           );
           if (created) locCreated++;
           else locExisting++;
@@ -620,23 +837,45 @@ export class WhmGroupTreeSeedService {
     return;
   }
 
-  /** Attach a group membership for an admin user to the top-level movement. */
+  /** Attach (or repair) a Leader membership for an admin user on the top-level Movement. */
   async assignAdminToMovement(username: string): Promise<void> {
     this.init();
-    const tenant = await this.tenantRepo.findOne({ where: { name: 'worshipharvest' } });
-    const movement = await this.groupRepo
-      .createQueryBuilder('g')
-      .where('g."tenantId" = :t', { t: tenant?.id })
-      .andWhere('g.name = :n', { n: 'Worship Harvest' })
-      .getOne();
+    const tenant = await this.tenantRepo.findOne({
+      where: { name: 'worshipharvest' },
+    });
+    if (!tenant) return;
+
+    // Scope movement lookup to the Movement category so a same-name group in
+    // another category cannot match.
+    const movementCat = await this.categoryRepo.findOne({
+      where: { name: 'Movement', tenant: { id: tenant.id } },
+    });
+    const movement = movementCat
+      ? await this.groupRepo
+          .createQueryBuilder('g')
+          .where('g."tenantId" = :t', { t: tenant.id })
+          .andWhere('g."categoryId" = :cat', { cat: movementCat.id })
+          .andWhere('g.name = :n', { n: 'Worship Harvest' })
+          .getOne()
+      : null;
 
     const user = await this.userRepo.findOne({ where: { username } });
     if (!user || !movement) return;
 
-    const exists = await this.membershipRepo.findOne({
+    const existing = await this.membershipRepo.findOne({
       where: { contactId: user.contactId, groupId: movement.id },
     });
-    if (exists) return;
+
+    if (existing) {
+      // Repair if the membership is inactive or not Leader
+      if (!existing.isActive || existing.role !== GroupRole.Leader) {
+        existing.isActive = true;
+        existing.role = GroupRole.Leader;
+        await this.membershipRepo.save(existing);
+        Logger.log('[WHM] Repaired admin membership on Worship Harvest');
+      }
+      return;
+    }
 
     await this.membershipRepo.save(
       this.membershipRepo.create({
@@ -646,15 +885,20 @@ export class WhmGroupTreeSeedService {
         isActive: true,
       }),
     );
-    Logger.log(`[WHM] Admin user ${username} assigned to Worship Harvest`);
+    Logger.log('[WHM] Admin assigned to Worship Harvest');
   }
 
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private async cat(tenant: Tenant, name: string): Promise<GroupCategory | null> {
-    return this.categoryRepo.findOne({ where: { name, tenant: { id: tenant.id } } });
+  private async cat(
+    tenant: Tenant,
+    name: string,
+  ): Promise<GroupCategory | null> {
+    return this.categoryRepo.findOne({
+      where: { name, tenant: { id: tenant.id } },
+    });
   }
 
   private async findOrCreate(
@@ -663,7 +907,12 @@ export class WhmGroupTreeSeedService {
     tenant: Tenant,
     parent: Group | null,
   ): Promise<Group> {
-    const [group] = await this.findOrCreateByNameAndParent(name, category, tenant, parent);
+    const [group] = await this.findOrCreateByNameAndParent(
+      name,
+      category,
+      tenant,
+      parent,
+    );
     return group;
   }
 
@@ -688,7 +937,13 @@ export class WhmGroupTreeSeedService {
 
     return [
       await this.groupRepo.save(
-        this.groupRepo.create({ name, category, tenant, parent: parent ?? undefined, privacy: GroupPrivacy.Public }),
+        this.groupRepo.create({
+          name,
+          category,
+          tenant,
+          parent: parent ?? undefined,
+          privacy: GroupPrivacy.Public,
+        }),
       ),
       true,
     ];
@@ -701,19 +956,47 @@ export class WhmGroupTreeSeedService {
     tenant: Tenant,
     parent: Group,
   ): Promise<[Group, boolean]> {
-    const existing = await this.groupRepo
+    // 1. Primary lookup: match by metaData.code (stable identity)
+    const byCode = await this.groupRepo
       .createQueryBuilder('g')
       .where('g."tenantId" = :tenantId', { tenantId: tenant.id })
       .andWhere('g."categoryId" = :catId', { catId: category.id })
-      .andWhere(`g."metaData"->>'code' = :code`, { code })
+      .andWhere('g."metaData"->>\'code\' = :code', { code })
       .getOne();
 
-    if (existing) return [existing, false];
+    if (byCode) {
+      // Reparent if the location moved to a different FOB
+      if (byCode.parentId !== parent.id) {
+        byCode.parent = parent;
+        await this.groupRepo.save(byCode);
+      }
+      return [byCode, false];
+    }
 
+    // 2. Fallback: match legacy rows by name (no code in metaData yet)
+    const byName = await this.groupRepo
+      .createQueryBuilder('g')
+      .where('g."tenantId" = :tenantId', { tenantId: tenant.id })
+      .andWhere('g."categoryId" = :catId', { catId: category.id })
+      .andWhere('g.name = :name', { name })
+      .getOne();
+
+    if (byName) {
+      // Stamp the code and reparent to the correct FOB
+      byName.metaData = { ...(byName.metaData ?? {}), code };
+      byName.parent = parent;
+      await this.groupRepo.save(byName);
+      return [byName, false];
+    }
+
+    // 3. Create new
     return [
       await this.groupRepo.save(
         this.groupRepo.create({
-          name, category, tenant, parent,
+          name,
+          category,
+          tenant,
+          parent,
           privacy: GroupPrivacy.Public,
           metaData: { code },
         }),
@@ -731,10 +1014,20 @@ export class WhmGroupTreeSeedService {
     let zones = 0;
     let mcs = 0;
     for (const zoneDef of WHKTKT_ZONES) {
-      const [zone, zc] = await this.findOrCreateByNameAndParent(zoneDef.name, zoneCat, tenant, whktkt);
+      const [zone, zc] = await this.findOrCreateByNameAndParent(
+        zoneDef.name,
+        zoneCat,
+        tenant,
+        whktkt,
+      );
       if (zc) zones++;
       for (const mcDef of zoneDef.mcs) {
-        const [, mc] = await this.findOrCreateByNameAndParent(mcDef.name, mcCat, tenant, zone);
+        const [, mc] = await this.findOrCreateByNameAndParent(
+          mcDef.name,
+          mcCat,
+          tenant,
+          zone,
+        );
         if (mc) mcs++;
       }
     }

--- a/src/seed/whm/whm-group-tree.seed.ts
+++ b/src/seed/whm/whm-group-tree.seed.ts
@@ -4,23 +4,18 @@ import { Connection, Repository } from 'typeorm';
 import Group from 'src/groups/entities/group.entity';
 import GroupCategory from 'src/groups/entities/groupCategory.entity';
 import { Tenant } from 'src/tenants/entities/tenant.entity';
-import { GroupCategoryPurpose } from 'src/groups/enums/groups';
 import { GroupPrivacy } from 'src/groups/enums/groupPrivacy';
 import GroupMembership from 'src/groups/entities/groupMembership.entity';
 import { GroupRole } from 'src/groups/enums/groupRole';
 import { User } from 'src/users/entities/user.entity';
 
 // ---------------------------------------------------------------------------
-// WHM location master list — 242 entries from worship_harvest_categorization_data.json
-// ---------------------------------------------------------------------------
-// FOB assignments are pending. All non-Kitukutwe locations are placed directly
-// under the "WHM Uganda" structure group. Run import-fobs-locations.ts with the
-// canonical fobs_locations.csv to attach locations to their FOBs once available.
+// Location master list  (source: worship_harvest_categorization_data + user-supplied)
+// New locations added 2026-06-25: WHKRKU, WHMSJJ, WHBWMB, WHSTMG
 // ---------------------------------------------------------------------------
 const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHABYT', name: 'WH Abayita' },
   { code: 'WHAFOL', name: 'WH Africa Online' },
-  { code: 'WHAONL', name: 'WHAONL' },
   { code: 'WHAPAC', name: 'WH Apac' },
   { code: 'WHARUA', name: 'WH Arua' },
   { code: 'WHASOL', name: 'WH Asia Online' },
@@ -34,7 +29,6 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHBKRR', name: 'WH Bukerere' },
   { code: 'WHBKSA', name: 'WH Bukasa' },
   { code: 'WHBKTO', name: 'WH Bukoto' },
-  { code: 'WHBKYA', name: 'WHBKYA' },
   { code: 'WHBLID', name: 'WH Bulindo' },
   { code: 'WHBLND', name: 'WH Bulondo' },
   { code: 'WHBMDA', name: 'WH Bermuda' },
@@ -46,16 +40,15 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHBSKM', name: 'WH Busukuma' },
   { code: 'WHBUDO', name: 'WH Buddo' },
   { code: 'WHBULB', name: 'WH Buloba' },
-  { code: 'WHBUSG', name: 'WHBUSG' },
   { code: 'WHBUSK', name: 'WH Busiika' },
   { code: 'WHBWBJ', name: 'WH Bwebajja' },
   { code: 'WHBWGA', name: 'WH Bwerenga' },
+  { code: 'WHBWMB', name: 'WH Buwambo' },        // new 2026-06-25
   { code: 'WHBWNG', name: 'WH Buwenge' },
   { code: 'WHBWYA', name: 'WH Buwaya' },
   { code: 'WHBYGR', name: 'WH Bweyogerere' },
   { code: 'WHBZGA', name: 'WH Buziga' },
   { code: 'WHCNDA', name: 'WH Canada' },
-  { code: 'WHDNTN', name: 'WHDNTN' },
   { code: 'WHDRSM', name: 'WH Dar es Salaam' },
   { code: 'WHDWTN', name: 'WH Downtown' },
   { code: 'WHEBCT', name: 'WH Entebbe Central' },
@@ -72,7 +65,6 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHHOMA', name: 'WH Hoima' },
   { code: 'WHIBND', name: 'WH Ibanda' },
   { code: 'WHICMS', name: 'WH Iganga CMS' },
-  { code: 'WHIDDI', name: 'WHIDDI' },
   { code: 'WHIDUD', name: 'WH Idudi' },
   { code: 'WHIGNG', name: 'WH Iganga' },
   { code: 'WHISHK', name: 'WH Ishaka' },
@@ -92,7 +84,6 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHKGLI', name: 'WH Kigali' },
   { code: 'WHKGMB', name: 'WH Kigumba' },
   { code: 'WHKGNG', name: 'WH Kigungu' },
-  { code: 'WHKGWA', name: 'WHKGWA' },
   { code: 'WHKHRA', name: 'WH Kaihura' },
   { code: 'WHKIRA', name: 'WH Kira' },
   { code: 'WHKISG', name: 'WH Kisoga' },
@@ -100,7 +91,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHKITI', name: 'WH Kiti' },
   { code: 'WHKITO', name: 'WH Kito-Kisooba' },
   { code: 'WHKJBJ', name: 'WH Kijabijjo' },
-  { code: 'WHKJNS', name: 'WH kajjansi' },
+  { code: 'WHKJNS', name: 'WH Kajjansi' },
   { code: 'WHKKBA', name: 'WH Kakoba' },
   { code: 'WHKKRA', name: 'WH Kakira' },
   { code: 'WHKKRI', name: 'WH Kakiri' },
@@ -108,18 +99,15 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHKLGI', name: 'WH Kalagi' },
   { code: 'WHKLMZ', name: 'WH Kilemezi' },
   { code: 'WHKLRO', name: 'WH Kaliro' },
-  { code: 'WHKMBU', name: 'WH Kiamu' },
+  { code: 'WHKMBU', name: 'WH Kiambu' },
   { code: 'WHKMLI', name: 'WH Kamuli' },
   { code: 'WHKMNY', name: 'WH Kimwanyi' },
-  { code: 'WHKMWK', name: 'WHKMWK' },
-  { code: 'WHKNYO', name: 'WHKNYO' },
-  { code: 'WHKONL', name: 'WHKONL' },
   { code: 'WHKRCH', name: 'WH Kericho' },
+  { code: 'WHKRKU', name: 'WH Kireku' },          // new 2026-06-25
   { code: 'WHKRNY', name: 'WH Kirinya' },
   { code: 'WHKSAS', name: 'WH Kisaasi' },
   { code: 'WHKSBI', name: 'WH Kasubi' },
   { code: 'WHKSGJ', name: 'WH Kasengejje' },
-  { code: 'WHKSKS', name: 'WHKSKS' },
   { code: 'WHKSNG', name: 'WH Kasenge' },
   { code: 'WHKSNJ', name: 'WH Kasanje' },
   { code: 'WHKSSE', name: 'WH Kasese' },
@@ -138,7 +126,6 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHKYGR', name: 'WH Kyengera' },
   { code: 'WHKYGW', name: 'WH Kayunga - Wakiso' },
   { code: 'WHKYJJ', name: 'WH Kyenjojo' },
-  { code: 'WHKYJO', name: 'WHKYJO' },
   { code: 'WHKYNG', name: 'WH Kayunga' },
   { code: 'WHKYNJ', name: 'WH Kyanja' },
   { code: 'WHKYTM', name: 'WH Kyetume' },
@@ -156,7 +143,6 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHLWRO', name: 'WH Luwero' },
   { code: 'WHLYTD', name: 'WH Lyantonde' },
   { code: 'WHLZRA', name: 'WH Luzira' },
-  { code: 'WHMASK', name: 'WHMASK' },
   { code: 'WHMAYA', name: 'WH Maya' },
   { code: 'WHMBKO', name: 'WH Mbiko' },
   { code: 'WHMBLE', name: 'WH Mbale' },
@@ -176,6 +162,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHMPGI', name: 'WH Mpigi' },
   { code: 'WHMPRW', name: 'WH Mpererwe' },
   { code: 'WHMSDY', name: 'WH Misindye' },
+  { code: 'WHMSJJ', name: 'WH Masajja' },         // new 2026-06-25
   { code: 'WHMSKA', name: 'WH Masaka' },
   { code: 'WHMSLT', name: 'WH Masulita' },
   { code: 'WHMSND', name: 'WH Masindi' },
@@ -184,10 +171,8 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHMTGB', name: 'WH Mutungo-Biina' },
   { code: 'WHMTND', name: 'WH Mutundwe' },
   { code: 'WHMTUG', name: 'WH Matugga' },
-  { code: 'WHMTWE', name: 'WHMTWE' },
   { code: 'WHMTYN', name: 'WH Mityana' },
   { code: 'WHMWFU', name: 'WH Muwafu' },
-  { code: 'WHMWGL', name: 'WH Mawangala' },
   { code: 'WHMWRD', name: 'WH Mawanda Road' },
   { code: 'WHMYNG', name: 'WH Muyenga' },
   { code: 'WHNAJJ', name: 'WH Najjera' },
@@ -215,9 +200,8 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHNMGR', name: 'WH Namagera' },
   { code: 'WHNMLG', name: 'WH Namulonge' },
   { code: 'WHNMNV', name: 'WH Namanve' },
-  { code: 'WHNMPG', name: 'WH Nampunge' },
+  { code: 'WHNMPG', name: 'WH Nampunge' },  // unassigned — no FOB in current list
   { code: 'WHNMTB', name: 'WH Namataba' },
-  { code: 'WHNMVD', name: 'WHNMVD' },
   { code: 'WHNMWD', name: 'WH Namwendwa' },
   { code: 'WHNMWG', name: 'WH Namuwongo' },
   { code: 'WHNRBI', name: 'WH Nairobi' },
@@ -229,8 +213,6 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHNSSA', name: 'WH Nsasa' },
   { code: 'WHNTDA', name: 'WH Ntinda' },
   { code: 'WHNTGM', name: 'WH Ntungamo' },
-  { code: 'WHNTND', name: 'WHNTND' },
-  { code: 'WHNTTE', name: 'WHNTTE' },
   { code: 'WHNTWO', name: 'WH Ntawo' },
   { code: 'WHNWLS', name: 'WH North Wales' },
   { code: 'WHNWPD', name: 'WH Nawampanda' },
@@ -239,7 +221,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHONGR', name: 'WH Ongata Rongai' },
   { code: 'WHPDHA', name: 'WH Paidha' },
   { code: 'WHPKCH', name: 'WH Pakwach' },
-  { code: 'WHPLSA', name: 'WH Pallisa' },
+  { code: 'WHPLSA', name: 'WH Pallisa' },  // unassigned — no FOB in current list
   { code: 'WHRBGA', name: 'WH Rubaga' },
   { code: 'WHRUIR', name: 'WH Ruiru' },
   { code: 'WHSEGK', name: 'WH Seguku' },
@@ -248,6 +230,7 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHSNTM', name: 'WH Sentema' },
   { code: 'WHSOND', name: 'WH Sonde' },
   { code: 'WHSROT', name: 'WH Soroti' },
+  { code: 'WHSTMG', name: 'WH Seeta-Magere' },    // new 2026-06-25
   { code: 'WHTEXS', name: 'WH Texas' },
   { code: 'WHTHKA', name: 'WH Thika' },
   { code: 'WHTRRO', name: 'WH Tororo' },
@@ -263,19 +246,209 @@ const WHM_LOCATIONS: { code: string; name: string }[] = [
   { code: 'WHZRBW', name: 'WH Zirobwe' },
 ];
 
-// Kitukutwe FOB — confirmed member codes (from kitukutwe_fob_dashboard_data.json)
-const KTKT_FOB_CODES = new Set([
-  'WHKTKT',
-  'WHNKWR',
-  'WHNSSA',
-  'WHNBSG',
-  'WHNKSJ',
-  'WHKLGI',
-  'WHKJBJ',
-  'WHKMNY',
-]);
+// ---------------------------------------------------------------------------
+// Full hierarchy: Movement → 6 Regions → 37 FOBs → Locations
+// Source: "FOB and Locations.xlsx" + user-supplied 2026-06-25.
+// Geographical region placement is a best-guess; admins can move FOBs after.
+// ---------------------------------------------------------------------------
+const REGION_FOB_LOCATION_MAP: {
+  region: string;
+  fobs: { name: string; codes: string[] }[];
+}[] = [
+  // Source: FOB DIA reports, 14th June 2026
+  {
+    region: 'Greater Kampala East',
+    fobs: [
+      {
+        name: 'Naalya FOB',
+        codes: ['WHNLYA'],
+      },
+      {
+        name: 'Mukono FOB',
+        codes: ['WHKBMB', 'WHKYNG', 'WHKITO', 'WHLUGZ', 'WHMKNO', 'WHMCTY', 'WHNKFM', 'WHNTWO'],
+      },
+      {
+        name: 'Kitukutwe FOB',
+        codes: ['WHKLGI', 'WHKJBJ', 'WHKTKT', 'WHNBSG', 'WHNKSJ', 'WHNKWR', 'WHNSSA', 'WHKMNY'],
+      },
+      {
+        name: 'Makerere FOB',
+        codes: ['WHKSBI', 'WHMKRR', 'WHMNGO', 'WHNKLB', 'WHNKMB'],
+      },
+      {
+        name: 'Mukono Central FOB',
+        codes: ['WHKISG', 'WHMKNC', 'WHNMTB', 'WHNKNJ', 'WHKYTM'],
+      },
+      {
+        name: 'Kira FOB',
+        codes: ['WHKIRA', 'WHKLBR', 'WHKYNJ', 'WHNAJJ', 'WHBWMB'],
+      },
+      {
+        name: 'Kungu FOB',
+        codes: ['WHKTFB', 'WHKUNG', 'WHMWRD', 'WHNMFR', 'WHSTMG'],
+      },
+      {
+        name: 'Sonde FOB',
+        codes: ['WHBYGR', 'WHKWGA', 'WHMSDY', 'WHNTDA', 'WHSOND', 'WHSETA', 'WHBLID'],
+      },
+    ],
+  },
+  {
+    region: 'Greater Kampala South',
+    fobs: [
+      {
+        name: 'Kansanga FOB',
+        codes: [
+          'WHBSBL', 'WHBZGA', 'WHDWTN', 'WHGBRD', 'WHKBLI', 'WHKBYE',
+          'WHMKND', 'WHMTND', 'WHMYNG', 'WHNDJE', 'WHRBGA', 'WHSLRD',
+          'WHNSBY', 'WHMSJJ',
+        ],
+      },
+      {
+        name: 'Bugolobi FOB',
+        codes: ['WHBGLB', 'WHBKSA', 'WHKRNY', 'WHLZRA', 'WHMTGB', 'WHNMWG', 'WHKRKU'],
+      },
+      {
+        name: 'Nakawa FOB',
+        codes: ['WHBKTO', 'WHLGJA', 'WHNKWA', 'WHLUSZ'],
+      },
+      {
+        name: 'Entebbe FOB',
+        codes: ['WHABYT', 'WHENTB', 'WHEBCT', 'WHGRUG', 'WHKGNG'],
+      },
+      {
+        name: 'Joggo FOB',
+        codes: ['WHBAJO', 'WHBKRR', 'WHJOGO', 'WHNMNV', 'WHNLYG', 'WHNSBW'],
+      },
+      {
+        name: 'Kajjansi FOB',
+        codes: ['WHBNMY', 'WHBWBJ', 'WHKJNS', 'WHKITD', 'WHSEGK', 'WHNLMY', 'WHBWGA'],
+      },
+      {
+        name: 'Nakawuka FOB',
+        codes: ['WHNKWK', 'WHNSGU', 'WHBWYA', 'WHKSNJ', 'WHKSNG'],
+      },
+    ],
+  },
+  {
+    region: 'Greater Kampala West',
+    fobs: [
+      {
+        name: 'Gayaza FOB',
+        codes: ['WHGYZA', 'WHKSAS', 'WHKYBD', 'WHLSNJ', 'WHMGRE', 'WHMPRW', 'WHNGBO'],
+      },
+      {
+        name: 'Wakiso FOB',
+        codes: [
+          'WHBULB', 'WHBSGA', 'WHKKRI', 'WHKSGJ', 'WHKYGW',
+          'WHMSLT', 'WHMTYN', 'WHNSNA', 'WHNGND', 'WHWKSO', 'WHNYSA',
+        ],
+      },
+      {
+        name: 'Kabubbu FOB',
+        codes: ['WHBUSK', 'WHBSKM', 'WHKBUB', 'WHNMLG', 'WHZRBW', 'WHKWED'],
+      },
+      {
+        name: 'Matugga FOB',
+        codes: ['WHKVLE', 'WHMTUG', 'WHNKSK', 'WHNDJB', 'WHWTBA', 'WHWBLZ', 'WHLWRO'],
+      },
+      {
+        name: 'Mpigi FOB',
+        codes: ['WHBUDO', 'WHGOMB', 'WHKTND', 'WHKYGR', 'WHMPGI', 'WHNSGI', 'WHMAYA'],
+      },
+      {
+        name: 'Kiti FOB',
+        codes: ['WHKWND', 'WHKWMP', 'WHKLMZ', 'WHKITI', 'WHLGBA', 'WHMGJO', 'WHTULA'],
+      },
+      {
+        name: 'Sentema FOB',
+        codes: ['WHMSNF', 'WHSNTM'],
+      },
+    ],
+  },
+  {
+    region: 'Eastern Uganda',
+    fobs: [
+      {
+        name: 'Jinja FOB',
+        codes: [
+          'WHBDND', 'WHBGMB', 'WHBWNG', 'WHJNJA', 'WHKBBI',
+          'WHMBKO', 'WHMTAI', 'WHNJRU', 'WHNWPD', 'WHNMGR', 'WHMFBR',
+        ],
+      },
+      {
+        name: 'Iganga FOB',
+        codes: ['WHIDUD', 'WHIGNG', 'WHICMS', 'WHKLRO', 'WHLUKA'],
+      },
+      {
+        name: 'Kamuli FOB',
+        codes: ['WHBLND', 'WHKMLI', 'WHNMWD'],
+      },
+      {
+        name: 'Wairaka FOB',
+        codes: ['WHKKRA', 'WHMGMG', 'WHWRKA', 'WHNLSA'],
+      },
+      {
+        name: 'Mbale FOB',
+        codes: ['WHBDKA', 'WHMBLE', 'WHSROT', 'WHTRRO', 'WHMWFU'],
+      },
+      {
+        name: 'Gulu FOB',
+        codes: ['WHAPAC', 'WHGULU', 'WHLIRA'],
+      },
+    ],
+  },
+  {
+    region: 'Western Uganda',
+    fobs: [
+      {
+        name: 'Arua FOB',
+        codes: ['WHARUA', 'WHKBKO', 'WHNEBB', 'WHPDHA', 'WHPKCH', 'WHWNDI', 'WHBNDO'],
+      },
+      {
+        name: 'Masaka FOB',
+        codes: ['WHKBNG', 'WHLKYA', 'WHLYTD', 'WHMSKA', 'WHNYDO'],
+      },
+      {
+        name: 'Mbarara FOB',
+        codes: ['WHBHRW', 'WHIBND', 'WHISHK', 'WHKBLE', 'WHKKBA', 'WHMBRA', 'WHNTGM', 'WHBSHY'],
+      },
+      {
+        name: 'Fort Portal FOB',
+        codes: ['WHFTPT', 'WHKSSE', 'WHKYGG', 'WHKYJJ', 'WHMBND', 'WHKHRA'],
+      },
+      {
+        name: 'Hoima FOB',
+        codes: ['WHHOMA', 'WHMSND', 'WHKGMB'],
+      },
+    ],
+  },
+  {
+    region: 'Global',
+    fobs: [
+      {
+        name: 'Kenya FOB',
+        codes: ['WHJUJA', 'WHKEOL', 'WHKRCH', 'WHKMBU', 'WHKTGL', 'WHNRBI', 'WHONGR', 'WHRUIR', 'WHTHKA', 'WHMBSA'],
+      },
+      {
+        name: 'Rest of Africa FOB',
+        codes: ['WHAFOL', 'WHASOL', 'WHDRSM', 'WHKGLI', 'WHLUSK'],
+      },
+      {
+        name: 'Europe & Oceania FOB',
+        codes: ['WHAUST', 'WHEONL', 'WHGNVA', 'WHGMNY', 'WHLEDS', 'WHLUTN', 'WHNWLS', 'WHUKDM', 'WHKFLD', 'WHWGAN'],
+      },
+      {
+        name: 'Americas FOB',
+        codes: ['WHTEXS', 'WHUSOA', 'WHBMDA', 'WHCNDA'],
+      },
+    ],
+  },
+];
 
-// WHKTKT zones and MCs (from whktkt_zonal_dashboard_data.json latestRows)
+// ---------------------------------------------------------------------------
+// WHKTKT internal structure — zones and missional communities
+// ---------------------------------------------------------------------------
 const WHKTKT_ZONES: { name: string; mcs: { name: string }[] }[] = [
   {
     name: 'Bulindo',
@@ -284,120 +457,77 @@ const WHKTKT_ZONES: { name: string; mcs: { name: string }[] }[] = [
   {
     name: 'Cathedral Zone',
     mcs: [
-      { name: 'Beloved (A)' },
-      { name: 'Beyond Self (A)' },
-      { name: 'Blessed Kids (C)' },
-      { name: 'Feathers of Greatness (T)' },
-      { name: 'Hopeful (T)' },
-      { name: 'Matthew (A)' },
-      { name: 'Miraculous (A)' },
-      { name: 'Obedience (A)' },
-      { name: 'Revelation (T)' },
-      { name: 'Righteous (T)' },
-      { name: 'Zion (C)' },
+      { name: 'Beloved (A)' }, { name: 'Beyond Self (A)' }, { name: 'Blessed Kids (C)' },
+      { name: 'Feathers of Greatness (T)' }, { name: 'Hopeful (T)' }, { name: 'Matthew (A)' },
+      { name: 'Miraculous (A)' }, { name: 'Obedience (A)' }, { name: 'Revelation (T)' },
+      { name: 'Righteous (T)' }, { name: 'Zion (C)' },
     ],
   },
   {
     name: 'Kazinga',
     mcs: [
-      { name: "Be'zri (A)" },
-      { name: 'Divine (C)' },
-      { name: 'Grace (A)' },
-      { name: 'Nissi (C)' },
+      { name: "Be'zri (A)" }, { name: 'Divine (C)' }, { name: 'Grace (A)' }, { name: 'Nissi (C)' },
     ],
   },
   {
     name: 'Kijabijjo',
     mcs: [
-      { name: 'Bethel (T)' },
-      { name: 'Christ The King (T)' },
-      { name: 'Faithful (A)' },
-      { name: 'Galatians (T)' },
-      { name: 'Gates of Heaven (T)' },
-      { name: 'Genesis (T)' },
-      { name: 'Glory (C)' },
-      { name: 'Justified (T)' },
-      { name: 'Majesty (T)' },
-      { name: 'Mulungi (A)' },
-      { name: 'Overcomers (A)' },
-      { name: 'Peace (C)' },
-      { name: 'Peniel (T)' },
-      { name: 'True Star (C)' },
-      { name: 'Victory (T)' },
+      { name: 'Bethel (T)' }, { name: 'Christ The King (T)' }, { name: 'Faithful (A)' },
+      { name: 'Galatians (T)' }, { name: 'Gates of Heaven (T)' }, { name: 'Genesis (T)' },
+      { name: 'Glory (C)' }, { name: 'Justified (T)' }, { name: 'Majesty (T)' },
+      { name: 'Mulungi (A)' }, { name: 'Overcomers (A)' }, { name: 'Peace (C)' },
+      { name: 'Peniel (T)' }, { name: 'True Star (C)' }, { name: 'Victory (T)' },
     ],
   },
   {
     name: 'Kira',
     mcs: [
-      { name: 'Glorious (C)' },
-      { name: 'Icons (A)' },
-      { name: 'Kira Kapeera (A)' },
-      { name: 'Sufficient (A)' },
+      { name: 'Glorious (C)' }, { name: 'Icons (A)' },
+      { name: 'Kira Kapeera (A)' }, { name: 'Sufficient (A)' },
     ],
   },
   {
     name: 'Kitukutwe',
     mcs: [
-      { name: 'Arrows (C)' },
-      { name: 'Beautiful (A)' },
-      { name: 'Gratitude (A)' },
-      { name: 'Multitudes (A)' },
-      { name: 'Rooted (A)' },
-      { name: 'Shalom (C)' },
+      { name: 'Arrows (C)' }, { name: 'Beautiful (A)' }, { name: 'Gratitude (A)' },
+      { name: 'Multitudes (A)' }, { name: 'Rooted (A)' }, { name: 'Shalom (C)' },
     ],
   },
   {
     name: 'Kitukutwe 2',
     mcs: [
-      { name: 'Agape (A)' },
-      { name: 'Beacon of Power (A)' },
-      { name: 'Kwagala (A)' },
-      { name: 'Zoe (A)' },
+      { name: 'Agape (A)' }, { name: 'Beacon of Power (A)' },
+      { name: 'Kwagala (A)' }, { name: 'Zoe (A)' },
     ],
   },
   {
     name: 'Kiwologoma',
     mcs: [
-      { name: 'Harvest (T)' },
-      { name: 'Little Lighters (C)' },
-      { name: 'Redemption (A)' },
-      { name: 'Redemption Kids (C)' },
-      { name: 'Restoration (A)' },
-      { name: 'Solomon (A)' },
-      { name: 'Zion Wave (A)' },
+      { name: 'Harvest (T)' }, { name: 'Little Lighters (C)' }, { name: 'Redemption (A)' },
+      { name: 'Redemption Kids (C)' }, { name: 'Restoration (A)' },
+      { name: 'Solomon (A)' }, { name: 'Zion Wave (A)' },
     ],
   },
   {
     name: 'Najjera',
     mcs: [
-      { name: 'Faraja (A)' },
-      { name: "God's Will (A)" },
-      { name: 'Heirs of The Promise (A)' },
-      { name: 'Hosanna (A)' },
-      { name: 'Hosanna Kids (C)' },
-      { name: 'New Life (A)' },
+      { name: 'Faraja (A)' }, { name: "God's Will (A)" }, { name: 'Heirs of The Promise (A)' },
+      { name: 'Hosanna (A)' }, { name: 'Hosanna Kids (C)' }, { name: 'New Life (A)' },
     ],
   },
   {
     name: 'Namirembe rd',
     mcs: [
-      { name: 'Cubs of Judah(C)' },
-      { name: 'Lion of Judah (A)' },
-      { name: "Messiah's Own (T)" },
-      { name: 'Tendo (C)' },
+      { name: 'Cubs of Judah(C)' }, { name: 'Lion of Judah (A)' },
+      { name: "Messiah's Own (T)" }, { name: 'Tendo (C)' },
     ],
   },
   {
     name: 'Nsasa',
     mcs: [
-      { name: 'Abundance (A)' },
-      { name: 'Called to Greatness (C)' },
-      { name: 'Glory MC (A)' },
-      { name: "Heaven's little Heroes (C)" },
-      { name: 'Renaissance (T)' },
-      { name: 'Shalac (T)' },
-      { name: 'Shape (A)' },
-      { name: 'Steadfast (T)' },
+      { name: 'Abundance (A)' }, { name: 'Called to Greatness (C)' }, { name: 'Glory MC (A)' },
+      { name: "Heaven's little Heroes (C)" }, { name: 'Renaissance (T)' },
+      { name: 'Shalac (T)' }, { name: 'Shape (A)' }, { name: 'Steadfast (T)' },
     ],
   },
 ];
@@ -422,114 +552,109 @@ export class WhmGroupTreeSeedService {
 
   async seedGroupTree(): Promise<void> {
     this.init();
-    Logger.log('🌲 [WHM] Seeding WHM group tree...');
+    Logger.log('🌲 [WHM] Seeding group tree...');
 
-    const tenant = await this.tenantRepo.findOne({
-      where: { name: 'worshipharvest' },
-    });
+    const tenant = await this.tenantRepo.findOne({ where: { name: 'worshipharvest' } });
     if (!tenant) throw new Error('WHM tenant not found — run base seed first');
 
-    const structureCat = await this.categoryRepo.findOne({
-      where: {
-        purpose: GroupCategoryPurpose.STRUCTURE,
-        tenant: { id: tenant.id },
-      },
-    });
-    const locationCat = await this.categoryRepo.findOne({
-      where: {
-        purpose: GroupCategoryPurpose.LOCATION,
-        tenant: { id: tenant.id },
-      },
-    });
-    const fellowshipCat = await this.categoryRepo.findOne({
-      where: {
-        purpose: GroupCategoryPurpose.FELLOWSHIP,
-        tenant: { id: tenant.id },
-      },
-    });
+    const movementCat  = await this.cat(tenant, 'Movement');
+    const regionCat    = await this.cat(tenant, 'Region');
+    const fobCat       = await this.cat(tenant, 'Forward Operating Base');
+    const locationCat  = await this.cat(tenant, 'Location');
+    const zoneCat      = await this.cat(tenant, 'Zone');
+    const mcCat        = await this.cat(tenant, 'Missional Community');
 
-    if (!structureCat || !locationCat || !fellowshipCat) {
-      throw new Error(
-        'Required group categories not found — run base seed first',
-      );
+    if (!movementCat || !regionCat || !fobCat || !locationCat || !zoneCat || !mcCat) {
+      throw new Error('Required group categories missing — run seedGroupCategories first');
     }
 
-    // 1. Top-level region
-    const region = await this.findOrCreate(
-      'WHM Uganda',
-      structureCat,
-      tenant,
-      null,
-    );
+    // Build code → definition lookup
+    const locationDefs = new Map(WHM_LOCATIONS.map((l) => [l.code, l]));
 
-    // 2. Kitukutwe FOB
-    const ktktFob = await this.findOrCreate(
-      'Kitukutwe FOB',
-      structureCat,
-      tenant,
-      region,
-    );
+    // 1. Movement root
+    const movement = await this.findOrCreate('Worship Harvest', movementCat, tenant, null);
 
-    // 3. All 242 locations
-    const locationByCode = new Map<string, Group>();
-    let created = 0;
-    let skipped = 0;
+    let fobCount = 0;
+    let locCreated = 0;
+    let locExisting = 0;
+    const assignedCodes = new Set<string>();
+    let whktkt: Group | null = null;
 
-    for (const loc of WHM_LOCATIONS) {
-      const parent = KTKT_FOB_CODES.has(loc.code) ? ktktFob : region;
-      const [group, wasCreated] = await this.findOrCreateLocation(
-        loc.code,
-        loc.name,
-        locationCat,
-        tenant,
-        parent,
-      );
-      locationByCode.set(loc.code, group);
-      if (wasCreated) created++;
-      else skipped++;
-    }
-    Logger.log(
-      `[WHM] Locations: ${created} created, ${skipped} already existed`,
-    );
+    // 2. Regions → FOBs → Locations
+    for (const regionDef of REGION_FOB_LOCATION_MAP) {
+      const region = await this.findOrCreate(regionDef.region, regionCat, tenant, movement);
 
-    // 4. WHKTKT zones and MCs
-    const whktkt = locationByCode.get('WHKTKT');
-    if (!whktkt) {
-      Logger.warn(
-        '[WHM] WHKTKT not found in locationByCode — skipping zones/MCs',
-      );
-      return;
-    }
+      for (const fobDef of regionDef.fobs) {
+        const fob = await this.findOrCreate(fobDef.name, fobCat, tenant, region);
+        fobCount++;
 
-    let zoneCreated = 0;
-    let mcCreated = 0;
-
-    for (const zoneDef of WHKTKT_ZONES) {
-      const [zone, zoneWasCreated] = await this.findOrCreateByNameAndParent(
-        zoneDef.name,
-        structureCat,
-        tenant,
-        whktkt,
-      );
-      if (zoneWasCreated) zoneCreated++;
-
-      for (const mcDef of zoneDef.mcs) {
-        const [, mcWasCreated] = await this.findOrCreateByNameAndParent(
-          mcDef.name,
-          fellowshipCat,
-          tenant,
-          zone,
-        );
-        if (mcWasCreated) mcCreated++;
+        for (const code of fobDef.codes) {
+          assignedCodes.add(code);
+          const def = locationDefs.get(code);
+          if (!def) {
+            Logger.warn(`[WHM] Code ${code} (${fobDef.name}) not in location master list`);
+            continue;
+          }
+          const [loc, created] = await this.findOrCreateLocation(
+            def.code, def.name, locationCat, tenant, fob,
+          );
+          if (created) locCreated++;
+          else locExisting++;
+          if (code === 'WHKTKT') whktkt = loc;
+        }
       }
     }
 
-    Logger.log(`[WHM] WHKTKT: ${zoneCreated} zones, ${mcCreated} MCs created`);
+    Logger.log(
+      `[WHM] 6 regions | ${fobCount} FOBs | ${locCreated} locations created, ${locExisting} existing`,
+    );
 
-    // 5. Demo user group memberships
-    await this.seedDemoMemberships(region, ktktFob, whktkt);
+    // 3. WHKTKT internal structure (zones + MCs)
+    if (whktkt) {
+      await this.seedWhktktZones(whktkt, zoneCat, mcCat, tenant);
+    } else {
+      Logger.warn('[WHM] WHKTKT not found — skipping zones/MCs');
+    }
 
-    Logger.log('✅ [WHM] Group tree seeded.');
+    Logger.log('✅ [WHM] Group tree complete.');
+    return;
+  }
+
+  /** Attach a group membership for an admin user to the top-level movement. */
+  async assignAdminToMovement(username: string): Promise<void> {
+    this.init();
+    const tenant = await this.tenantRepo.findOne({ where: { name: 'worshipharvest' } });
+    const movement = await this.groupRepo
+      .createQueryBuilder('g')
+      .where('g."tenantId" = :t', { t: tenant?.id })
+      .andWhere('g.name = :n', { n: 'Worship Harvest' })
+      .getOne();
+
+    const user = await this.userRepo.findOne({ where: { username } });
+    if (!user || !movement) return;
+
+    const exists = await this.membershipRepo.findOne({
+      where: { contactId: user.contactId, groupId: movement.id },
+    });
+    if (exists) return;
+
+    await this.membershipRepo.save(
+      this.membershipRepo.create({
+        contactId: user.contactId,
+        groupId: movement.id,
+        role: GroupRole.Leader,
+        isActive: true,
+      }),
+    );
+    Logger.log(`[WHM] Admin user ${username} assigned to Worship Harvest`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async cat(tenant: Tenant, name: string): Promise<GroupCategory | null> {
+    return this.categoryRepo.findOne({ where: { name, tenant: { id: tenant.id } } });
   }
 
   private async findOrCreate(
@@ -538,12 +663,7 @@ export class WhmGroupTreeSeedService {
     tenant: Tenant,
     parent: Group | null,
   ): Promise<Group> {
-    const [group] = await this.findOrCreateByNameAndParent(
-      name,
-      category,
-      tenant,
-      parent,
-    );
+    const [group] = await this.findOrCreateByNameAndParent(name, category, tenant, parent);
     return group;
   }
 
@@ -559,97 +679,19 @@ export class WhmGroupTreeSeedService {
       .andWhere('g."categoryId" = :catId', { catId: category.id })
       .andWhere('g.name = :name', { name });
 
-    if (parent) {
-      qb.andWhere('g."parentId" = :parentId', { parentId: parent.id });
-    } else {
-      qb.andWhere('g."parentId" IS NULL');
-    }
+    parent
+      ? qb.andWhere('g."parentId" = :parentId', { parentId: parent.id })
+      : qb.andWhere('g."parentId" IS NULL');
 
     const existing = await qb.getOne();
     if (existing) return [existing, false];
 
-    const group = this.groupRepo.create({
-      name,
-      category,
-      tenant,
-      parent: parent ?? undefined,
-      privacy: GroupPrivacy.Public,
-    });
-    return [await this.groupRepo.save(group), true];
-  }
-
-  private async seedDemoMemberships(
-    region: Group,
-    ktktFob: Group,
-    whktkt: Group,
-  ): Promise<void> {
-    const kitukutweZone = await this.groupRepo
-      .createQueryBuilder('g')
-      .where('g."parentId" = :parentId', { parentId: whktkt.id })
-      .andWhere('g.name = :name', { name: 'Kitukutwe' })
-      .getOne();
-
-    const arrowsMc = kitukutweZone
-      ? await this.groupRepo
-          .createQueryBuilder('g')
-          .where('g."parentId" = :parentId', { parentId: kitukutweZone.id })
-          .andWhere('g.name = :name', { name: 'Arrows (C)' })
-          .getOne()
-      : null;
-
-    const assignments: { username: string; group: Group | null }[] = [
-      { username: 'fellowship@worshipharvest.org', group: arrowsMc },
-      { username: 'zone@worshipharvest.org', group: kitukutweZone },
-      { username: 'location@worshipharvest.org', group: whktkt },
-      { username: 'fob@worshipharvest.org', group: ktktFob },
-      { username: 'network@worshipharvest.org', group: region },
-      { username: 'movement@worshipharvest.org', group: region },
-      { username: 'admin@worshipharvest.org', group: region },
+    return [
+      await this.groupRepo.save(
+        this.groupRepo.create({ name, category, tenant, parent: parent ?? undefined, privacy: GroupPrivacy.Public }),
+      ),
+      true,
     ];
-
-    let assigned = 0;
-    let skipped = 0;
-
-    for (const { username, group } of assignments) {
-      if (!group) {
-        Logger.warn(
-          `[WHM] Demo membership skipped — group not found for ${username}`,
-        );
-        skipped++;
-        continue;
-      }
-
-      const user = await this.userRepo.findOne({ where: { username } });
-      if (!user) {
-        Logger.warn(
-          `[WHM] Demo membership skipped — user not found: ${username}`,
-        );
-        skipped++;
-        continue;
-      }
-
-      const existing = await this.membershipRepo.findOne({
-        where: { contactId: user.contactId, groupId: group.id },
-      });
-      if (existing) {
-        skipped++;
-        continue;
-      }
-
-      await this.membershipRepo.save(
-        this.membershipRepo.create({
-          contactId: user.contactId,
-          groupId: group.id,
-          role: GroupRole.Leader,
-          isActive: true,
-        }),
-      );
-      assigned++;
-    }
-
-    Logger.log(
-      `[WHM] Demo memberships: ${assigned} assigned, ${skipped} skipped`,
-    );
   }
 
   private async findOrCreateLocation(
@@ -663,19 +705,39 @@ export class WhmGroupTreeSeedService {
       .createQueryBuilder('g')
       .where('g."tenantId" = :tenantId', { tenantId: tenant.id })
       .andWhere('g."categoryId" = :catId', { catId: category.id })
-      .andWhere('g."metaData"->>\'code\' = :code', { code })
+      .andWhere(`g."metaData"->>'code' = :code`, { code })
       .getOne();
 
     if (existing) return [existing, false];
 
-    const group = this.groupRepo.create({
-      name,
-      category,
-      tenant,
-      parent,
-      privacy: GroupPrivacy.Public,
-      metaData: { code },
-    });
-    return [await this.groupRepo.save(group), true];
+    return [
+      await this.groupRepo.save(
+        this.groupRepo.create({
+          name, category, tenant, parent,
+          privacy: GroupPrivacy.Public,
+          metaData: { code },
+        }),
+      ),
+      true,
+    ];
+  }
+
+  private async seedWhktktZones(
+    whktkt: Group,
+    zoneCat: GroupCategory,
+    mcCat: GroupCategory,
+    tenant: Tenant,
+  ): Promise<void> {
+    let zones = 0;
+    let mcs = 0;
+    for (const zoneDef of WHKTKT_ZONES) {
+      const [zone, zc] = await this.findOrCreateByNameAndParent(zoneDef.name, zoneCat, tenant, whktkt);
+      if (zc) zones++;
+      for (const mcDef of zoneDef.mcs) {
+        const [, mc] = await this.findOrCreateByNameAndParent(mcDef.name, mcCat, tenant, zone);
+        if (mc) mcs++;
+      }
+    }
+    Logger.log(`[WHM] WHKTKT: ${zones} zones, ${mcs} MCs created`);
   }
 }


### PR DESCRIPTION
# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new production seeding command for a full reset-and-seed workflow, with options to preview changes or skip admin setup.
  * Expanded seeded organization structure with a new region category and updated location hierarchy.
  * Added automatic creation of an admin account during seeding, plus assignment to the main movement group when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->