### PR TITLE
Feat/only view groups if you are the leader

### DIFF
--- a/src/groups/controllers/group.controller.ts
+++ b/src/groups/controllers/group.controller.ts
@@ -81,7 +81,7 @@ export class GroupController {
     @Query() req: SearchDto,
     @Request() rawRequest?: any,
   ): Promise<any> {
-    return this.service.findAll(req);
+    return this.service.findAll(req, rawRequest?.user);
   }
 
   @Post()

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -106,12 +106,14 @@ export class GroupsMembershipService {
 
     const data = await this.repository.find({
       relations: ['contact', 'contact.person', 'group', 'group.category'],
-      skip: req.skip ?? 0,
-      take: req.limit ?? 100,
       where: filter,
     });
 
-    return data.map((it) => this.toDto(it, req.groupId));
+    const skip = req.skip ?? 0;
+    const limit = req.limit ?? 100;
+    return data
+      .slice(skip, skip + limit)
+      .map((it) => this.toDto(it, req.groupId));
   }
 
   toDto(membership: GroupMembership, refGroupId: number): GroupMembershipDto {

--- a/src/groups/services/group-permissions.service.ts
+++ b/src/groups/services/group-permissions.service.ts
@@ -18,8 +18,12 @@ export class GroupPermissionsService {
     this.membershipRepository = connection.getRepository(GroupMembership);
   }
 
+  private isAdmin(user: any): boolean {
+    return Array.isArray(user?.roles) && user.roles.includes(roleAdmin.role);
+  }
+
   async hasPermissionForGroup(user: any, groupId: number) {
-    if (Array.isArray(user?.roles) && user.roles.includes(roleAdmin.role)) {
+    if (this.isAdmin(user)) {
       return true;
     }
 
@@ -69,6 +73,17 @@ export class GroupPermissionsService {
         'You have no permissions to modify this group',
       );
     }
+  }
+
+  // Bulk equivalent of hasPermissionForGroup: the set of group IDs for which
+  // hasPermissionForGroup(user, id) would return true. Returns null when the
+  // user is an admin, signalling "all groups accessible" without materialising
+  // the full ID list.
+  async getAccessibleGroupIds(user: any): Promise<number[] | null> {
+    if (this.isAdmin(user)) {
+      return null;
+    }
+    return this.getUserGroupIds(user);
   }
 
   async getUserGroupIds(user: any) {

--- a/src/groups/services/group-permissions.service.ts
+++ b/src/groups/services/group-permissions.service.ts
@@ -83,6 +83,9 @@ export class GroupPermissionsService {
     if (this.isAdmin(user)) {
       return null;
     }
+    if (!user?.contactId) {
+      return [];
+    }
     return this.getUserGroupIds(user);
   }
 

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -8,6 +8,7 @@ import {
   Repository,
   Connection,
   TreeRepository,
+  Not,
 } from 'typeorm';
 import Group from '../entities/group.entity';
 import GroupEvent from '../../events/entities/event.entity';
@@ -91,10 +92,15 @@ export class GroupsService {
       if (req.parentId === 'null' || req.parentId === '') {
         // Return root groups (no parent)
         return this.repository.find({
-          where: {
-            parentId: IsNull(),
-            ...(accessibleGroupIds ? { id: In(accessibleGroupIds) } : {}),
-          },
+          where: accessibleGroupIds
+            ? [
+                { id: In(accessibleGroupIds), parentId: IsNull() },
+                {
+                  id: In(accessibleGroupIds),
+                  parentId: Not(In(accessibleGroupIds)),
+                },
+              ]
+            : { parentId: IsNull() },
           relations: ['category', 'parent'],
           order: { name: 'ASC' },
         });
@@ -132,7 +138,20 @@ export class GroupsService {
 
     if (parentId !== undefined) {
       if (parentId === 'null' || parentId === '') {
-        query.andWhere('group.parentId IS NULL');
+        if (accessibleGroupIds) {
+          // Treat as a root any accessible group whose parent isn't also
+          // accessible (mirrors buildGroupTree's visible-root logic), not
+          // just physical roots with no parent at all.
+          query.andWhere(
+            '(group.parentId IS NULL OR group.parentId NOT IN (:...rootParentIds))',
+            {
+              rootParentIds:
+                accessibleGroupIds.length > 0 ? accessibleGroupIds : [-1],
+            },
+          );
+        } else {
+          query.andWhere('group.parentId IS NULL');
+        }
       } else {
         const parentIdNum = parseInt(parentId, 10);
         if (!isNaN(parentIdNum)) {

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -69,11 +69,20 @@ export class GroupsService {
     this.logger = this.appLogger.createContextLogger('GroupsService');
   }
 
-  async findAll(req: SearchDto): Promise<any[]> {
+  async findAll(req: SearchDto, user?: any): Promise<any[]> {
+    // Groups the user leads (directly or via an ancestor) or, for admins,
+    // null meaning unrestricted. Mirrors GroupPermissionsService.hasPermissionForGroup.
+    const accessibleGroupIds =
+      await this.groupsPermissionsService.getAccessibleGroupIds(user);
+    if (accessibleGroupIds !== null && accessibleGroupIds.length === 0) {
+      return [];
+    }
+
     if (req.purpose) {
       return this.findGroupsByPurpose(
         req.purpose as GroupCategoryPurpose,
         req.parentId,
+        accessibleGroupIds,
       );
     }
 
@@ -82,7 +91,10 @@ export class GroupsService {
       if (req.parentId === 'null' || req.parentId === '') {
         // Return root groups (no parent)
         return this.repository.find({
-          where: { parentId: IsNull() },
+          where: {
+            parentId: IsNull(),
+            ...(accessibleGroupIds ? { id: In(accessibleGroupIds) } : {}),
+          },
           relations: ['category', 'parent'],
           order: { name: 'ASC' },
         });
@@ -92,7 +104,10 @@ export class GroupsService {
       if (!isNaN(parentIdNum)) {
         // Return direct children of the specified group
         return this.repository.find({
-          where: { parentId: parentIdNum },
+          where: {
+            parentId: parentIdNum,
+            ...(accessibleGroupIds ? { id: In(accessibleGroupIds) } : {}),
+          },
           relations: ['category', 'parent'],
           order: { name: 'ASC' },
         });
@@ -101,12 +116,13 @@ export class GroupsService {
 
     // Default: return all groups as a tree structure
     // Manually build tree since findTrees() has issues with closure-table
-    return this.buildGroupTree();
+    return this.buildGroupTree(accessibleGroupIds);
   }
 
   private async findGroupsByPurpose(
     purpose: GroupCategoryPurpose,
     parentId?: string,
+    accessibleGroupIds?: number[] | null,
   ): Promise<Group[]> {
     const query = this.repository
       .createQueryBuilder('group')
@@ -127,14 +143,24 @@ export class GroupsService {
       }
     }
 
+    if (accessibleGroupIds) {
+      query.andWhere('group.id IN (:...accessibleGroupIds)', {
+        accessibleGroupIds:
+          accessibleGroupIds.length > 0 ? accessibleGroupIds : [-1],
+      });
+    }
+
     return query.orderBy('group.name', 'ASC').getMany();
   }
 
-  private async buildGroupTree(): Promise<any[]> {
+  private async buildGroupTree(
+    accessibleGroupIds?: number[] | null,
+  ): Promise<any[]> {
     // Fetch all groups flat
     const allGroups = await this.repository.find({
       relations: ['category'],
       order: { name: 'ASC' },
+      ...(accessibleGroupIds ? { where: { id: In(accessibleGroupIds) } } : {}),
     });
 
     // Build a map for quick lookup


### PR DESCRIPTION
# Ticket No
- GoLive104

# Summary of changes

- [group-permissions.service.ts](vscode-webview://0r2qf483ilgpe7kp3ckdl10b3q080e006j1b2m8rkfqo4poeqdbf/src/groups/services/group-permissions.service.ts) — extracted the admin check into isAdmin() (used by hasPermissionForGroup), and added getAccessibleGroupIds(user): returns null for admins (unrestricted) or the same leader+descendants ID set as hasPermissionForGroup would authorize per-group, computed in bulk via the existing getUserGroupIds.
- [groups.service.ts](vscode-webview://0r2qf483ilgpe7kp3ckdl10b3q080e006j1b2m8rkfqo4poeqdbf/src/groups/services/groups.service.ts) — findAll now takes user, resolves accessibleGroupIds up front, short-circuits to [] if a non-admin has no leadership groups, and threads the ID filter through all three result paths (purpose query, parent-drilldown query, and the flat list feeding buildGroupTree).

- [group.controller.ts](vscode-webview://0r2qf483ilgpe7kp3ckdl10b3q080e006j1b2m8rkfqo4poeqdbf/src/groups/controllers/group.controller.ts) — passes rawRequest.user into service.findAll.

# How should this be tested? [Screenshots, Video or Type instructions]
- 
<img width="1582" height="889" alt="image" src="https://github.com/user-attachments/assets/6736ebbf-319c-4110-92ab-8c317622eca7" />


# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group lists now respect the signed-in user’s access, so users only see groups they can view.
  * Group browsing and drill-down navigation now consistently apply permission filtering.
  * Duplicate contact entries in group membership results are reduced, favoring direct group membership when available.

* **New Features**
  * Improved group access handling for broader group listings, including efficient support for users with access to all groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->