### PR TITLE
feat(users): support fellowship leaders without email addresses

### DIFF
--- a/src/auth/auth.helpers.ts
+++ b/src/auth/auth.helpers.ts
@@ -11,7 +11,7 @@ export const createUserDto = (user: User): UserDto => {
   user.userRoles.forEach((it) => permissions.concat(it.roles.permissions));
   return {
     contactId: user.contact.id,
-    email: user.username,
+    email: user.email ?? null,
     username: user.username,
     fullName: getPersonFullName(user.contact.person),
     id: user.id,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -257,22 +257,22 @@ export class AuthService {
     if (!user) {
       throw new HttpException('User Password Not Updated', 404);
     }
-    const resolvedUser = await user;
-    if (resolvedUser.email) {
+    let mailURL = '';
+    if (user.email) {
       const mailerData: IEmail = {
-        to: resolvedUser.email,
+        to: user.email,
         subject: 'Password Change Confirmation',
         html: `
-          <h3>Hello ${resolvedUser.fullName},</h3></br>
+          <h3>Hello ${user.fullName},</h3></br>
           <h4>Your Password has been changed successfully!<h4></br>
       `,
       };
-      const mailURL = await sendEmail(mailerData);
+      mailURL = await sendEmail(mailerData);
       if (!mailURL) {
         Logger.error('Password change confirmation email not sent');
       }
     }
-    return { message: 'Password Change Successful', mailURL: '', user };
+    return { message: 'Password Change Successful', mailURL, user };
   }
 
   async getPermissions(roles: string[]) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -205,16 +205,26 @@ export class AuthService {
     const message =
       'An email has been sent to the provided address if it exists in our system';
     if (!userExists) {
-      Logger.error('Provided email address not registered');
+      Logger.error('Provided username not registered');
       return { token: '', mailURL: '', message };
     }
 
     const user = await this.usersService.findOne(userExists.id);
+
+    if (!user.email) {
+      return {
+        token: '',
+        mailURL: '',
+        message:
+          'No email address is on file for this account. Please contact your administrator to reset your password.',
+      };
+    }
+
     const token = (await this.jwtHelperService.generateToken(user)).token;
     const resetLink = `${process.env.APP_URL}/reset-password/${token}`;
 
     const mailerData: IEmail = {
-      to: `${(await user).username}`,
+      to: user.email,
       subject: 'Project Zoe - Reset Password',
       html: `
             <p>Hello ${user.fullName}</p></br>
@@ -247,21 +257,22 @@ export class AuthService {
     if (!user) {
       throw new HttpException('User Password Not Updated', 404);
     }
-    const mailerData: IEmail = {
-      to: `${(await user).username}`,
-      subject: 'Password Change Confirmation',
-      html: `
-          <h3>Hello ${(await user).fullName},</h3></br>
+    const resolvedUser = await user;
+    if (resolvedUser.email) {
+      const mailerData: IEmail = {
+        to: resolvedUser.email,
+        subject: 'Password Change Confirmation',
+        html: `
+          <h3>Hello ${resolvedUser.fullName},</h3></br>
           <h4>Your Password has been changed successfully!<h4></br>
       `,
-    };
-    const mailURL = await sendEmail(mailerData);
-    if (mailURL) {
-      const message = 'Password Change Successful';
-      return { message, mailURL, user };
-    } else {
-      Logger.error('Email not sent');
+      };
+      const mailURL = await sendEmail(mailerData);
+      if (!mailURL) {
+        Logger.error('Password change confirmation email not sent');
+      }
     }
+    return { message: 'Password Change Successful', mailURL: '', user };
   }
 
   async getPermissions(roles: string[]) {

--- a/src/auth/dto/user.dto.ts
+++ b/src/auth/dto/user.dto.ts
@@ -8,8 +8,8 @@ export class UserDto extends UserPermissions {
   contactId: number;
   @ApiProperty()
   username: string;
-  @ApiProperty()
-  email: string;
+  @ApiProperty({ required: false, nullable: true })
+  email: string | null;
   @ApiProperty()
   fullName: string;
   @ApiProperty()

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -6,7 +6,8 @@ export class CreateUserDto {
   @IsNumber()
   contactId: number;
 
-  username: string;
+  @IsOptional()
+  username?: string;
   @IsNotEmpty()
   password: string;
   @IsNotEmpty()

--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -5,6 +5,7 @@ export class UserPermissions {
 export class UserListDto extends UserPermissions {
   id: number;
   username: string;
+  email: string | null;
   fullName: string;
   contactId: number;
   contact: any;

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -25,14 +25,15 @@ const hashCost = 12;
 @Entity()
 @Unique(['username'])
 @Index(['tenant'])
+@Index(['email', 'tenant'], { unique: true })
 export class User {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ length: 40 })
+  @Column({ length: 254 })
   username: string;
 
-  @Column({ length: 100, nullable: true, unique: true })
+  @Column({ length: 100, nullable: true })
   email: string | null;
 
   @Column({ length: 100 })

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -32,6 +32,9 @@ export class User {
   @Column({ length: 40 })
   username: string;
 
+  @Column({ length: 100, nullable: true, unique: true })
+  email: string | null;
+
   @Column({ length: 100 })
   @Exclude()
   password: string;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -131,6 +131,7 @@ export class UsersService {
       isActive: user.isActive,
       lastLogin: user.lastLogin ?? null,
       username: user.username,
+      email: user.email ?? null,
       contactId: user.contactId,
       fullName,
     };
@@ -158,16 +159,31 @@ export class UsersService {
     if (!(await this.contactsService.findOne(data.contactId))) {
       throw new HttpException('Visitor Not Found', 404);
     }
-    const email = await this.emailRepository.findOne({
+
+    const emailRecord = await this.emailRepository.findOne({
       where: { contactId: data.contactId },
     });
+
     const toSave = new User();
     toSave.id = data.contactId;
-    toSave.username = email.value;
     toSave.contactId = data.contactId;
     toSave.password = data.password;
     toSave.isActive = data.isActive;
-    // Password will be hashed in create() method
+
+    if (emailRecord?.value) {
+      // Email-bearing user: email doubles as login username
+      toSave.username = emailRecord.value;
+      toSave.email = emailRecord.value;
+    } else if (hasValue(data.username)) {
+      // Email-less user: admin supplies a login username (e.g. phone number)
+      toSave.username = data.username;
+      toSave.email = null;
+    } else {
+      throw new HttpException(
+        'Contact has no email address. Provide a username for this user.',
+        400,
+      );
+    }
 
     const saveUser = await this.create(toSave);
 
@@ -182,7 +198,6 @@ export class UsersService {
 
     if (!user) {
       this.remove(user.id);
-
       throw new HttpException('Failed To Create User', 400);
     }
 
@@ -200,35 +215,38 @@ export class UsersService {
       }
     }
 
-    const tokenOptions = { expiresIn: '1d' };
-    const token = (
-      await this.jwtHelperService.generateToken(
-        {
-          id: user.id,
-          contactId: user.contactId,
-          username: user.username,
-          email: user.username,
-          fullName: user.fullName,
-          roles: user.roles,
-          isActive: user.isActive,
-        },
-        tokenOptions,
-      )
-    ).token;
+    // Only send welcome email when an email address is on file
+    if (user.email) {
+      const tokenOptions = { expiresIn: '1d' };
+      const token = (
+        await this.jwtHelperService.generateToken(
+          {
+            id: user.id,
+            contactId: user.contactId,
+            username: user.username,
+            email: user.email,
+            fullName: user.fullName,
+            roles: user.roles,
+            isActive: user.isActive,
+          },
+          tokenOptions,
+        )
+      ).token;
 
-    const resetLink = `${process.env.APP_URL}/reset-password/${token}`;
-    const mailerData: IEmail = {
-      to: `${(await user).username}`,
-      subject: 'Project Zoe - Worship Harvest - Account Activated!',
-      html: `
+      const resetLink = `${process.env.APP_URL}/reset-password/${token}`;
+      const mailerData: IEmail = {
+        to: user.email,
+        subject: 'Project Zoe - Worship Harvest - Account Activated!',
+        html: `
                 <p>Hello ${user.fullName},</p></br>
                 <p>The Lamb has won! So, your account has been created in the Project Zoe church management platform.<p></br>
                 <p>Follow this <a href=${resetLink}>link</a> to reset your password</p>
                 <p>This link will expire in 1 day</p>
             `,
-    };
-    const mailURL = await sendEmail(mailerData);
-    // return { token, mailURL, user };
+      };
+      await sendEmail(mailerData);
+    }
+
     return user;
   }
 
@@ -241,6 +259,7 @@ export class UsersService {
     const contact = await this.contactsService.createPerson({ ...rest, email });
     const user = new User();
     user.username = email;
+    user.email = email;
     user.password = password;
     user.contact = Contact.ref(contact.id);
     user.isActive = true;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -197,7 +197,7 @@ export class UsersService {
     const user = await this.findOne(saveUser.id);
 
     if (!user) {
-      this.remove(user.id);
+      await this.remove(saveUser.id);
       throw new HttpException('Failed To Create User', 400);
     }
 


### PR DESCRIPTION
Add a nullable email column to User, decoupling the login identifier (username) from the email address. Email-less users are created with an admin-supplied username (e.g. phone number); password reset is gracefully declined for accounts with no email on file.

- User entity: add email: string | null (nullable, unique column)
- CreateUserDto: make username optional (used when contact has no email)
- UserListDto / auth UserDto: surface email as nullable
- createUser: derive username+email from contact email record when present; fall back to data.username for email-less contacts; skip welcome email if null
- register: set user.email alongside user.username
- createUserDto helper: map email from user.email, not user.username
- forgotPassword: guard on null email, return clear admin-contact message
- resetPassword: use user.email as To: address; skip send if null


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profiles and lists now include an email address when available.
  * Account creation and password reset emails are now sent to the saved email address.

* **Bug Fixes**
  * Email-related flows now handle missing email addresses more gracefully.
  * Password reset and welcome messages no longer rely on a username as the email recipient.

* **Documentation**
  * API responses now reflect that email can be optional or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->