### PR TITLE
fix(crm): allow contact search to match full names with spaces

### DIFF
--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -94,6 +94,10 @@ export class ContactsService {
     this.logger = this.appLogger.createContextLogger('ContactsService');
   }
 
+  private static escapeLike(value: string): string {
+    return value.replace(/[%_\\]/g, (match) => `\\${match}`);
+  }
+
   async findAll(req: ContactSearchDto, user?: any): Promise<ContactListDto[]> {
     const tracking = this.logger.startTracking('findAllContacts', {
       userId: user?.id,
@@ -150,19 +154,24 @@ export class ContactsService {
 
       if (hasValue(req.query)) {
         hasFilter = true;
-        const resp = await this.personRepository.find({
-          select: ['contactId'],
-          where: [
-            {
-              firstName: ILike(`%${req.query.trim()}%`),
-            },
-            {
-              lastName: ILike(`%${req.query.trim()}%`),
-            },
-            {
-              middleName: ILike(`%${req.query.trim()}%`),
-            },
-          ],
+        const searchTerms = req.query.trim().split(/\s+/);        
+        const qb = this.personRepository.createQueryBuilder('person')
+          .select(['person.contactId']);
+        // Dynamically add an AND condition for every word keyword typed
+        searchTerms.forEach((term, index) => {
+          const condition = `(person.firstName ILIKE :term${index} OR person.lastName ILIKE :term${index} OR person.middleName ILIKE :term${index})`;
+          const params = { [`term${index}`]: `%${ContactsService.escapeLike(term)}%` };
+          if (index === 0) {
+            qb.where(condition, params);
+          } else {
+            qb.andWhere(condition, params);
+          }
+        });
+        const resp = await qb.getMany();
+        this.logger.dataAccess('debug', 'Name search results found', {
+          operation: 'findAllContacts',
+          userId: user?.id,
+          metadata: { nameSearchResultCount: resp.length, queryLength: req.query.length },
         });
         if (hasValue(idList)) {
           idList = intersection(
@@ -173,6 +182,7 @@ export class ContactsService {
           idList.push(...resp.map((it) => it.contactId));
         }
       }
+
 
       if (hasValue(req.phone)) {
         hasFilter = true;

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -153,35 +153,43 @@ export class ContactsService {
       }
 
       if (hasValue(req.query)) {
-        hasFilter = true;
-        const searchTerms = req.query.trim().split(/\s+/);        
-        const tenantId = this.tenantContext.requireTenant();
-        const qb = this.personRepository.createQueryBuilder('person')
-          .innerJoin('person.contact', 'contact')
-          .select(['person.contactId'])
-          .where('contact.tenantId = :tenantId', { tenantId });
-        // Dynamically add an AND condition for every word keyword typed
-        searchTerms.forEach((term, index) => {
-          const condition = `(person.firstName ILIKE :term${index} OR person.lastName ILIKE :term${index} OR person.middleName ILIKE :term${index})`;
-          const params = { [`term${index}`]: `%${ContactsService.escapeLike(term)}%` };
-          qb.andWhere(condition, params);
-        });
-        const resp = await qb.getMany();
-        this.logger.dataAccess('debug', 'Name search results found', {
-          operation: 'findAllContacts',
-          userId: user?.id,
-          metadata: { nameSearchResultCount: resp.length, queryLength: req.query.length },
-        });
-        if (hasValue(idList)) {
-          idList = intersection(
-            idList,
-            resp.map((it) => it.contactId),
-          );
-        } else {
-          idList.push(...resp.map((it) => it.contactId));
+        const trimmedQuery = req.query.trim();
+        if (hasValue(trimmedQuery)) {
+          hasFilter = true;
+          const searchTerms = trimmedQuery.split(/\s+/);
+          const tenantId = this.tenantContext.requireTenant();
+          const qb = this.personRepository
+            .createQueryBuilder('person')
+            .innerJoin('person.contact', 'contact')
+            .select(['person.contactId'])
+            .where('contact.tenantId = :tenantId', { tenantId });
+          // Dynamically add an AND condition for every word keyword typed
+          searchTerms.forEach((term, index) => {
+            const condition = `(person.firstName ILIKE :term${index} OR person.lastName ILIKE :term${index} OR person.middleName ILIKE :term${index})`;
+            const params = {
+              [`term${index}`]: `%${ContactsService.escapeLike(term)}%`,
+            };
+            qb.andWhere(condition, params);
+          });
+          const resp = await qb.getMany();
+          this.logger.dataAccess('debug', 'Name search results found', {
+            operation: 'findAllContacts',
+            userId: user?.id,
+            metadata: {
+              nameSearchResultCount: resp.length,
+              queryLength: trimmedQuery.length,
+            },
+          });
+          if (hasValue(idList)) {
+            idList = intersection(
+              idList,
+              resp.map((it) => it.contactId),
+            );
+          } else {
+            idList.push(...resp.map((it) => it.contactId));
+          }
         }
       }
-
 
       if (hasValue(req.phone)) {
         hasFilter = true;

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -155,17 +155,16 @@ export class ContactsService {
       if (hasValue(req.query)) {
         hasFilter = true;
         const searchTerms = req.query.trim().split(/\s+/);        
+        const tenantId = this.tenantContext.requireTenant();
         const qb = this.personRepository.createQueryBuilder('person')
-          .select(['person.contactId']);
+          .innerJoin('person.contact', 'contact')
+          .select(['person.contactId'])
+          .where('contact.tenantId = :tenantId', { tenantId });
         // Dynamically add an AND condition for every word keyword typed
         searchTerms.forEach((term, index) => {
           const condition = `(person.firstName ILIKE :term${index} OR person.lastName ILIKE :term${index} OR person.middleName ILIKE :term${index})`;
           const params = { [`term${index}`]: `%${ContactsService.escapeLike(term)}%` };
-          if (index === 0) {
-            qb.where(condition, params);
-          } else {
-            qb.andWhere(condition, params);
-          }
+          qb.andWhere(condition, params);
         });
         const resp = await qb.getMany();
         this.logger.dataAccess('debug', 'Name search results found', {


### PR DESCRIPTION
# Ticket No
- CRM-382 

# Summary of changes
- Replaced column-specific `ILike` array filters with a dynamic `QueryBuilder` implementation inside `ContactsService.findAll`.
- Tokenized the incoming search string (`req.query`) by word boundaries to match multi-word phrases against `firstName`, `lastName`, and `middleName` simultaneously.
- Switched data extraction to `getRawMany()` to provide a flat, predictable results layout for safe array intersection operations.

# How should this be tested?
1. Open the people  page.
2. Search for a single term (e.g., `"Sarah"`) and confirm matching results show up.
3. Search for a combined full name containing spaces (e.g., `"Sarah Nambi"`) and press Enter.
4. Verify that the correct contact maps and returns successfully instead of throwing an empty state.

# Out of scope
- Refactoring the telephone (`req.phone`) or email (`req.email`) string processing code blocks.
- Modifying frontend input keypress debouncer delays.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact name search to handle multi-word queries more accurately across first, middle, and last names.
  * Search now evaluates each term separately, improving precision for full-name and partial-name matches.
  * Enhanced handling of special characters in search input, reducing cases where searches fail or return incorrect matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->