### PR TITLE
feat(fellowship): auto-create schedule on MC group creation and add o…

### DIFF
--- a/docs/PRODUCT_DECISIONS.md
+++ b/docs/PRODUCT_DECISIONS.md
@@ -1,0 +1,47 @@
+# Product Decisions
+
+Lightweight record of intentional product/UX decisions and the reasoning behind
+them. Useful context for future feature work.
+
+---
+
+## MC Shepherd permissions — no GROUP_VIEW (2026-06-29)
+
+**Decision:** The MC Shepherd role does not include `GROUP_VIEW` or `GROUP_EDIT`.
+
+**Reasoning:**
+- Their core workflow is Reports + CRM. Both are fully covered by
+  `REPORT_VIEW`, `REPORT_SUBMIT`, `CRM_VIEW`, `CRM_EDIT`.
+- Member management happens through the CRM, not the group detail page.
+- Fellowship schedule setup is handled inline in the report submission form
+  (see below) — no group page access needed.
+- Giving them `GROUP_VIEW` would surface the Groups nav section without
+  a clear job to do, adding confusion rather than value.
+
+**Known gap — MC name changes:**
+MC leaders come up with their own MC names, so self-service renaming is
+desirable. However, this does not justify opening up the full group management
+UI. When prioritised, the right solution is a targeted "Rename my MC" action
+scoped to the leader's own group(s) — not GROUP_VIEW broadly.
+
+---
+
+## Fellowship schedule setup — inline in the report form (2026-06-29)
+
+**Decision:** MC leaders set their fellowship meeting schedule from inside the
+report submission form, not from a group detail page.
+
+**Reasoning:**
+- MC Shepherds cannot reach the group detail page (no GROUP_VIEW).
+- Even if they could, putting schedule setup there would be unintuitive —
+  the leader only thinks about their meeting schedule when they are about
+  to submit a report.
+- Inline setup is contextual: when the `dynamic_fellowship_schedule` field
+  comes back with `{ exists: false }`, the form surfaces a prompt to set
+  the schedule right there, then re-fetches and auto-populates the field.
+
+**Default:** Wednesday (meetingDay = 3). Most WHM MCs meet on Wednesdays.
+Children's and teens MCs that meet on other days can override this in the
+same dialog.
+
+---

--- a/docs/ReportFields.md
+++ b/docs/ReportFields.md
@@ -220,4 +220,124 @@
   - Empty options show appropriate error messages
   - Standard Flutter form validation integration
 
- 
+---
+
+## Dynamic Fellowship Schedule Selector (`dynamic_fellowship_schedule`)
+
+Populates a field with the meeting schedule for the fellowship group (MC) that
+the current user directly leads. Used in the MC Attendance Report to capture
+which meeting day the report covers.
+
+### Field Configuration
+
+  {
+    "name": "fellowshipSchedule",
+    "label": "MC Meeting Day",
+    "type": "select",
+    "required": true,
+    "options": [{ "type": "dynamic_fellowship_schedule" }]
+  }
+
+### Backend endpoint
+
+  GET /fellowships/my-schedule
+
+### Response shape
+
+When a schedule exists:
+
+  {
+    "exists": true,
+    "day": 4,           // 0 = Sunday … 6 = Saturday
+    "label": "Thursdays",
+    "fellowshipGroupId": 42
+  }
+
+When no schedule is configured:
+
+  {
+    "exists": false,
+    "weekdays": [
+      { "value": 0, "label": "Sunday" },
+      ...
+      { "value": 6, "label": "Saturday" }
+    ]
+  }
+
+### Prerequisites for non-empty response
+
+1. The logged-in user's contact must be an **active Leader** of a group whose
+   category has `purpose = fellowship` (a direct MC leader — FOB/Zone leaders
+   always receive `{ exists: false }`).
+2. That MC group must have an **active `FellowshipSchedule` row**.
+   Create one via `POST /fellowships/schedules`:
+
+     {
+       "fellowshipGroupId": 42,
+       "meetingDay": 4,    // 0–6
+       "startTime": "19:00",
+       "frequency": "weekly"
+     }
+
+### Form submission
+
+The field value submitted is the `day` integer (e.g. `4`). On the backend,
+`reports.service.ts` reads this value to identify the fellowship instance when
+recording attendance via `fellowshipAttendanceService.recordReportAttendance`.
+
+---
+
+## Dynamic Member Selector (`dynamic_member_selector`)
+
+Populates a multi-select field with the active members of the MC(s) the current
+user directly leads. Used in the MC Attendance Report to mark which members were
+present at the meeting.
+
+### Field Configuration
+
+  {
+    "name": "fellowshipMembers",
+    "label": "MC Members Present",
+    "type": "select",
+    "required": true,
+    "options": [{ "type": "dynamic_member_selector" }]
+  }
+
+### Backend endpoint
+
+  GET /fellowships/my-members
+
+### Response shape
+
+  [
+    { "id": 101, "firstName": "Alice", "lastName": "Nakato", "avatar": null },
+    { "id": 102, "firstName": "Bob",   "lastName": "Onen",   "avatar": null }
+  ]
+
+### Prerequisites for non-empty response
+
+1. The logged-in user's contact must be an **active Leader** of a fellowship
+   group (same scope rule as `dynamic_fellowship_schedule`).
+2. That MC group must have **active `GroupMembership` rows** (contacts assigned
+   as members with `isActive = true`).
+
+### Form submission
+
+The field value submitted is an **array of contact IDs** for members who
+attended (e.g. `[101, 102]`). The backend records individual
+`FellowshipAttendance` rows for each ID.
+
+---
+
+## How the two fields work together on submission
+
+When a report containing both a `dynamic_fellowship_schedule` field and a
+`dynamic_member_selector` field is submitted, `reports.service.ts` automatically:
+
+1. Finds the schedule field by its sentinel option type.
+2. Finds the member field by its sentinel option type.
+3. Calls `fellowshipAttendanceService.recordReportAttendance(contactId, userId, meetingDay, attendedContactIds)`.
+
+This writes individual `FellowshipAttendance` rows for the MC meeting, so
+attendance is tracked at the per-member level without the MC leader needing to
+use the separate check-in flow.

