### PR TITLE
fix(groups): use PATCH for group category update

### DIFF
--- a/src/groups/controllers/group-category.controller.ts
+++ b/src/groups/controllers/group-category.controller.ts
@@ -4,8 +4,8 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
-  Put,
   Query,
   UseGuards,
   UseInterceptors,
@@ -35,7 +35,7 @@ export class GroupCategoryController {
     return await this.service.create(data);
   }
 
-  @Put()
+  @Patch()
   async update(@Body() data: GroupCategory): Promise<GroupCategory> {
     return await this.service.update(data);
   }
@@ -47,7 +47,6 @@ export class GroupCategoryController {
 
   @Delete(':id')
   async remove(@Param('id') id: string): Promise<void> {
-    console.log('*****', id);
     await this.service.remove(id);
   }
 }


### PR DESCRIPTION
## Summary

- Changes the group category update endpoint from `PUT` to `PATCH` — `PUT` implies full replacement; `PATCH` correctly signals a partial update, which is what the endpoint does
- Removes a stray `console.log('*****', id)` from the delete handler

The service implementation was already correct (tenant-aware, duplicate-name check, partial field update). This is purely a controller-level HTTP method fix.

**Note:** This fix was identified during review of PR #175 (Musamasaba98), which contained the same observation but was too stale to merge directly.

## Test plan

- [ ] `PATCH /api/groups/categories` with `{ id, name }` updates the category name
- [ ] `PATCH /api/groups/categories` with `{ id, purpose }` updates the purpose without touching name
- [ ] Duplicate name for same tenant returns 409
- [ ] Category belonging to a different tenant is not found (404)
- [ ] `DELETE /api/groups/categories/:id` still works (no console noise in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)