### PR TITLE
fix(reports): allow hierarchical leaders to submit reports for descen…

### DIFF
--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -3,6 +3,9 @@ import { ReportsService } from './reports.service';
 import { UsersService } from '../users/users.service';
 import { GroupsService } from '../groups/services/groups.service';
 import { GroupTreeService } from '../groups/services/group-tree.service';
+import { GroupPermissionsService } from '../groups/services/group-permissions.service';
+import { TenantContext } from '../shared/tenant/tenant-context';
+import { FellowshipAttendanceService } from '../attendance/services/fellowship-attendance.service';
 import { AppLogger } from '../utils/app-logger.service';
 import { Connection, Repository, TreeRepository } from 'typeorm';
 import { Report } from './entities/report.entity';
@@ -19,6 +22,9 @@ describe('ReportsService', () => {
   let mockUsersService: Partial<UsersService>;
   let mockGroupsService: Partial<GroupsService>;
   let mockGroupTreeService: Partial<GroupTreeService>;
+  let mockGroupPermissionsService: Partial<GroupPermissionsService>;
+  let mockTenantContext: Partial<TenantContext>;
+  let mockFellowshipAttendanceService: Partial<FellowshipAttendanceService>;
   let mockAppLogger: Partial<AppLogger>;
   let mockRepositories: any;
 
@@ -93,6 +99,21 @@ describe('ReportsService', () => {
       getReportAccessibleGroups: jest.fn(),
     };
 
+    mockGroupPermissionsService = {
+      hasPermissionForGroup: jest.fn(),
+      assertPermissionForGroup: jest.fn(),
+      getUserGroupIds: jest.fn(),
+      getUserIsMemberLeaderGroupIds: jest.fn(),
+    };
+
+    mockTenantContext = {
+      requireTenant: jest.fn().mockReturnValue(1),
+    };
+
+    mockFellowshipAttendanceService = {
+      recordReportAttendance: jest.fn(),
+    };
+
     mockAppLogger = {
       createContextLogger: jest.fn().mockReturnValue({
         startTracking: jest.fn().mockReturnValue('tracking-id'),
@@ -121,6 +142,18 @@ describe('ReportsService', () => {
         {
           provide: GroupTreeService,
           useValue: mockGroupTreeService,
+        },
+        {
+          provide: GroupPermissionsService,
+          useValue: mockGroupPermissionsService,
+        },
+        {
+          provide: TenantContext,
+          useValue: mockTenantContext,
+        },
+        {
+          provide: FellowshipAttendanceService,
+          useValue: mockFellowshipAttendanceService,
         },
         {
           provide: AppLogger,

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -2,11 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ReportsService } from './reports.service';
 import { UsersService } from '../users/users.service';
 import { GroupsService } from '../groups/services/groups.service';
-import { GroupTreeService } from '../groups/services/group-tree.service';
 import { GroupPermissionsService } from '../groups/services/group-permissions.service';
+import { GroupTreeService } from '../groups/services/group-tree.service';
+import { AppLogger } from '../utils/app-logger.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { FellowshipAttendanceService } from '../attendance/services/fellowship-attendance.service';
-import { AppLogger } from '../utils/app-logger.service';
 import { Connection, Repository, TreeRepository } from 'typeorm';
 import { Report } from './entities/report.entity';
 import { ReportSubmission } from './entities/report.submission.entity';
@@ -21,11 +21,11 @@ describe('ReportsService', () => {
   let mockConnection: Partial<Connection>;
   let mockUsersService: Partial<UsersService>;
   let mockGroupsService: Partial<GroupsService>;
-  let mockGroupTreeService: Partial<GroupTreeService>;
   let mockGroupPermissionsService: Partial<GroupPermissionsService>;
+  let mockGroupTreeService: Partial<GroupTreeService>;
+  let mockAppLogger: Partial<AppLogger>;
   let mockTenantContext: Partial<TenantContext>;
   let mockFellowshipAttendanceService: Partial<FellowshipAttendanceService>;
-  let mockAppLogger: Partial<AppLogger>;
   let mockRepositories: any;
 
   beforeEach(async () => {
@@ -107,11 +107,14 @@ describe('ReportsService', () => {
     };
 
     mockTenantContext = {
+      tenantId: 1,
+      hasTenant: jest.fn().mockReturnValue(true),
       requireTenant: jest.fn().mockReturnValue(1),
     };
 
     mockFellowshipAttendanceService = {
       recordReportAttendance: jest.fn(),
+      getMyMembers: jest.fn(),
     };
 
     mockAppLogger = {
@@ -119,7 +122,7 @@ describe('ReportsService', () => {
         startTracking: jest.fn().mockReturnValue('tracking-id'),
         endTracking: jest.fn(),
         apiLog: jest.fn(),
-        businessLog: jest.fn(),
+        business: jest.fn(),
         error: jest.fn(),
       }),
     };
@@ -140,12 +143,16 @@ describe('ReportsService', () => {
           useValue: mockGroupsService,
         },
         {
+          provide: GroupPermissionsService,
+          useValue: mockGroupPermissionsService,
+        },
+        {
           provide: GroupTreeService,
           useValue: mockGroupTreeService,
         },
         {
-          provide: GroupPermissionsService,
-          useValue: mockGroupPermissionsService,
+          provide: AppLogger,
+          useValue: mockAppLogger,
         },
         {
           provide: TenantContext,
@@ -154,10 +161,6 @@ describe('ReportsService', () => {
         {
           provide: FellowshipAttendanceService,
           useValue: mockFellowshipAttendanceService,
-        },
-        {
-          provide: AppLogger,
-          useValue: mockAppLogger,
         },
       ],
     }).compile();

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1289,7 +1289,18 @@ export class ReportsService {
 
     // Allow users who lead a group higher in the hierarchy (e.g. a FOB or
     // Zone leader submitting on behalf of a Location/MC nested beneath them).
-    // GroupPermissionsService.hasPermissionForGroup walks ancestors for this.
+    // First confirm the target group is in the required category so a structural
+    // leader cannot be authorized for a group in the wrong category.
+    if (categoryId) {
+      const targetGroup = await this.treeRepository.findOne({
+        where: { id: groupId },
+        relations: ['category'],
+      });
+      if (!targetGroup || targetGroup.category?.id !== categoryId) {
+        return false;
+      }
+    }
+
     return this.groupPermissionsService.hasPermissionForGroup(user, groupId);
   }
 

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -27,6 +27,7 @@ import { TreeRepository } from 'typeorm';
 import Group from 'src/groups/entities/group.entity';
 import { UsersService } from 'src/users/users.service';
 import { GroupsService } from 'src/groups/services/groups.service';
+import { GroupPermissionsService } from 'src/groups/services/group-permissions.service';
 import { GroupTreeService } from 'src/groups/services/group-tree.service';
 import { ReportField } from './entities/report.field.entity';
 import { ReportSubmissionData } from './entities/report.submission.data.entity';
@@ -54,6 +55,7 @@ export class ReportsService {
     @Inject('CONNECTION') connection: Connection,
     private readonly usersService: UsersService,
     private readonly groupsService: GroupsService,
+    private readonly groupPermissionsService: GroupPermissionsService,
     private readonly groupTreeService: GroupTreeService,
     private readonly appLogger: AppLogger,
     private readonly tenantContext: TenantContext,
@@ -110,7 +112,7 @@ export class ReportsService {
     // Retrieve the report by its ID
     const report = await this.reportRepository.findOne({
       where: { id: reportId, status: ReportStatus.ACTIVE },
-      relations: ['targetGroupCategory'],
+      relations: ['targetGroupCategory', 'fields'],
     });
     if (!report) {
       throw new NotFoundException(`Report with ID ${reportId} not found`);
@@ -144,16 +146,62 @@ export class ReportsService {
     let targetGroup: Group | null = null;
     let selectedGroupId: number | null = null;
 
+    // The designated group field can either be configured explicitly via
+    // report.groupFieldName, or inferred from a field marked as a
+    // 'dynamic_group_selector' (e.g. serviceLocationId on the Sunday Service
+    // Report). Prefer the hidden field, since the selector marker is applied
+    // to both the display field (e.g. serviceLocationName) and the id field.
+    const groupSelectorFields = (report.fields ?? []).filter(
+      (f) =>
+        Array.isArray(f.options) &&
+        f.options.some((o: any) => o.type === 'dynamic_group_selector'),
+    );
+    const groupSelectorField =
+      groupSelectorFields.find((f) => f.hidden) ?? groupSelectorFields[0];
+    const groupFieldName = report.groupFieldName || groupSelectorField?.name;
+
+    this.logger.business('log', 'Resolved report group field', {
+      operation: 'submitReport',
+      resource: 'reports',
+      resourceId: report.id,
+      metadata: {
+        staticGroupFieldName: report.groupFieldName ?? null,
+        groupSelectorFieldNames: groupSelectorFields.map((f) => f.name),
+        selectedGroupSelectorField: groupSelectorField?.name ?? null,
+        resolvedGroupFieldName: groupFieldName ?? null,
+      },
+    });
+
     // Check if report has a designated group field
-    if (report.groupFieldName && submissionDto.data[report.groupFieldName]) {
-      selectedGroupId = parseInt(submissionDto.data[report.groupFieldName]);
+    if (groupFieldName && submissionDto.data[groupFieldName]) {
+      selectedGroupId = parseInt(submissionDto.data[groupFieldName]);
+
+      this.logger.business('log', 'Resolved selected group for submission', {
+        operation: 'submitReport',
+        resource: 'reports',
+        resourceId: report.id,
+        contactId: submittingUser.contactId,
+        metadata: {
+          groupFieldName,
+          rawGroupFieldValue: submissionDto.data[groupFieldName],
+          selectedGroupId,
+        },
+      });
 
       // Validate user can submit for this group
       const canSubmitForGroup = await this.validateUserGroupPermission(
-        submittingUser.contactId,
+        user,
         selectedGroupId,
         report.targetGroupCategory?.id,
       );
+
+      this.logger.business('log', 'Group submission permission check', {
+        operation: 'submitReport',
+        resource: 'reports',
+        resourceId: report.id,
+        contactId: submittingUser.contactId,
+        metadata: { selectedGroupId, canSubmitForGroup },
+      });
 
       if (!canSubmitForGroup) {
         throw new BadRequestException(
@@ -1201,23 +1249,29 @@ export class ReportsService {
   }
 
   private async validateUserGroupPermission(
-    contactId: number,
+    user: UserDto,
     groupId: number,
     categoryId?: number,
   ): Promise<boolean> {
     const membership = await this.groupMembershipRepo.findOne({
       where: {
-        contactId,
+        contactId: user.contactId,
         group: { id: groupId },
       },
       relations: ['group', 'group.category'],
     });
 
-    if (!membership) return false;
-    if (categoryId && membership.group.category?.id !== categoryId)
-      return false;
+    if (
+      membership &&
+      (!categoryId || membership.group.category?.id === categoryId)
+    ) {
+      return true;
+    }
 
-    return true;
+    // Allow users who lead a group higher in the hierarchy (e.g. a FOB or
+    // Zone leader submitting on behalf of a Location/MC nested beneath them).
+    // GroupPermissionsService.hasPermissionForGroup walks ancestors for this.
+    return this.groupPermissionsService.hasPermissionForGroup(user, groupId);
   }
 
   private async getUserGroupsInCategory(

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -174,7 +174,12 @@ export class ReportsService {
 
     // Check if report has a designated group field
     if (groupFieldName && submissionDto.data[groupFieldName]) {
-      selectedGroupId = parseInt(submissionDto.data[groupFieldName]);
+      selectedGroupId = parseInt(submissionDto.data[groupFieldName], 10);
+      if (Number.isNaN(selectedGroupId)) {
+        throw new BadRequestException(
+          `Invalid group value for field "${groupFieldName}"`,
+        );
+      }
 
       this.logger.business('log', 'Resolved selected group for submission', {
         operation: 'submitReport',
@@ -1266,6 +1271,20 @@ export class ReportsService {
       (!categoryId || membership.group.category?.id === categoryId)
     ) {
       return true;
+    }
+
+    // hasPermissionForGroup only checks leadership ancestry, not category, so
+    // the target group's category must be re-checked here before allowing the
+    // hierarchical fallback (otherwise an ancestor leader could submit for a
+    // descendant group in the wrong category).
+    if (categoryId) {
+      const targetGroup = await this.treeRepository.findOne({
+        where: { id: groupId },
+        relations: ['category'],
+      });
+      if (targetGroup?.category?.id !== categoryId) {
+        return false;
+      }
     }
 
     // Allow users who lead a group higher in the hierarchy (e.g. a FOB or


### PR DESCRIPTION
allow hierarchical leaders to submit reports for descendant groups

Report submission previously only allowed users with a direct GroupMembership in the target group to submit. This blocked FOB/Zone leaders from submitting on behalf of a nested Location/MC. Now falls back to GroupPermissionsService.hasPermissionForGroup, which walks ancestors, and also infers the group field from a
`dynamic_group_selector` field when `report.groupFieldName` isn't set.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report submission authorization to correctly validate permissions against the selected group (and its category when applicable).
  * Report submission now resolves the correct group field more reliably, including dynamically configured selectors.
  * Added clearer permission validation so unauthorized submissions fail consistently for the chosen group.
* **Tests**
  * Updated the report service test suite to cover the new permission-related dependency and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->