--- a/src/attendance/controllers/fellowships.controller.ts
+++ b/src/attendance/controllers/fellowships.controller.ts
@@ -44,8 +44,13 @@ export class FellowshipsController {
   async updateSchedule(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateFellowshipScheduleDto,
+    @Request() req: any,
   ) {
-    return this.fellowshipAttendanceService.updateSchedule(id, dto);
+    return this.fellowshipAttendanceService.updateSchedule(
+      id,
+      dto,
+      req.user.contactId,
+    );
   }
 
   @Get('my-members')

--- a/src/attendance/services/fellowship-attendance.service.ts
+++ b/src/attendance/services/fellowship-attendance.service.ts
@@ -3,6 +3,7 @@ import {
   Inject,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { Connection, In, Repository } from 'typeorm';
 import { FellowshipSchedule } from '../entities/fellowship-schedule.entity';
@@ -75,6 +76,7 @@ export class FellowshipAttendanceService {
   async updateSchedule(
     id: number,
     dto: UpdateFellowshipScheduleDto,
+    contactId: number,
   ): Promise<FellowshipSchedule> {
     const tenantId = this.tenantContext.requireTenant();
     const schedule = await this.scheduleRepo.findOne({
@@ -83,6 +85,28 @@ export class FellowshipAttendanceService {
     if (!schedule) {
       throw new NotFoundException(`Fellowship schedule ${id} not found`);
     }
+
+    const isLeader = await this.membershipRepo
+      .createQueryBuilder('gm')
+      .innerJoin('gm.group', 'g')
+      .innerJoin('g.category', 'c')
+      .where('gm.contactId = :contactId', { contactId })
+      .andWhere('gm.groupId = :groupId', {
+        groupId: schedule.fellowshipGroupId,
+      })
+      .andWhere('gm.role = :role', { role: GroupRole.Leader })
+      .andWhere('gm.isActive = true')
+      .andWhere('c.purpose = :purpose', {
+        purpose: GroupCategoryPurpose.FELLOWSHIP,
+      })
+      .getCount();
+
+    if (!isLeader) {
+      throw new ForbiddenException(
+        'You are not a leader of this fellowship group',
+      );
+    }
+
     Object.assign(schedule, dto);
     return this.scheduleRepo.save(schedule);
   }
@@ -370,8 +394,11 @@ export class FellowshipAttendanceService {
     const dayName = WEEKDAY_NAMES[schedule.meetingDay];
     return {
       exists: true,
+      id: schedule.id,
       day: schedule.meetingDay,
       label: `${dayName}s`,
+      startTime: schedule.startTime,
+      frequency: schedule.frequency,
       fellowshipGroupId: schedule.fellowshipGroupId,
     };
   }

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -37,6 +37,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { Tenant } from 'src/tenants/entities/tenant.entity';
+import { FellowshipSchedule } from '../../attendance/entities/fellowship-schedule.entity';
 
 @Injectable()
 export class GroupsService {
@@ -46,6 +47,7 @@ export class GroupsService {
   private readonly eventRepository: Repository<GroupEvent>;
   private readonly groupCategoryRepository: Repository<GroupCategory>;
   private readonly phoneRepository: Repository<Phone>;
+  private readonly fellowshipScheduleRepository: Repository<FellowshipSchedule>;
   private readonly logger: ContextLogger;
 
   constructor(
@@ -62,6 +64,8 @@ export class GroupsService {
     this.eventRepository = connection.getRepository(GroupEvent);
     this.groupCategoryRepository = connection.getRepository(GroupCategory);
     this.phoneRepository = connection.getRepository(Phone);
+    this.fellowshipScheduleRepository =
+      connection.getRepository(FellowshipSchedule);
     this.logger = this.appLogger.createContextLogger('GroupsService');
   }
 
@@ -443,6 +447,22 @@ export class GroupsService {
         : null;
 
       const savedGroup = await this.treeRepository.save(newGroup);
+
+      if (newGroupCategory?.purpose === GroupCategoryPurpose.FELLOWSHIP) {
+        const tenantId =
+          savedGroup.tenant?.id ?? (newGroupCategory?.tenant?.id as any);
+        await this.fellowshipScheduleRepository.save(
+          this.fellowshipScheduleRepository.create({
+            tenant: { id: tenantId } as any,
+            fellowshipGroup: { id: savedGroup.id } as any,
+            fellowshipGroupId: savedGroup.id,
+            meetingDay: 3,
+            startTime: '19:00',
+            frequency: 'weekly',
+            isActive: true,
+          }),
+        );
+      }
 
       this.logger.business('log', 'Group created successfully', {
         operation: 'createGroup',


### PR DESCRIPTION
…wnership-protected update endpoint

- Auto-creates Wednesday FellowshipSchedule (meetingDay=3, 19:00, weekly) when a fellowship-category group is created
- Enriches GET /fellowships/my-schedule response with id, startTime, frequency for the frontend change dialog
- PUT /fellowships/schedules/:id verifies caller is active Leader of the schedule's fellowship group
- Documents dynamic_fellowship_schedule and dynamic_member_selector field types in ReportFields.md
- Adds PRODUCT_DECISIONS.md capturing MC Shepherd permission scope, Wednesday default, and deferred MC self-rename


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here

