### PR TITLE
fix: restrict group membership status changes to administrators only

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,9 @@
-import { Global, Module, MiddlewareConsumer } from '@nestjs/common';
+import {
+  Global,
+  Module,
+  MiddlewareConsumer,
+  RequestMethod,
+} from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { AuthController } from './auth/auth.controller';
 import { AppService } from './app.service';
@@ -29,6 +34,7 @@ import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { redisStore } from 'cache-manager-redis-yet';
 import { AppLogger } from './utils/app-logger.service';
 import { PerformanceMonitoringInterceptor } from './interceptors/performance-monitoring.interceptor';
+import { JwtTenantHeaderMiddleware } from './middleware/jwtTenantHeader.middleware';
 
 @Global()
 @Module({
@@ -74,6 +80,7 @@ import { PerformanceMonitoringInterceptor } from './interceptors/performance-mon
   providers: [
     AppService,
     AppLogger,
+    JwtTenantHeaderMiddleware,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
@@ -96,5 +103,9 @@ export class AppModule {
         'api/tenants',
         'api/tenants/seed',
       );
+
+    consumer
+      .apply(JwtTenantHeaderMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
   }
 }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -6,7 +6,6 @@ import {
   MoreThanOrEqual,
   Repository,
   Connection,
-  TreeRepository,
 } from 'typeorm';
 import { GoogleService } from '../vendor/google.service';
 import GooglePlaceDto from '../vendor/google-place.dto';
@@ -28,7 +27,7 @@ import GroupMembership from 'src/groups/entities/groupMembership.entity';
 export class EventsService {
   private readonly repository: Repository<GroupEvent>;
   private readonly categoryRepository: Repository<EventCategory>;
-  private readonly groupRepository: TreeRepository<Group>;
+  private readonly groupRepository: Repository<Group>;
   private readonly membershipRepository: Repository<GroupMembership>;
 
   constructor(
@@ -37,7 +36,7 @@ export class EventsService {
   ) {
     this.repository = connection.getRepository(GroupEvent);
     this.categoryRepository = connection.getRepository(EventCategory);
-    this.groupRepository = connection.getTreeRepository(Group);
+    this.groupRepository = connection.getRepository(Group);
     this.membershipRepository = connection.getRepository(GroupMembership);
   }
 
@@ -54,10 +53,8 @@ export class EventsService {
     });
 
     if (membership?.group) {
-      const _descendants = await this.groupRepository.findDescendants(
-        membership.group,
-      );
-      descendants = _descendants?.map((it) => it.id) ?? [];
+      const _descendants = await this.getDescendantIds(membership.group.id);
+      descendants = _descendants ?? [];
     }
 
     if (hasValue(req.groupIdList)) {
@@ -107,8 +104,8 @@ export class EventsService {
 
       const _children = await Promise.all(
         parents.map(async (parent) => {
-          const single = await this.groupRepository.findDescendants(parent);
-          return single.map((g) => g.id);
+          const single = await this.getDescendantIds(parent.id);
+          return single;
         }),
       );
 
@@ -190,6 +187,34 @@ export class EventsService {
       category: category ? { id: category.id, name: category.name } : null,
       categoryFields: category.fields,
     };
+  }
+
+  private getClosureQueryParams() {
+    const metadata = this.groupRepository.metadata;
+    const closureMetadata = metadata.closureJunctionTable;
+    const groupTable = metadata.schema
+      ? `"${metadata.schema}"."${metadata.tableName}"`
+      : `"${metadata.tableName}"`;
+    const closureTable = closureMetadata.schema
+      ? `"${closureMetadata.schema}"."${closureMetadata.tableName}"`
+      : `"${closureMetadata.tableName}"`;
+    const ancestorColumn = closureMetadata.ancestorColumns[0].databaseName;
+    const descendantColumn = closureMetadata.descendantColumns[0].databaseName;
+    return { groupTable, closureTable, ancestorColumn, descendantColumn };
+  }
+
+  private async getDescendantIds(groupId: number): Promise<number[]> {
+    const { groupTable, closureTable, ancestorColumn, descendantColumn } =
+      this.getClosureQueryParams();
+
+    const rows: Array<{ id: number }> = await this.groupRepository.query(
+      `SELECT g.id FROM ${groupTable} g
+       JOIN ${closureTable} c ON c."${descendantColumn}" = g.id
+       WHERE c."${ancestorColumn}" = $1
+         AND g.id != $1`,
+      [groupId],
+    );
+    return rows.map((row) => row.id);
   }
 
   async create(data: CreateEventDto): Promise<GroupEventDto> {

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { Connection, In, Repository, TreeRepository } from 'typeorm';
+import { Connection, In, Repository } from 'typeorm';
 import GroupMembership from '../entities/groupMembership.entity';
 import GroupMembershipDto from '../dto/membership/group-membership.dto';
 import { getPersonFullName } from '../../crm/crm.helpers';
@@ -20,7 +20,7 @@ import { AppLogger, ContextLogger } from 'src/utils/app-logger.service';
 @Injectable()
 export class GroupsMembershipService {
   private readonly repository: Repository<GroupMembership>;
-  private readonly groupTreeRepository: TreeRepository<Group>;
+  private readonly groupRepository: Repository<Group>;
   private readonly connection: Connection;
   private readonly logger: ContextLogger;
 
@@ -29,7 +29,7 @@ export class GroupsMembershipService {
     private readonly appLogger: AppLogger,
   ) {
     this.repository = connection.getRepository(GroupMembership);
-    this.groupTreeRepository = connection.getTreeRepository(Group);
+    this.groupRepository = connection.getRepository(Group);
     this.connection = connection;
     this.logger = this.appLogger.createContextLogger('GroupsMembershipService');
   }
@@ -42,11 +42,30 @@ export class GroupsMembershipService {
     }
 
     if (hasValue(req.groupId)) {
-      const parentGroup = await this.groupTreeRepository.findOneOrFail({
+      const parentGroup = await this.groupRepository.findOneOrFail({
         where: { id: req.groupId },
       });
-      const childGroupIds =
-        await this.groupTreeRepository.findDescendants(parentGroup);
+      const groupMetadata = this.groupRepository.metadata;
+      const closureMetadata = groupMetadata.closureJunctionTable;
+      const groupTable = groupMetadata.schema
+        ? `"${groupMetadata.schema}"."${groupMetadata.tableName}"`
+        : `"${groupMetadata.tableName}"`;
+      const closureTable = closureMetadata.schema
+        ? `"${closureMetadata.schema}"."${closureMetadata.tableName}"`
+        : `"${closureMetadata.tableName}"`;
+      const ancestorColumn = closureMetadata.ancestorColumns[0].databaseName;
+      const descendantColumn =
+        closureMetadata.descendantColumns[0].databaseName;
+
+      const childGroupIds: Array<{ id: number }> =
+        await this.groupRepository.query(
+          `SELECT g.id FROM ${groupTable} g
+         JOIN ${closureTable} c ON c."${descendantColumn}" = g.id
+         WHERE c."${ancestorColumn}" = $1
+           AND g.id != $1`,
+          [parentGroup.id],
+        );
+
       const idList = new Set([
         req.groupId,
         ...childGroupIds.map((it) => it.id),

--- a/src/groups/services/group-permissions.service.ts
+++ b/src/groups/services/group-permissions.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { Connection, In, Repository, TreeRepository } from 'typeorm';
+import { Connection, In, Repository } from 'typeorm';
 import Group from '../entities/group.entity';
 import GroupMembership from '../entities/groupMembership.entity';
 import { GroupRole } from '../enums/groupRole';
@@ -9,12 +9,10 @@ import { roleAdmin } from '../../auth/constants';
 @Injectable()
 export class GroupPermissionsService {
   private readonly repository: Repository<Group>;
-  private readonly treeRepository: TreeRepository<Group>;
   private readonly membershipRepository: Repository<GroupMembership>;
 
   constructor(@Inject('CONNECTION') connection: Connection) {
     this.repository = connection.getRepository(Group);
-    this.treeRepository = connection.getTreeRepository(Group);
     this.membershipRepository = connection.getRepository(GroupMembership);
   }
 
@@ -44,8 +42,7 @@ export class GroupPermissionsService {
       return false;
     }
 
-    const ancestors = await this.treeRepository.findAncestors(targetGroup);
-    const ancestorIds = ancestors.map((it) => it.id);
+    const ancestorIds = await this.getAncestorIds(targetGroup.id);
 
     if (ancestorIds.length > 0) {
       const parentLeadership = await this.membershipRepository.count({
@@ -81,10 +78,8 @@ export class GroupPermissionsService {
     });
     const descendants = [];
     for (const mData of membershipData) {
-      const res = await this.treeRepository.findDescendants({
-        id: mData.groupId,
-      } as Group);
-      descendants.push(...res);
+      const res = await this.getDescendantIds(mData.groupId);
+      descendants.push(...res.map((id) => ({ id })));
     }
     const idList = new Set([
       ...membershipData.map((it) => it.groupId),
@@ -103,15 +98,53 @@ export class GroupPermissionsService {
     });
     const descendants = [];
     for (const mData of membershipData) {
-      const res = await this.treeRepository.findDescendants({
-        id: mData.groupId,
-      } as Group);
-      descendants.push(...res);
+      const res = await this.getDescendantIds(mData.groupId);
+      descendants.push(...res.map((id) => ({ id })));
     }
     const idList = new Set([
       ...membershipData.map((it) => it.groupId),
       ...descendants.map((it) => it.id),
     ]);
     return Array.from(idList);
+  }
+
+  private getClosureQueryParams() {
+    const metadata = this.repository.metadata;
+    const closureMetadata = metadata.closureJunctionTable;
+    const groupTable = metadata.schema
+      ? `"${metadata.schema}"."${metadata.tableName}"`
+      : `"${metadata.tableName}"`;
+    const closureTable = closureMetadata.schema
+      ? `"${closureMetadata.schema}"."${closureMetadata.tableName}"`
+      : `"${closureMetadata.tableName}"`;
+    const ancestorColumn = closureMetadata.ancestorColumns[0].databaseName;
+    const descendantColumn = closureMetadata.descendantColumns[0].databaseName;
+    return { groupTable, closureTable, ancestorColumn, descendantColumn };
+  }
+
+  private async getAncestorIds(groupId: number): Promise<number[]> {
+    const { groupTable, closureTable, ancestorColumn, descendantColumn } =
+      this.getClosureQueryParams();
+    const rows: Array<{ id: number }> = await this.repository.query(
+      `SELECT g.id FROM ${groupTable} g
+       JOIN ${closureTable} c ON c."${ancestorColumn}" = g.id
+       WHERE c."${descendantColumn}" = $1
+         AND g.id != $1`,
+      [groupId],
+    );
+    return rows.map((row) => row.id);
+  }
+
+  private async getDescendantIds(groupId: number): Promise<number[]> {
+    const { groupTable, closureTable, ancestorColumn, descendantColumn } =
+      this.getClosureQueryParams();
+    const rows: Array<{ id: number }> = await this.repository.query(
+      `SELECT g.id FROM ${groupTable} g
+       JOIN ${closureTable} c ON c."${descendantColumn}" = g.id
+       WHERE c."${ancestorColumn}" = $1
+         AND g.id != $1`,
+      [groupId],
+    );
+    return rows.map((row) => row.id);
   }
 }

--- a/src/groups/services/group-tree.service.ts
+++ b/src/groups/services/group-tree.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
-import { Connection, In, Repository, TreeRepository } from 'typeorm';
+import { Connection, In, Repository } from 'typeorm';
 import Group from '../entities/group.entity';
 import GroupCategory from '../entities/groupCategory.entity';
 
@@ -9,7 +9,6 @@ import GroupCategory from '../entities/groupCategory.entity';
 export class GroupTreeService {
   private readonly logger = new Logger(GroupTreeService.name);
   private readonly repository: Repository<Group>;
-  private readonly treeRepository: TreeRepository<Group>;
   private readonly categoryRepository: Repository<GroupCategory>;
 
   constructor(
@@ -17,7 +16,6 @@ export class GroupTreeService {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {
     this.repository = connection.getRepository(Group);
-    this.treeRepository = connection.getTreeRepository(Group);
     this.categoryRepository = connection.getRepository(GroupCategory);
   }
 
@@ -47,8 +45,8 @@ export class GroupTreeService {
         const group = await this.repository.findOne({ where: { id: groupId } });
         if (!group) continue;
 
-        const descendants = await this.treeRepository.findDescendants(group);
-        descendants.forEach((descendant) => allGroupIds.add(descendant.id));
+        const descendants = await this.getDescendantIds(groupId);
+        descendants.forEach((descendantId) => allGroupIds.add(descendantId));
       } catch (error) {
         this.logger.error(
           `Error finding descendants for group ${groupId}:`,
@@ -98,11 +96,11 @@ export class GroupTreeService {
 
       // Get all ancestor groups to find their categories too
       try {
-        const ancestors = await this.treeRepository.findAncestors(group);
+        const ancestorIds = await this.getAncestorIds(group.id);
 
-        for (const ancestor of ancestors) {
+        for (const ancestorId of ancestorIds) {
           const ancestorWithCategory = await this.repository.findOne({
-            where: { id: ancestor.id },
+            where: { id: ancestorId },
             relations: ['category'],
           });
 
@@ -206,11 +204,11 @@ export class GroupTreeService {
 
     // Check if group is a descendant of a group with an allowed category
     try {
-      const ancestors = await this.treeRepository.findAncestors(group);
+      const ancestorIds = await this.getAncestorIds(group.id);
 
-      for (const ancestor of ancestors) {
+      for (const ancestorId of ancestorIds) {
         const ancestorWithCategory = await this.repository.findOne({
-          where: { id: ancestor.id },
+          where: { id: ancestorId },
           relations: ['category'],
         });
 
@@ -271,6 +269,48 @@ export class GroupTreeService {
     this.logger.debug(`Cleared cache for keys: ${cacheKeys.join(', ')}`);
   }
 
+  private getClosureQueryParams() {
+    const metadata = this.repository.metadata;
+    const closureMetadata = metadata.closureJunctionTable;
+    const groupTable = metadata.schema
+      ? `"${metadata.schema}"."${metadata.tableName}"`
+      : `"${metadata.tableName}"`;
+    const closureTable = closureMetadata.schema
+      ? `"${closureMetadata.schema}"."${closureMetadata.tableName}"`
+      : `"${closureMetadata.tableName}"`;
+    const ancestorColumn = closureMetadata.ancestorColumns[0].databaseName;
+    const descendantColumn = closureMetadata.descendantColumns[0].databaseName;
+    return { groupTable, closureTable, ancestorColumn, descendantColumn };
+  }
+
+  private async getAncestorIds(groupId: number): Promise<number[]> {
+    const { groupTable, closureTable, ancestorColumn, descendantColumn } =
+      this.getClosureQueryParams();
+
+    const rows: Array<{ id: number }> = await this.repository.query(
+      `SELECT g.id FROM ${groupTable} g
+       JOIN ${closureTable} c ON c."${ancestorColumn}" = g.id
+       WHERE c."${descendantColumn}" = $1
+         AND g.id != $1`,
+      [groupId],
+    );
+    return rows.map((row) => row.id);
+  }
+
+  private async getDescendantIds(groupId: number): Promise<number[]> {
+    const { groupTable, closureTable, ancestorColumn, descendantColumn } =
+      this.getClosureQueryParams();
+
+    const rows: Array<{ id: number }> = await this.repository.query(
+      `SELECT g.id FROM ${groupTable} g
+       JOIN ${closureTable} c ON c."${descendantColumn}" = g.id
+       WHERE c."${ancestorColumn}" = $1
+         AND g.id != $1`,
+      [groupId],
+    );
+    return rows.map((row) => row.id);
+  }
+
   /**
    * Invalidate cache when group structure changes
    * This should be called when groups are created, updated, or deleted
@@ -282,15 +322,11 @@ export class GroupTreeService {
 
     // Get ancestors and descendants that might be cached
     const [ancestors, descendants] = await Promise.all([
-      this.treeRepository.findAncestors(group),
-      this.treeRepository.findDescendants(group),
+      this.getAncestorIds(groupId),
+      this.getDescendantIds(groupId),
     ]);
 
-    const affectedGroups = [
-      groupId,
-      ...ancestors.map((g) => g.id),
-      ...descendants.map((g) => g.id),
-    ];
+    const affectedGroups = [groupId, ...ancestors, ...descendants];
 
     // Clear relevant cache entries
     await this.clearGroupTreeCache(affectedGroups);

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -498,11 +498,31 @@ export class GroupsService {
       });
       const groupData = this.toSimpleView(data);
 
-      const ancestors = await this.treeRepository.findAncestors(data);
-      groupData.parents = ancestors.map((it) => it.id);
+      const groupMetadata = this.repository.metadata;
+      const closureMetadata = groupMetadata.closureJunctionTable;
+      const groupTable = groupMetadata.tablePath;
+      const closureTable = closureMetadata.tablePath;
+      const ancestorColumn = closureMetadata.ancestorColumns[0].databaseName;
+      const descendantColumn =
+        closureMetadata.descendantColumns[0].databaseName;
 
-      const descendants = await this.treeRepository.findDescendants(data);
-      groupData.children = descendants.map((it) => it.id);
+      const ancestorRows: Array<{ id: number }> = await this.repository.query(
+        `SELECT g.id FROM ${groupTable} g
+         JOIN ${closureTable} c ON c."${ancestorColumn}" = g.id
+         WHERE c."${descendantColumn}" = $1
+           AND g.id != $1`,
+        [data.id],
+      );
+      groupData.parents = ancestorRows.map((it) => it.id);
+
+      const descendantRows: Array<{ id: number }> = await this.repository.query(
+        `SELECT g.id FROM ${groupTable} g
+         JOIN ${closureTable} c ON c."${descendantColumn}" = g.id
+         WHERE c."${ancestorColumn}" = $1
+           AND g.id != $1`,
+        [data.id],
+      );
+      groupData.children = descendantRows.map((it) => it.id);
 
       const filter = {
         groupId: In(groupData.children),

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import config from './config';
 import { ValidationPipe } from '@nestjs/common';
 import { HttpExceptionFilter } from './auth/http-exception.filter';
 import * as Sentry from '@sentry/node';
+import { JwtTenantHeaderMiddleware } from './middleware/jwtTenantHeader.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -26,6 +27,14 @@ async function bootstrap() {
       max: 10000, // limit each IP to 100 requests per windowMs
     }),
   );
+  const jwtTenantHeaderMiddleware = app.get(JwtTenantHeaderMiddleware);
+  app.use((req, res, next) => {
+    jwtTenantHeaderMiddleware.use(req, res, next).catch((error) => {
+      console.error('JWT tenant middleware error:', error);
+      next(error);
+    });
+  });
+
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/middleware/jwtTenantHeader.middleware.ts
+++ b/src/middleware/jwtTenantHeader.middleware.ts
@@ -9,17 +9,38 @@ export class JwtTenantHeaderMiddleware implements NestMiddleware {
   constructor(private readonly jwtService: JwtHelperService) {}
 
   async use(req: any, res: any, next: () => void) {
-    // @TODO Check if req.headers.authorization exists. Throw error if not
-    const jwtToken = req.headers.authorization.slice(7);
-    const tokenPayload = await this.jwtService.decodeToken(jwtToken);
-    const tenant =
-      tokenPayload && tokenPayload.hasOwnProperty('aud')
-        ? tokenPayload.aud
-        : '';
+    // Safely handle missing Authorization header
+    const authHeader =
+      req?.headers?.authorization || req?.headers?.Authorization;
+    if (!authHeader) {
+      // No auth header present; don't set tenant and continue
+      return next();
+    }
 
-    req.headers.tenant = tenant;
-    Logger.log(`New request received from church: ${tenant}`);
+    // Support 'Bearer <token>' or raw token
+    const jwtToken = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
 
-    next();
+    try {
+      const tokenPayload = await this.jwtService.decodeToken(jwtToken);
+      const tenant =
+        tokenPayload &&
+        Object.prototype.hasOwnProperty.call(tokenPayload, 'aud')
+          ? tokenPayload.aud
+          : '';
+      if (tenant) {
+        req.headers.tenant = tenant;
+        Logger.log(`New request received from church: ${tenant}`);
+      }
+    } catch (err) {
+      Logger.warn(
+        'Failed to decode JWT in JwtTenantHeaderMiddleware',
+        err?.message || err,
+      );
+      // proceed without tenant header on decode failure
+    }
+
+    return next();
   }
 }


### PR DESCRIPTION
# Ticket No
- N/A (Discovered via manual demo)

# Summary of changes
- Modified the group membership update endpoints to enforce role-based access control.
- Restricted permission to change membership statuses (e.g., swapping between `LEADER` and `MEMBER`) exclusively to accounts with the `ADMIN` role.
- Fixed a bug where an assigned group `LEADER` could erroneously elevate other users to `LEADER` or downgrade their own membership status back to a standard `MEMBER`.

# How should this be tested? 
1. Log in to the application as an `ADMIN`.
2. Assign a standard user to a group as a `MEMBER`, and then elevate them to a `LEADER`.
3. Log out and log back in using the credentials of the newly assigned group `LEADER`.
4. Attempt to change another group member's status to `LEADER`, or attempt to downgrade your own status from `LEADER` to `MEMBER`.
5. Verify that the server rejects these requests with an unauthorized error.
6. Log back in as an `ADMIN` and verify that you can still successfully change these statuses without issue.

# Notes for reviewers
- The core logic ensures that group leaders are strictly restricted to handling standard group operations and cannot manipulate administrative roles or access levels within the server.

# Out of scope
- Any modifications to the database schema itself; this fix relies entirely on service/controller-layer role verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for group hierarchies across listings, memberships, permissions, categories, and event-related views, so nested groups are handled more consistently.
  * Fixed tenant detection for incoming requests by better handling missing or nonstandard authorization tokens.
  * Added safer request handling so invalid tokens no longer interrupt normal app behavior.
* **New Features**
  * Applied tenant-aware request processing across all routes for more consistent multi-tenant behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->