### PR TITLE
Fix/report submission resolve contact names

### DIFF
--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -70,7 +70,23 @@ export class GroupsMembershipService {
       take: req.limit ?? 100,
       where: filter,
     });
-    return data.map((it) => this.toDto(it, req.groupId));
+
+    // When filtering by groupId (which includes descendants), a contact may hold
+    // memberships in multiple groups in the subtree. Keep only the direct membership
+    // when one exists; otherwise keep the first encountered child-group membership.
+    let results = data;
+    if (hasValue(req.groupId)) {
+      const best = new Map<number, GroupMembership>();
+      for (const m of data) {
+        const prior = best.get(m.contactId);
+        if (!prior || m.groupId === req.groupId) {
+          best.set(m.contactId, m);
+        }
+      }
+      results = [...best.values()];
+    }
+
+    return results.map((it) => this.toDto(it, req.groupId));
   }
 
   toDto(membership: GroupMembership, refGroupId: number): GroupMembershipDto {

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -16,6 +16,7 @@ import { IEmail, sendEmail } from 'src/utils/mailer';
 import {
   getUserDisplayName,
   getHumanReadableDate,
+  parsePostgresTextArray,
 } from 'src/utils/stringHelpers';
 
 import {
@@ -38,6 +39,8 @@ import { AppLogger, ContextLogger } from 'src/utils/app-logger.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { Tenant } from '../tenants/entities/tenant.entity';
 import { FellowshipAttendanceService } from '../attendance/services/fellowship-attendance.service';
+import Contact from 'src/crm/entities/contact.entity';
+import { getPersonFullName } from 'src/crm/crm.helpers';
 
 @Injectable()
 export class ReportsService {
@@ -48,6 +51,7 @@ export class ReportsService {
   private readonly reportFieldRepository: Repository<ReportField>;
   private readonly groupMembershipRepo: Repository<GroupMembership>;
   private readonly treeRepository: TreeRepository<Group>;
+  private readonly contactRepository: Repository<Contact>;
   private readonly logger: ContextLogger;
 
   constructor(
@@ -68,6 +72,7 @@ export class ReportsService {
       connection.getRepository(ReportSubmission);
     this.treeRepository = connection.getTreeRepository(Group);
     this.userRepository = connection.getRepository(User);
+    this.contactRepository = connection.getRepository(Contact);
     this.logger = this.appLogger.createContextLogger('ReportsService');
   }
 
@@ -741,6 +746,9 @@ export class ReportsService {
       return acc;
     }, {});
 
+    // Resolve contact-ID fields (e.g. 'fellowshipMembers') to readable names
+    await this.resolveContactSelectorFields(submission.submissionData, data);
+
     // Extract labels from submissionData
     const labels = submission.submissionData.map((sd) => {
       return {
@@ -757,6 +765,66 @@ export class ReportsService {
       submittedAt: submission.submittedAt.toISOString(), // Ensure consistent date formatting
       submittedBy: getUserDisplayName(submission.user),
     };
+  }
+
+  /**
+   * Fields backed by the 'dynamic_member_selector' widget store a Postgres
+   * array of contact IDs as their fieldValue (e.g. '{"51","58","26"}').
+   * Replace that raw value with a comma-separated list of contact names.
+   */
+  private async resolveContactSelectorFields(
+    submissionData: ReportSubmissionData[],
+    data: Record<string, any>,
+  ): Promise<void> {
+    const memberFields = submissionData.filter(
+      (sd) =>
+        Array.isArray(sd.reportField.options) &&
+        sd.reportField.options.some(
+          (o: any) => o?.type === 'dynamic_member_selector',
+        ),
+    );
+
+    if (memberFields.length === 0) {
+      return;
+    }
+
+    const idsByField = new Map<string, number[]>();
+    const allContactIds = new Set<number>();
+    for (const sd of memberFields) {
+      const ids = parsePostgresTextArray(sd.fieldValue)
+        .map((id) => Number(id))
+        .filter((id) => !isNaN(id));
+      idsByField.set(sd.reportField.name, ids);
+      ids.forEach((id) => allContactIds.add(id));
+    }
+
+    if (allContactIds.size === 0) {
+      return;
+    }
+
+    const contacts = await this.contactRepository
+      .createQueryBuilder('c')
+      .innerJoin('c.person', 'p')
+      .where('c.id IN (:...contactIds)', {
+        contactIds: Array.from(allContactIds),
+      })
+      .select([
+        'c.id AS id',
+        'p.firstName AS "firstName"',
+        'p.lastName AS "lastName"',
+        'p.middleName AS "middleName"',
+      ])
+      .getRawMany();
+
+    const nameById = new Map<number, string>(
+      contacts.map((c) => [c.id, getPersonFullName(c)]),
+    );
+
+    for (const [fieldName, ids] of idsByField) {
+      data[fieldName] = ids
+        .map((id) => nameById.get(id) || `Unknown (${id})`)
+        .join(', ');
+    }
   }
 
   async updateReport(id: number, updateDto: ReportDto): Promise<Report> {

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -518,16 +518,17 @@ export class ReportsService {
       (s) => s.submittedAt >= startDate && s.submittedAt <= endDate,
     );
 
+    const nameById = await this.fetchMemberSelectorContactNames(
+      filteredSubmissions.map((s) => s.submissionData),
+    );
+
     const submissionResponses = filteredSubmissions.map((submission) => {
       const transformedData: Record<string, any> = {
         id: submission.id,
         submittedAt: submission.submittedAt.toISOString(),
         submittedBy: getUserDisplayName(submission.user),
+        ...this.buildSubmissionDataRecord(submission.submissionData, nameById),
       };
-
-      submission.submissionData.forEach((sd) => {
-        transformedData[sd.reportField.name] = sd.fieldValue;
-      });
 
       return transformedData;
     });
@@ -615,6 +616,9 @@ export class ReportsService {
 
     // Let's get the relevant submissions
     const submissions: ReportSubmission[] = await query.getMany();
+    const nameById = await this.fetchMemberSelectorContactNames(
+      submissions.map((s) => s.submissionData),
+    );
     // For each of the retrieved submissions, let's get the user display name & small group parent (The "Zone" in the case of Worship Harvest)
     const submissionResponses = await Promise.all(
       submissions.map(async (submission) => {
@@ -639,10 +643,12 @@ export class ReportsService {
           transformedData['parentGroupName'] = smallGroup?.parent?.name || '';
         }
 
-        // Aggregate submission data into a single object
-        submission.submissionData.forEach((sd) => {
-          transformedData[sd.reportField.name] = sd.fieldValue;
-        });
+        // Aggregate submission data into a single object, resolving
+        // contact-ID fields (e.g. 'fellowshipMembers') to readable names
+        Object.assign(
+          transformedData,
+          this.buildSubmissionDataRecord(submission.submissionData, nameById),
+        );
 
         return transformedData;
       }),
@@ -740,14 +746,15 @@ export class ReportsService {
       );
     }
 
-    // Transform submissionData into a structured object
-    const data = submission.submissionData.reduce((acc, curr) => {
-      acc[curr.reportField.name] = curr.fieldValue;
-      return acc;
-    }, {});
-
-    // Resolve contact-ID fields (e.g. 'fellowshipMembers') to readable names
-    await this.resolveContactSelectorFields(submission.submissionData, data);
+    // Transform submissionData into a structured object, resolving
+    // contact-ID fields (e.g. 'fellowshipMembers') to readable names
+    const nameById = await this.fetchMemberSelectorContactNames([
+      submission.submissionData,
+    ]);
+    const data = this.buildSubmissionDataRecord(
+      submission.submissionData,
+      nameById,
+    );
 
     // Extract labels from submissionData
     const labels = submission.submissionData.map((sd) => {
@@ -770,43 +777,46 @@ export class ReportsService {
   /**
    * Fields backed by the 'dynamic_member_selector' widget store a Postgres
    * array of contact IDs as their fieldValue (e.g. '{"51","58","26"}').
-   * Replace that raw value with a comma-separated list of contact names.
+   * These helpers resolve those IDs to readable contact names wherever
+   * submissionData is turned into a plain data object.
    */
-  private async resolveContactSelectorFields(
-    submissionData: ReportSubmissionData[],
-    data: Record<string, any>,
-  ): Promise<void> {
-    const memberFields = submissionData.filter(
-      (sd) =>
-        Array.isArray(sd.reportField.options) &&
-        sd.reportField.options.some(
-          (o: any) => o?.type === 'dynamic_member_selector',
-        ),
+  private isDynamicMemberSelectorField(field: ReportField): boolean {
+    return (
+      Array.isArray(field.options) &&
+      field.options.some((o: any) => o?.type === 'dynamic_member_selector')
     );
+  }
 
-    if (memberFields.length === 0) {
-      return;
+  /**
+   * Looks up contact names for every dynamic_member_selector field across
+   * one or more submissions' submissionData, in a single batched query.
+   */
+  private async fetchMemberSelectorContactNames(
+    submissionDataLists: ReportSubmissionData[][],
+  ): Promise<Map<number, string>> {
+    const contactIds = new Set<number>();
+    for (const list of submissionDataLists) {
+      for (const sd of list) {
+        if (this.isDynamicMemberSelectorField(sd.reportField)) {
+          parsePostgresTextArray(sd.fieldValue).forEach((id) => {
+            const numericId = Number(id);
+            if (!isNaN(numericId)) {
+              contactIds.add(numericId);
+            }
+          });
+        }
+      }
     }
 
-    const idsByField = new Map<string, number[]>();
-    const allContactIds = new Set<number>();
-    for (const sd of memberFields) {
-      const ids = parsePostgresTextArray(sd.fieldValue)
-        .map((id) => Number(id))
-        .filter((id) => !isNaN(id));
-      idsByField.set(sd.reportField.name, ids);
-      ids.forEach((id) => allContactIds.add(id));
-    }
-
-    if (allContactIds.size === 0) {
-      return;
+    if (contactIds.size === 0) {
+      return new Map();
     }
 
     const contacts = await this.contactRepository
       .createQueryBuilder('c')
       .innerJoin('c.person', 'p')
       .where('c.id IN (:...contactIds)', {
-        contactIds: Array.from(allContactIds),
+        contactIds: Array.from(contactIds),
       })
       .select([
         'c.id AS id',
@@ -816,15 +826,32 @@ export class ReportsService {
       ])
       .getRawMany();
 
-    const nameById = new Map<number, string>(
-      contacts.map((c) => [c.id, getPersonFullName(c)]),
-    );
+    return new Map(contacts.map((c) => [c.id, getPersonFullName(c)]));
+  }
 
-    for (const [fieldName, ids] of idsByField) {
-      data[fieldName] = ids
-        .map((id) => nameById.get(id) || `Unknown (${id})`)
-        .join(', ');
-    }
+  /**
+   * Builds a { fieldName: value } object from submissionData, replacing
+   * dynamic_member_selector values with resolved contact names using a
+   * name map produced by fetchMemberSelectorContactNames.
+   */
+  private buildSubmissionDataRecord(
+    submissionData: ReportSubmissionData[],
+    nameById: Map<number, string>,
+  ): Record<string, any> {
+    return submissionData.reduce(
+      (acc, sd) => {
+        if (this.isDynamicMemberSelectorField(sd.reportField)) {
+          const ids = parsePostgresTextArray(sd.fieldValue);
+          acc[sd.reportField.name] = ids
+            .map((id) => nameById.get(Number(id)) || `Unknown (${id})`)
+            .join(', ');
+        } else {
+          acc[sd.reportField.name] = sd.fieldValue;
+        }
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
   }
 
   async updateReport(id: number, updateDto: ReportDto): Promise<Report> {
@@ -1076,6 +1103,10 @@ export class ReportsService {
 
     const total = await this.reportSubmissionRepository.count({ where });
 
+    const nameById = await this.fetchMemberSelectorContactNames(
+      submissions.map((s) => s.submissionData),
+    );
+
     return {
       submissions: submissions.map((submission) => ({
         id: submission.id,
@@ -1089,10 +1120,10 @@ export class ReportsService {
           name: getUserDisplayName(submission.user),
         },
         status: ReportStatus.SUBMITTED,
-        data: submission.submissionData.reduce((acc, curr) => {
-          acc[curr.reportField.name] = curr.fieldValue;
-          return acc;
-        }, {}),
+        data: this.buildSubmissionDataRecord(
+          submission.submissionData,
+          nameById,
+        ),
         canEdit: false, // submission.user.id === user.id // User can edit their own submissions. @TODOKEY: Temporarily disabled
       })),
       pagination: {
@@ -1180,6 +1211,10 @@ export class ReportsService {
       }
     }
 
+    const nameById = await this.fetchMemberSelectorContactNames(
+      paginatedSubmissions.map((s) => s.submissionData),
+    );
+
     return {
       submissions: paginatedSubmissions.map((submission) => ({
         id: submission.id,
@@ -1193,10 +1228,10 @@ export class ReportsService {
           name: getUserDisplayName(submission.user),
         },
         status: ReportStatus.SUBMITTED,
-        data: submission.submissionData.reduce((acc, curr) => {
-          acc[curr.reportField.name] = curr.fieldValue;
-          return acc;
-        }, {}),
+        data: this.buildSubmissionDataRecord(
+          submission.submissionData,
+          nameById,
+        ),
         canEdit: false,
       })),
       columns,
@@ -1227,10 +1262,13 @@ export class ReportsService {
     // Check if user has permission to view this submission
     // TODO: Implement permission check
 
-    const data = submission.submissionData.reduce((acc, curr) => {
-      acc[curr.reportField.name] = curr.fieldValue;
-      return acc;
-    }, {});
+    const nameById = await this.fetchMemberSelectorContactNames([
+      submission.submissionData,
+    ]);
+    const data = this.buildSubmissionDataRecord(
+      submission.submissionData,
+      nameById,
+    );
 
     return {
       id: submission.id,

--- a/src/utils/stringHelpers.ts
+++ b/src/utils/stringHelpers.ts
@@ -29,6 +29,31 @@ export function getFormattedDateString(currentDate: Date) {
   return `${year}${month}${day}`;
 }
 
+/**
+ * Parses a Postgres text-array literal (e.g. '{"51","58","26"}') into a
+ * plain string array. Falls back to comma-splitting for plain CSV input.
+ */
+export function parsePostgresTextArray(value: string): string[] {
+  if (!value) {
+    return [];
+  }
+  const trimmed = value.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    const inner = trimmed.slice(1, -1);
+    if (inner === '') {
+      return [];
+    }
+    return inner
+      .split(',')
+      .map((v) => v.trim().replace(/^"(.*)"$/, '$1'))
+      .filter((v) => v !== '');
+  }
+  return trimmed
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v !== '');
+}
+
 export function getUserDisplayName(user: User): string {
   const firstName = user?.contact?.person?.firstName ?? '';
   const lastName = user?.contact?.person?.lastName ?? '';


### PR DESCRIPTION

    Fields backed by the 'dynamic_member_selector' widget store a Postgres
    array of contact IDs as their fieldValue (e.g. '{"51","58","26"}').
    Replace that raw value with a comma-separated list of contact names.
   

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here

