### PR TITLE
Fix(group-membership): deduplicate members when querying by groupId and descendants

### DIFF
--- a/src/attendance/services/fellowship-attendance.service.ts
+++ b/src/attendance/services/fellowship-attendance.service.ts
@@ -26,6 +26,7 @@ import { ContactCategory } from '../../crm/enums/contactCategory';
 import { Gender } from '../../crm/enums/gender';
 import { GroupRole } from '../../groups/enums/groupRole';
 import { GroupCategoryPurpose } from '../../groups/enums/groups';
+import { ContactStatus } from 'src/crm/enums/contactStatus';
 
 const WEEKDAY_NAMES = [
   'Sunday',
@@ -317,6 +318,7 @@ export class FellowshipAttendanceService {
       .createQueryBuilder('c')
       .innerJoin('c.person', 'p')
       .where('c.id IN (:...contactIds)', { contactIds: memberContactIds })
+      .andWhere('c.status = :status', { status: ContactStatus.Active })
       .andWhere('c.tenantId = :tenantId', { tenantId })
       .select([
         'c.id AS id',

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -70,7 +70,23 @@ export class GroupsMembershipService {
       take: req.limit ?? 100,
       where: filter,
     });
-    return data.map((it) => this.toDto(it, req.groupId));
+
+    // When filtering by groupId (which includes descendants), a contact may hold
+    // memberships in multiple groups in the subtree. Keep only the direct membership
+    // when one exists; otherwise keep the first encountered child-group membership.
+    let results = data;
+    if (hasValue(req.groupId)) {
+      const best = new Map<number, GroupMembership>();
+      for (const m of data) {
+        const prior = best.get(m.contactId);
+        if (!prior || m.groupId === req.groupId) {
+          best.set(m.contactId, m);
+        }
+      }
+      results = [...best.values()];
+    }
+
+    return results.map((it) => this.toDto(it, req.groupId));
   }
 
   toDto(membership: GroupMembership, refGroupId: number): GroupMembershipDto {

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -42,26 +42,66 @@ export class GroupsMembershipService {
       filter.contactId = req.contactId;
     }
 
+    let groupIds: number[] = [];
     if (hasValue(req.groupId)) {
       const parentGroup = await this.groupTreeRepository.findOneOrFail({
         where: { id: req.groupId },
       });
-      const childGroupIds =
+      const childGroups =
         await this.groupTreeRepository.findDescendants(parentGroup);
-      const idList = new Set([
-        req.groupId,
-        ...childGroupIds.map((it) => it.id),
-      ]);
-      filter.groupId = In([...idList.values()]);
+      groupIds = [...new Set([req.groupId, ...childGroups.map((it) => it.id)])];
+      filter.groupId = In(groupIds);
     }
 
     if (hasNoValue(filter)) {
       throw new ClientFriendlyException('Please specify groupId or contactId');
     }
 
-    // By default, only show active memberships unless explicitly requested
-    if (!req.hasOwnProperty('includeInactive') || !req.includeInactive) {
+    const activeOnly =
+      !req.hasOwnProperty('includeInactive') || !req.includeInactive;
+    if (activeOnly) {
       filter.isActive = true;
+    }
+
+    if (hasValue(req.groupId)) {
+      // Two-step: paginate distinct contactIds first so that limit/skip count
+      // unique contacts rather than raw membership rows (a contact in multiple
+      // sub-groups would otherwise consume multiple row slots per page).
+      const qb = this.repository
+        .createQueryBuilder('m')
+        .select('m.contactId', 'contactId')
+        .where('m.groupId IN (:...groupIds)', { groupIds })
+        .groupBy('m.contactId');
+
+      if (activeOnly) {
+        qb.andWhere('m.isActive = :isActive', { isActive: true });
+      }
+      if (hasValue(req.contactId)) {
+        qb.andWhere('m.contactId = :contactId', { contactId: req.contactId });
+      }
+
+      const rows: { contactId: number }[] = await qb
+        .offset(req.skip ?? 0)
+        .limit(req.limit ?? 100)
+        .getRawMany();
+
+      if (rows.length === 0) return [];
+
+      const contactIds = rows.map((r) => r.contactId);
+      const data = await this.repository.find({
+        relations: ['contact', 'contact.person', 'group', 'group.category'],
+        where: { ...filter, contactId: In(contactIds) },
+        order: { id: 'ASC' },
+      });
+
+      const best = new Map<number, GroupMembership>();
+      for (const m of data) {
+        const prior = best.get(m.contactId);
+        if (!prior || m.groupId === req.groupId) {
+          best.set(m.contactId, m);
+        }
+      }
+      return [...best.values()].map((it) => this.toDto(it, req.groupId));
     }
 
     const data = await this.repository.find({
@@ -71,22 +111,7 @@ export class GroupsMembershipService {
       where: filter,
     });
 
-    // When filtering by groupId (which includes descendants), a contact may hold
-    // memberships in multiple groups in the subtree. Keep only the direct membership
-    // when one exists; otherwise keep the first encountered child-group membership.
-    let results = data;
-    if (hasValue(req.groupId)) {
-      const best = new Map<number, GroupMembership>();
-      for (const m of data) {
-        const prior = best.get(m.contactId);
-        if (!prior || m.groupId === req.groupId) {
-          best.set(m.contactId, m);
-        }
-      }
-      results = [...best.values()];
-    }
-
-    return results.map((it) => this.toDto(it, req.groupId));
+    return data.map((it) => this.toDto(it, req.groupId));
   }
 
   toDto(membership: GroupMembership, refGroupId: number): GroupMembershipDto {


### PR DESCRIPTION


When a contact belongs to both a parent group and one of its child groups, they previously appeared multiple times in the result. Now only one record is returned per contact — preferring the direct membership over an inferred child-group one.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- Here Person, Brian Malinga appears twice, since he belongs to the parent and child groups. 

<img width="1370" height="875" alt="Screenshot from 2026-06-30 19-01-49" src="https://github.com/user-attachments/assets/d109876c-257a-4f8b-8436-76ffcb4cbcae" />

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group membership results to avoid duplicate entries when viewing a group and its descendant groups.
  * When a contact appears in both a parent group and a child group, the direct group membership is now prioritized.
  * Attendance member lists now exclude inactive contacts, returning only active members for the current user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->