### PR TITLE
feat(groups): add bulk import endpoint for zones, sectors, and MCs

### DIFF
--- a/public/bulk-group-import-sample.csv
+++ b/public/bulk-group-import-sample.csv
@@ -1,0 +1,11 @@
+location,zone,sector,mc
+WH Bugolobi,East Zone,Sector A,Bugolobi MC 1
+WH Bugolobi,East Zone,Sector A,Bugolobi MC 2
+WH Bugolobi,East Zone,Sector B,Bugolobi MC 3
+WH Bugolobi,West Zone,,Bugolobi MC 4
+WH Bugolobi,,,Bugolobi MC 5
+WH Ntinda,Central Zone,Sector 1,Ntinda MC 1
+WH Ntinda,Central Zone,Sector 1,Ntinda MC 2
+WH Ntinda,Central Zone,Sector 2,Ntinda MC 3
+WH Ntinda,North Zone,,Ntinda MC 4
+WH Bugolobi,East Zone,Sector A,Bugolobi MC 1

--- a/src/groups/controllers/group-import.controller.ts
+++ b/src/groups/controllers/group-import.controller.ts
@@ -1,0 +1,82 @@
+import {
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { SentryInterceptor } from '../../utils/sentry.interceptor';
+import { TenantContextInterceptor } from 'src/interceptors/tenant-context.interceptor';
+import {
+  GroupImportService,
+  BulkGroupRow,
+  BulkImportResult,
+} from '../services/group-import.service';
+
+const EXPECTED_HEADERS = ['location', 'zone', 'sector', 'mc'];
+
+function parseCsv(buffer: Buffer): BulkGroupRow[] {
+  const lines = buffer
+    .toString('utf-8')
+    .replace(/\r/g, '')
+    .split('\n')
+    .filter((l) => l.trim());
+
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split(',').map((h) => h.trim().toLowerCase());
+
+  if (!headers.includes('location') || !headers.includes('mc')) {
+    throw new Error(
+      `CSV must include at minimum "location" and "mc" columns. Got: ${headers.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  return lines.slice(1).map((line) => {
+    const values = line.split(',').map((v) => v.trim());
+    const row: any = {};
+    headers.forEach((h, i) => {
+      row[h] = values[i] ?? '';
+    });
+    return row as BulkGroupRow;
+  });
+}
+
+@UseInterceptors(SentryInterceptor, TenantContextInterceptor)
+@UseGuards(JwtAuthGuard)
+@ApiTags('Groups')
+@Controller('api/groups/import')
+export class GroupImportController {
+  constructor(private readonly importService: GroupImportService) {}
+
+  @Post('bulk')
+  @UseInterceptors(FileInterceptor('file'))
+  async bulkImport(
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<BulkImportResult> {
+    if (!file) {
+      throw new BadRequestException('No file uploaded.');
+    }
+
+    let rows: BulkGroupRow[];
+    try {
+      rows = parseCsv(file.buffer);
+    } catch (err) {
+      throw new BadRequestException(err.message);
+    }
+
+    if (rows.length === 0) {
+      throw new BadRequestException(
+        'CSV has no data rows. Expected columns: location,zone,sector,mc (zone and sector are optional)',
+      );
+    }
+
+    return this.importService.bulkImport(rows);
+  }
+}

--- a/src/groups/controllers/group-import.controller.ts
+++ b/src/groups/controllers/group-import.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags } from '@nestjs/swagger';
+import { parse } from 'csv-parse/sync';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { SentryInterceptor } from '../../utils/sentry.interceptor';
 import { TenantContextInterceptor } from 'src/interceptors/tenant-context.interceptor';
@@ -17,19 +18,35 @@ import {
   BulkImportResult,
 } from '../services/group-import.service';
 
-const EXPECTED_HEADERS = ['location', 'zone', 'sector', 'mc'];
+const MAX_CSV_BYTES = 5 * 1024 * 1024; // 5 MB
+
+function csvFileFilter(
+  _req: any,
+  file: Express.Multer.File,
+  cb: (err: Error | null, accept: boolean) => void,
+) {
+  const isCsv =
+    file.originalname.toLowerCase().endsWith('.csv') ||
+    file.mimetype === 'text/csv' ||
+    file.mimetype === 'application/csv';
+  cb(
+    isCsv ? null : new BadRequestException('Only CSV files are accepted.'),
+    isCsv,
+  );
+}
 
 function parseCsv(buffer: Buffer): BulkGroupRow[] {
-  const lines = buffer
-    .toString('utf-8')
-    .replace(/\r/g, '')
-    .split('\n')
-    .filter((l) => l.trim());
+  const records: Record<string, string>[] = parse(buffer, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+    bom: true,
+    relax_column_count: true,
+  });
 
-  if (lines.length < 2) return [];
+  if (records.length === 0) return [];
 
-  const headers = lines[0].split(',').map((h) => h.trim().toLowerCase());
-
+  const headers = Object.keys(records[0]).map((h) => h.toLowerCase());
   if (!headers.includes('location') || !headers.includes('mc')) {
     throw new Error(
       `CSV must include at minimum "location" and "mc" columns. Got: ${headers.join(
@@ -38,13 +55,15 @@ function parseCsv(buffer: Buffer): BulkGroupRow[] {
     );
   }
 
-  return lines.slice(1).map((line) => {
-    const values = line.split(',').map((v) => v.trim());
-    const row: any = {};
-    headers.forEach((h, i) => {
-      row[h] = values[i] ?? '';
-    });
-    return row as BulkGroupRow;
+  return records.map((rec) => {
+    const lower: Record<string, string> = {};
+    for (const [k, v] of Object.entries(rec)) lower[k.toLowerCase()] = v;
+    return {
+      location: lower['location'] ?? '',
+      zone: lower['zone'] ?? '',
+      sector: lower['sector'] ?? '',
+      mc: lower['mc'] ?? '',
+    };
   });
 }
 
@@ -56,7 +75,12 @@ export class GroupImportController {
   constructor(private readonly importService: GroupImportService) {}
 
   @Post('bulk')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_CSV_BYTES },
+      fileFilter: csvFileFilter,
+    }),
+  )
   async bulkImport(
     @UploadedFile() file: Express.Multer.File,
   ): Promise<BulkImportResult> {

--- a/src/groups/controllers/group-import.controller.ts
+++ b/src/groups/controllers/group-import.controller.ts
@@ -1,6 +1,8 @@
 import {
   Controller,
+  Get,
   Post,
+  Res,
   UploadedFile,
   UseInterceptors,
   UseGuards,
@@ -73,6 +75,11 @@ function parseCsv(buffer: Buffer): BulkGroupRow[] {
 @Controller('api/groups/import')
 export class GroupImportController {
   constructor(private readonly importService: GroupImportService) {}
+
+  @Get('bulk/sample')
+  getSample(@Res() res: any) {
+    return res.sendFile('bulk-group-import-sample.csv', { root: './public' });
+  }
 
   @Post('bulk')
   @UseInterceptors(

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -21,6 +21,8 @@ import { GroupTreeService } from './services/group-tree.service';
 import { TenantHeaderMiddleware } from 'src/middleware/tenant-header.middleware';
 import { MiddlewareConsumer } from '@nestjs/common';
 import { AppLogger } from 'src/utils/app-logger.service';
+import { GroupImportService } from './services/group-import.service';
+import { GroupImportController } from './controllers/group-import.controller';
 
 @Module({
   imports: [
@@ -39,6 +41,7 @@ import { AppLogger } from 'src/utils/app-logger.service';
     EventsService,
     GroupPermissionsService,
     GroupTreeService,
+    GroupImportService,
     AppLogger,
   ],
   controllers: [
@@ -47,6 +50,7 @@ import { AppLogger } from 'src/utils/app-logger.service';
     GroupMembershipController,
     GroupMembershipReqeustController,
     GroupController,
+    GroupImportController,
   ],
   exports: [
     GroupsService,

--- a/src/groups/services/group-import.service.ts
+++ b/src/groups/services/group-import.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Inject, BadRequestException } from '@nestjs/common';
+import { Connection, Repository, TreeRepository } from 'typeorm';
+import Group from '../entities/group.entity';
+import GroupCategory from '../entities/groupCategory.entity';
+import { GroupPrivacy } from '../enums/groupPrivacy';
+import { GroupCategoryNames } from '../enums/groups';
+import { TenantContext } from 'src/shared/tenant/tenant-context';
+import { FellowshipSchedule } from 'src/attendance/entities/fellowship-schedule.entity';
+import { GroupCategoryPurpose } from '../enums/groups';
+
+export interface BulkGroupRow {
+  location: string;
+  zone?: string;
+  sector?: string;
+  mc: string;
+}
+
+export interface BulkImportResult {
+  totalRows: number;
+  created: { zones: number; sectors: number; mcs: number };
+  skipped: { zones: number; sectors: number; mcs: number };
+  errors: string[];
+}
+
+@Injectable()
+export class GroupImportService {
+  private readonly groupRepo: Repository<Group>;
+  private readonly treeRepo: TreeRepository<Group>;
+  private readonly categoryRepo: Repository<GroupCategory>;
+  private readonly scheduleRepo: Repository<FellowshipSchedule>;
+
+  constructor(
+    @Inject('CONNECTION') connection: Connection,
+    private readonly tenantContext: TenantContext,
+  ) {
+    this.groupRepo = connection.getRepository(Group);
+    this.treeRepo = connection.getTreeRepository(Group);
+    this.categoryRepo = connection.getRepository(GroupCategory);
+    this.scheduleRepo = connection.getRepository(FellowshipSchedule);
+  }
+
+  async bulkImport(rows: BulkGroupRow[]): Promise<BulkImportResult> {
+    const tenantId = this.tenantContext.requireTenant();
+
+    const [locationCat, zoneCat, sectorCat, mcCat] = await Promise.all([
+      this.findCategory(GroupCategoryNames.LOCATION, tenantId),
+      this.findCategory(GroupCategoryNames.ZONE, tenantId),
+      this.findCategory('Sector', tenantId),
+      this.findCategory(GroupCategoryNames.MC, tenantId),
+    ]);
+
+    if (!mcCat) {
+      throw new BadRequestException(
+        `"${GroupCategoryNames.MC}" category not found for this tenant.`,
+      );
+    }
+
+    const result: BulkImportResult = {
+      totalRows: rows.length,
+      created: { zones: 0, sectors: 0, mcs: 0 },
+      skipped: { zones: 0, sectors: 0, mcs: 0 },
+      errors: [],
+    };
+
+    for (const [index, row] of rows.entries()) {
+      const rowNum = index + 2; // account for header row
+      try {
+        const locationName = row.location?.trim();
+        const mcName = row.mc?.trim();
+
+        if (!locationName) {
+          result.errors.push(`Row ${rowNum}: "location" is required.`);
+          continue;
+        }
+        if (!mcName) {
+          result.errors.push(`Row ${rowNum}: "mc" is required.`);
+          continue;
+        }
+
+        const location = await this.findByName(
+          locationName,
+          locationCat,
+          tenantId,
+        );
+        if (!location) {
+          result.errors.push(
+            `Row ${rowNum}: Location "${locationName}" not found. Locations must already exist.`,
+          );
+          continue;
+        }
+
+        let parent = location;
+
+        if (row.zone?.trim()) {
+          if (!zoneCat) {
+            result.errors.push(
+              `Row ${rowNum}: Zone category ("${GroupCategoryNames.ZONE}") not found for this tenant.`,
+            );
+            continue;
+          }
+          const [zone, wasCreated] = await this.findOrCreate(
+            row.zone.trim(),
+            zoneCat,
+            tenantId,
+            parent,
+          );
+          wasCreated ? result.created.zones++ : result.skipped.zones++;
+          parent = zone;
+        }
+
+        if (row.sector?.trim()) {
+          if (!sectorCat) {
+            result.errors.push(
+              `Row ${rowNum}: Sector category not found for this tenant.`,
+            );
+            continue;
+          }
+          const [sector, wasCreated] = await this.findOrCreate(
+            row.sector.trim(),
+            sectorCat,
+            tenantId,
+            parent,
+          );
+          wasCreated ? result.created.sectors++ : result.skipped.sectors++;
+          parent = sector;
+        }
+
+        const [mc, wasCreated] = await this.findOrCreate(
+          mcName,
+          mcCat,
+          tenantId,
+          parent,
+        );
+        if (wasCreated) {
+          result.created.mcs++;
+          await this.ensureFellowshipSchedule(mc.id, tenantId);
+        } else {
+          result.skipped.mcs++;
+        }
+      } catch (err) {
+        result.errors.push(`Row ${rowNum}: ${err.message}`);
+      }
+    }
+
+    return result;
+  }
+
+  private async findCategory(
+    name: string,
+    tenantId: number,
+  ): Promise<GroupCategory | null> {
+    return this.categoryRepo
+      .createQueryBuilder('c')
+      .where('c.name = :name', { name })
+      .andWhere('c."tenantId" = :tenantId', { tenantId })
+      .getOne();
+  }
+
+  private async findByName(
+    name: string,
+    category: GroupCategory | null,
+    tenantId: number,
+  ): Promise<Group | null> {
+    const qb = this.groupRepo
+      .createQueryBuilder('g')
+      .where('g."tenantId" = :tenantId', { tenantId })
+      .andWhere('LOWER(g.name) = LOWER(:name)', { name });
+    if (category) {
+      qb.andWhere('g."categoryId" = :catId', { catId: category.id });
+    }
+    return qb.getOne();
+  }
+
+  private async findOrCreate(
+    name: string,
+    category: GroupCategory,
+    tenantId: number,
+    parent: Group,
+  ): Promise<[Group, boolean]> {
+    const existing = await this.groupRepo
+      .createQueryBuilder('g')
+      .where('g."tenantId" = :tenantId', { tenantId })
+      .andWhere('g."categoryId" = :catId', { catId: category.id })
+      .andWhere('LOWER(g.name) = LOWER(:name)', { name })
+      .andWhere('g."parentId" = :parentId', { parentId: parent.id })
+      .getOne();
+
+    if (existing) return [existing, false];
+
+    const group = await this.treeRepo.save(
+      this.treeRepo.create({
+        name,
+        category,
+        tenant: { id: tenantId } as any,
+        parent,
+        privacy: GroupPrivacy.Public,
+      }),
+    );
+    return [group, true];
+  }
+
+  private async ensureFellowshipSchedule(mcId: number, tenantId: number) {
+    const existing = await this.scheduleRepo.findOne({
+      where: { fellowshipGroupId: mcId },
+    });
+    if (!existing) {
+      await this.scheduleRepo.save(
+        this.scheduleRepo.create({
+          tenant: { id: tenantId } as any,
+          fellowshipGroup: { id: mcId } as any,
+          fellowshipGroupId: mcId,
+          meetingDay: 3,
+          startTime: '19:00',
+          frequency: 'weekly',
+          isActive: true,
+        }),
+      );
+    }
+  }
+}

--- a/src/groups/services/group-import.service.ts
+++ b/src/groups/services/group-import.service.ts
@@ -1,12 +1,11 @@
 import { Injectable, Inject, BadRequestException } from '@nestjs/common';
-import { Connection, Repository, TreeRepository } from 'typeorm';
+import { Connection, EntityManager, QueryRunner, Repository } from 'typeorm';
 import Group from '../entities/group.entity';
 import GroupCategory from '../entities/groupCategory.entity';
 import { GroupPrivacy } from '../enums/groupPrivacy';
 import { GroupCategoryNames } from '../enums/groups';
 import { TenantContext } from 'src/shared/tenant/tenant-context';
 import { FellowshipSchedule } from 'src/attendance/entities/fellowship-schedule.entity';
-import { GroupCategoryPurpose } from '../enums/groups';
 
 export interface BulkGroupRow {
   location: string;
@@ -22,21 +21,21 @@ export interface BulkImportResult {
   errors: string[];
 }
 
+interface RowCounts {
+  zones: { created: number; skipped: number };
+  sectors: { created: number; skipped: number };
+  mcs: { created: number; skipped: number };
+}
+
 @Injectable()
 export class GroupImportService {
-  private readonly groupRepo: Repository<Group>;
-  private readonly treeRepo: TreeRepository<Group>;
   private readonly categoryRepo: Repository<GroupCategory>;
-  private readonly scheduleRepo: Repository<FellowshipSchedule>;
 
   constructor(
-    @Inject('CONNECTION') connection: Connection,
+    @Inject('CONNECTION') private readonly connection: Connection,
     private readonly tenantContext: TenantContext,
   ) {
-    this.groupRepo = connection.getRepository(Group);
-    this.treeRepo = connection.getTreeRepository(Group);
     this.categoryRepo = connection.getRepository(GroupCategory);
-    this.scheduleRepo = connection.getRepository(FellowshipSchedule);
   }
 
   async bulkImport(rows: BulkGroupRow[]): Promise<BulkImportResult> {
@@ -49,6 +48,11 @@ export class GroupImportService {
       this.findCategory(GroupCategoryNames.MC, tenantId),
     ]);
 
+    if (!locationCat) {
+      throw new BadRequestException(
+        `"${GroupCategoryNames.LOCATION}" category not found for this tenant.`,
+      );
+    }
     if (!mcCat) {
       throw new BadRequestException(
         `"${GroupCategoryNames.MC}" category not found for this tenant.`,
@@ -63,86 +67,120 @@ export class GroupImportService {
     };
 
     for (const [index, row] of rows.entries()) {
-      const rowNum = index + 2; // account for header row
+      const rowNum = index + 2; // 1-based + header row
+      const qr = this.connection.createQueryRunner();
+      await qr.connect();
+      await qr.startTransaction();
       try {
-        const locationName = row.location?.trim();
-        const mcName = row.mc?.trim();
-
-        if (!locationName) {
-          result.errors.push(`Row ${rowNum}: "location" is required.`);
-          continue;
-        }
-        if (!mcName) {
-          result.errors.push(`Row ${rowNum}: "mc" is required.`);
-          continue;
-        }
-
-        const location = await this.findByName(
-          locationName,
+        const counts = await this.processRow(
+          row,
           locationCat,
-          tenantId,
-        );
-        if (!location) {
-          result.errors.push(
-            `Row ${rowNum}: Location "${locationName}" not found. Locations must already exist.`,
-          );
-          continue;
-        }
-
-        let parent = location;
-
-        if (row.zone?.trim()) {
-          if (!zoneCat) {
-            result.errors.push(
-              `Row ${rowNum}: Zone category ("${GroupCategoryNames.ZONE}") not found for this tenant.`,
-            );
-            continue;
-          }
-          const [zone, wasCreated] = await this.findOrCreate(
-            row.zone.trim(),
-            zoneCat,
-            tenantId,
-            parent,
-          );
-          wasCreated ? result.created.zones++ : result.skipped.zones++;
-          parent = zone;
-        }
-
-        if (row.sector?.trim()) {
-          if (!sectorCat) {
-            result.errors.push(
-              `Row ${rowNum}: Sector category not found for this tenant.`,
-            );
-            continue;
-          }
-          const [sector, wasCreated] = await this.findOrCreate(
-            row.sector.trim(),
-            sectorCat,
-            tenantId,
-            parent,
-          );
-          wasCreated ? result.created.sectors++ : result.skipped.sectors++;
-          parent = sector;
-        }
-
-        const [mc, wasCreated] = await this.findOrCreate(
-          mcName,
+          zoneCat,
+          sectorCat,
           mcCat,
           tenantId,
-          parent,
+          qr,
         );
-        if (wasCreated) {
-          result.created.mcs++;
-          await this.ensureFellowshipSchedule(mc.id, tenantId);
-        } else {
-          result.skipped.mcs++;
-        }
+        await qr.commitTransaction();
+        result.created.zones += counts.zones.created;
+        result.created.sectors += counts.sectors.created;
+        result.created.mcs += counts.mcs.created;
+        result.skipped.zones += counts.zones.skipped;
+        result.skipped.sectors += counts.sectors.skipped;
+        result.skipped.mcs += counts.mcs.skipped;
       } catch (err) {
+        await qr.rollbackTransaction();
         result.errors.push(`Row ${rowNum}: ${err.message}`);
+      } finally {
+        await qr.release();
       }
     }
 
     return result;
+  }
+
+  private async processRow(
+    row: BulkGroupRow,
+    locationCat: GroupCategory,
+    zoneCat: GroupCategory | null,
+    sectorCat: GroupCategory | null,
+    mcCat: GroupCategory,
+    tenantId: number,
+    qr: QueryRunner,
+  ): Promise<RowCounts> {
+    const counts: RowCounts = {
+      zones: { created: 0, skipped: 0 },
+      sectors: { created: 0, skipped: 0 },
+      mcs: { created: 0, skipped: 0 },
+    };
+
+    const locationName = row.location?.trim();
+    const mcName = row.mc?.trim();
+
+    if (!locationName) throw new Error('"location" is required.');
+    if (!mcName) throw new Error('"mc" is required.');
+
+    const location = await this.findByName(
+      locationName,
+      locationCat,
+      tenantId,
+      qr.manager,
+    );
+    if (!location) {
+      throw new Error(
+        `Location "${locationName}" not found. Locations must already exist.`,
+      );
+    }
+
+    let parent = location;
+
+    if (row.zone?.trim()) {
+      if (!zoneCat) {
+        throw new Error(
+          `Zone category ("${GroupCategoryNames.ZONE}") not found for this tenant.`,
+        );
+      }
+      const [zone, wasCreated] = await this.findOrCreate(
+        row.zone.trim(),
+        zoneCat,
+        tenantId,
+        parent,
+        qr,
+      );
+      wasCreated ? counts.zones.created++ : counts.zones.skipped++;
+      parent = zone;
+    }
+
+    if (row.sector?.trim()) {
+      if (!sectorCat) {
+        throw new Error('Sector category not found for this tenant.');
+      }
+      const [sector, wasCreated] = await this.findOrCreate(
+        row.sector.trim(),
+        sectorCat,
+        tenantId,
+        parent,
+        qr,
+      );
+      wasCreated ? counts.sectors.created++ : counts.sectors.skipped++;
+      parent = sector;
+    }
+
+    const [mc, wasCreated] = await this.findOrCreate(
+      mcName,
+      mcCat,
+      tenantId,
+      parent,
+      qr,
+    );
+    if (wasCreated) {
+      counts.mcs.created++;
+      await this.ensureFellowshipSchedule(mc.id, tenantId, qr.manager);
+    } else {
+      counts.mcs.skipped++;
+    }
+
+    return counts;
   }
 
   private async findCategory(
@@ -158,26 +196,32 @@ export class GroupImportService {
 
   private async findByName(
     name: string,
-    category: GroupCategory | null,
+    category: GroupCategory,
     tenantId: number,
+    manager: EntityManager,
   ): Promise<Group | null> {
-    const qb = this.groupRepo
+    return manager
+      .getRepository(Group)
       .createQueryBuilder('g')
       .where('g."tenantId" = :tenantId', { tenantId })
-      .andWhere('LOWER(g.name) = LOWER(:name)', { name });
-    if (category) {
-      qb.andWhere('g."categoryId" = :catId', { catId: category.id });
-    }
-    return qb.getOne();
+      .andWhere('g."categoryId" = :catId', { catId: category.id })
+      .andWhere('LOWER(g.name) = LOWER(:name)', { name })
+      .getOne();
   }
 
+  // Uses SAVEPOINT so a unique-constraint violation from a concurrent insert
+  // doesn't abort the outer transaction — we roll back only the failed INSERT,
+  // then re-find the row that the competing writer just committed.
   private async findOrCreate(
     name: string,
     category: GroupCategory,
     tenantId: number,
     parent: Group,
+    qr: QueryRunner,
   ): Promise<[Group, boolean]> {
-    const existing = await this.groupRepo
+    const groupRepo = qr.manager.getRepository(Group);
+
+    const existing = await groupRepo
       .createQueryBuilder('g')
       .where('g."tenantId" = :tenantId', { tenantId })
       .andWhere('g."categoryId" = :catId', { catId: category.id })
@@ -187,25 +231,48 @@ export class GroupImportService {
 
     if (existing) return [existing, false];
 
-    const group = await this.treeRepo.save(
-      this.treeRepo.create({
-        name,
-        category,
-        tenant: { id: tenantId } as any,
-        parent,
-        privacy: GroupPrivacy.Public,
-      }),
-    );
-    return [group, true];
+    const sp = `sp_foi_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    await qr.manager.query(`SAVEPOINT "${sp}"`);
+    try {
+      const treeRepo = qr.manager.getTreeRepository(Group);
+      const group = await treeRepo.save(
+        treeRepo.create({
+          name,
+          category,
+          tenant: { id: tenantId } as any,
+          parent,
+          privacy: GroupPrivacy.Public,
+        }),
+      );
+      return [group, true];
+    } catch (err) {
+      if ((err as any).code === '23505') {
+        await qr.manager.query(`ROLLBACK TO SAVEPOINT "${sp}"`);
+        const concurrent = await groupRepo
+          .createQueryBuilder('g')
+          .where('g."tenantId" = :tenantId', { tenantId })
+          .andWhere('g."categoryId" = :catId', { catId: category.id })
+          .andWhere('g.name = :name', { name })
+          .andWhere('g."parentId" = :parentId', { parentId: parent.id })
+          .getOne();
+        if (concurrent) return [concurrent, false];
+      }
+      throw err;
+    }
   }
 
-  private async ensureFellowshipSchedule(mcId: number, tenantId: number) {
-    const existing = await this.scheduleRepo.findOne({
+  private async ensureFellowshipSchedule(
+    mcId: number,
+    tenantId: number,
+    manager: EntityManager,
+  ) {
+    const scheduleRepo = manager.getRepository(FellowshipSchedule);
+    const existing = await scheduleRepo.findOne({
       where: { fellowshipGroupId: mcId },
     });
     if (!existing) {
-      await this.scheduleRepo.save(
-        this.scheduleRepo.create({
+      await scheduleRepo.save(
+        scheduleRepo.create({
           tenant: { id: tenantId } as any,
           fellowshipGroup: { id: mcId } as any,
           fellowshipGroupId: mcId,


### PR DESCRIPTION
POST /api/groups/import/bulk accepts a CSV with columns location,zone,sector,mc. Uses find-or-create logic so re-uploading the same file is safe — existing groups are skipped and counted as skipped, not duplicated. New MCs automatically get a fellowship schedule. Locations must already exist; zones and sectors are optional per row.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk group import from a CSV upload.
  * The import supports hierarchical group data and handles missing optional fields gracefully.

* **Bug Fixes**
  * Improves validation for uploaded CSV files, including missing files, missing required columns, and empty imports.
  * Provides clearer error feedback when uploaded data is malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->