### PR TITLE
Feat/report submission

### DIFF
--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -5,7 +5,7 @@ import {
   HttpStatus,
   BadRequestException,
 } from '@nestjs/common';
-import { Connection, Repository, In, Not } from 'typeorm';
+import { Connection, Repository, In, Not, Between } from 'typeorm';
 import { UserDto } from 'src/auth/dto/user.dto';
 import { Report } from './entities/report.entity';
 import { ReportSubmission } from './entities/report.submission.entity';
@@ -122,6 +122,23 @@ export class ReportsService {
     });
     if (!submittingUser) {
       throw new NotFoundException(`User with ID ${user.id} not found`);
+    }
+
+    // A user may only submit a given report once per week (week starts Sunday)
+    const weekStart = this.getStartOfWeek(new Date());
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+    const existingSubmission = await this.reportSubmissionRepository.findOne({
+      where: {
+        report: { id: reportId },
+        user: { id: submittingUser.id },
+        submittedAt: Between(weekStart, weekEnd),
+      },
+    });
+    if (existingSubmission) {
+      throw new BadRequestException(
+        `You have already submitted "${report.name}" for this week`,
+      );
     }
 
     let targetGroup: Group | null = null;
@@ -419,6 +436,13 @@ export class ReportsService {
       this.logger.endTracking(tracking, false);
       throw error;
     }
+  }
+
+  private getStartOfWeek(date: Date): Date {
+    const startOfWeek = new Date(date);
+    startOfWeek.setHours(0, 0, 0, 0);
+    startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay()); // Sunday = 0
+    return startOfWeek;
   }
 
   async getReport(reportId: number): Promise<Report> {


### PR DESCRIPTION
Added a weekly-submission guard in submitReport (src/reports/reports.service.ts): before creating a new ReportSubmission, it checks for an existing submission by the same user for the same report within the current Sunday–Saturday week (using the same week-start convention — getDate() - getDay() — already used elsewhere in this service) and throws a BadRequestException if one exists. No changes were needed in reports.controller.ts since submitReport already delegates directly to the service.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate report submissions within the same week for the same report and user.
  * Added week-based submission checks so only one report can be submitted per weekly window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->