### PR TITLE
Update the group membership of a specific group instead of all groups…

### DIFF
--- a/src/groups/dto/membership/update-group-membership.dto.ts
+++ b/src/groups/dto/membership/update-group-membership.dto.ts
@@ -4,6 +4,10 @@ import { GroupRole } from '../../enums/groupRole';
 export default class UpdateGroupMembershipDto {
   @IsNumber()
   id: number;
+
+  @IsNumber()
+  groupId: number;
+
   @IsNotEmpty()
   @IsEnum(GroupRole)
   role: GroupRole;

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -222,6 +222,7 @@ export class GroupsMembershipService {
         role: dto.role,
       })
       .where('id = :id', { id: dto.id })
+      .andWhere('groupId = :groupId', { groupId: dto.groupId })
       .execute();
     Logger.log(`Updated data ${update.affected} ${JSON.stringify(update.raw)}`);
     return await this.findOne(dto.id);


### PR DESCRIPTION
Update the group membership of a specific group instead of all groups that the user belonged to.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group membership updates now require both the membership ID and group ID to match, helping prevent accidental updates to the wrong record.
  * Added validation for the group ID used during membership updates, improving request reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->