### PR TITLE
test: expand unit test suite from 69 to 126 tests and wire into CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           npm install   
 
       - name: Run tests
-        run: npm test -- --forceExit --passWithNoTests
+        run: npm test -- --forceExit
 
       - name: Create an .env file
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,8 @@ jobs:
         run: |
           npm install   
 
-      # - name: Run the tests and generate coverage report
-      #   run: npm test -- --coverage
-
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v1
+      - name: Run tests
+        run: npm test -- --forceExit --passWithNoTests
 
       - name: Create an .env file
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -30,7 +30,7 @@ jobs:
           npm install   
 
       - name: Run tests
-        run: npm test -- --forceExit --passWithNoTests
+        run: npm test -- --forceExit
 
       - name: Create an .env file
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -29,11 +29,8 @@ jobs:
         run: |
           npm install   
 
-      # - name: Run the tests and generate coverage report
-      #   run: npm test -- --coverage
-
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v1
+      - name: Run tests
+        run: npm test -- --forceExit --passWithNoTests
 
       - name: Create an .env file
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: volta-cli/action@v1
+        with:
+          node-version: '18.x'
+          npm-version: '8.x'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test -- --forceExit --passWithNoTests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm test -- --forceExit --passWithNoTests
+        run: npm test -- --forceExit

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@nestjs/websockets": "^10.2.6",
         "@sentry/node": "^7.73.0",
         "@sentry/tracing": "^7.73.0",
-        "axios": "^1.13.6",
+        "axios": "^1.18.1",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
         "cache-manager": "^7.2.7",
@@ -38,30 +38,29 @@
         "csv-parse": "^6.1.0",
         "csv-parser": "^3.0.0",
         "date-fns": "^2.30.0",
+        "exceljs": "^4.4.0",
         "express-rate-limit": "^7.0.2",
         "express-validator": "^7.0.1",
         "geolib": "^3.3.4",
         "google-libphonenumber": "^3.2.33",
         "googleapis": "^129.0.0",
         "helmet": "^7.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "minimist": "^1.2.8",
         "morgan": "^1.10.0",
-        "nest-csv-parser": "^2.0.4",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
         "password-validator": "^5.3.0",
         "pg": "^8.11.3",
-        "postmark": "^3.0.19",
+        "postmark": "^4.0.7",
         "redis": "^4.7.1",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^5.0.5",
         "rxjs": "^7.1.0",
         "swagger-ui-express": "^5.0.0",
-        "typeorm": "^0.3.17",
-        "winston": "^3.10.0",
-        "xlsx": "^0.18.5"
+        "typeorm": "^0.3.29",
+        "winston": "^3.10.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.7.2",
@@ -248,11 +247,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -261,7 +262,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -269,19 +272,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -306,12 +311,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -330,12 +337,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -346,6 +355,8 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -354,6 +365,8 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -362,11 +375,15 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -374,25 +391,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -410,7 +431,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -418,7 +441,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -426,7 +451,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -434,23 +461,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -672,29 +703,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -702,12 +737,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -720,6 +757,8 @@
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1159,6 +1198,47 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "license": "MIT",
@@ -1195,6 +1275,52 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1277,7 +1403,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1661,6 +1789,8 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1670,6 +1800,8 @@
     },
     "node_modules/@jridgewell/source-map/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1828,7 +1960,9 @@
       }
     },
     "node_modules/@nestjs/cli/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1929,10 +2063,6 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "rxjs": "^7.1.0"
       }
-    },
-    "node_modules/@nestjs/config/node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
     },
     "node_modules/@nestjs/core": {
       "version": "10.4.22",
@@ -2211,10 +2341,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@nestjs/swagger/node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.22",
@@ -2562,12 +2688,13 @@
       "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
-      "version": "0.2.7",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "fflate": "^0.8.2",
-        "token-types": "^6.0.0"
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -2690,26 +2817,10 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3315,6 +3426,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
@@ -3332,13 +3456,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -3512,7 +3629,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3536,6 +3655,81 @@
     "node_modules/aproba": {
       "version": "2.1.0",
       "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
@@ -3717,6 +3911,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -3741,12 +3937,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3931,9 +4130,31 @@
       "version": "2.4.3",
       "license": "MIT"
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
       "engines": {
         "node": "*"
       }
@@ -3959,7 +4180,6 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -3969,7 +4189,6 @@
     },
     "node_modules/bl/node_modules/buffer": {
       "version": "5.7.1",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3989,6 +4208,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -4024,7 +4249,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4115,6 +4342,15 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "license": "BSD-3-Clause"
@@ -4122,6 +4358,23 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4266,7 +4519,9 @@
       }
     },
     "node_modules/cachedir": {
-      "version": "2.3.0",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4365,15 +4620,16 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "license": "Apache-2.0",
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
       "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
+        "traverse": ">=0.3.0 <0.4"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -4479,25 +4735,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cli-color": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "ansi-regex": "^2.1.1",
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.51",
-        "es6-iterator": "^2.0.3",
-        "memoizee": "^0.4.14",
-        "timers-ext": "^0.1.7"
-      }
-    },
-    "node_modules/cli-color/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -4665,13 +4902,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "dev": true,
@@ -4757,6 +4987,8 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4789,11 +5021,13 @@
       }
     },
     "node_modules/commitizen": {
-      "version": "4.3.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.2.tgz",
+      "integrity": "sha512-1Zs37z9JPvAcuTSSricZZwBhOPVNNxJouuY4yDEt+eD70EoxT2TU9kViG8CuB/PmVg2G4XsAGQiK4YCst97aDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cachedir": "2.3.0",
+        "cachedir": "2.4.0",
         "cz-conventional-changelog": "3.3.0",
         "dedent": "0.7.0",
         "detect-indent": "6.1.0",
@@ -4801,10 +5035,10 @@
         "find-root": "1.1.0",
         "fs-extra": "9.1.0",
         "glob": "7.2.3",
-        "inquirer": "8.2.5",
+        "inquirer": "8.2.7",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
-        "minimist": "1.2.7",
+        "lodash": "4.18.1",
+        "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
       },
@@ -4814,11 +5048,13 @@
         "git-cz": "bin/git-cz"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/commitizen/node_modules/cli-width": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4845,15 +5081,17 @@
       }
     },
     "node_modules/commitizen/node_modules/inquirer": {
-      "version": "8.2.5",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+      "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@inquirer/external-editor": "^1.0.0",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
         "cli-cursor": "^3.1.0",
         "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
@@ -4863,32 +5101,23 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
-        "wrap-ansi": "^7.0.0"
+        "wrap-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/commitizen/node_modules/minimist": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/commitizen/node_modules/mute-stream": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/commitizen/node_modules/run-async": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4904,7 +5133,9 @@
       }
     },
     "node_modules/commitizen/node_modules/wrap-ansi": {
-      "version": "7.0.0",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4913,10 +5144,7 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/compare-func": {
@@ -4934,6 +5162,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/compressible": {
@@ -5097,7 +5340,6 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -5158,6 +5400,19 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/create-jest": {
@@ -5297,17 +5552,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/d": {
-      "version": "1.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/dargs": {
@@ -5521,6 +5765,8 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5663,6 +5909,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "license": "MIT"
@@ -5730,7 +6021,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -5770,12 +6060,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -5884,7 +6176,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5938,50 +6232,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.64",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "esniff": "^2.0.1",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.4",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "ext": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/es6-weak-map": {
-      "version": "2.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
@@ -5995,6 +6245,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -6311,19 +6562,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/esniff": {
-      "version": "2.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "dev": true,
@@ -6413,14 +6651,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "license": "MIT"
@@ -6431,6 +6661,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/execa": {
@@ -6576,15 +6839,10 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "license": "ISC",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6601,6 +6859,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -6638,9 +6909,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -6674,10 +6945,6 @@
       "version": "4.2.3",
       "license": "MIT"
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "license": "MIT"
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "dev": true,
@@ -6704,16 +6971,18 @@
       }
     },
     "node_modules/file-type": {
-      "version": "20.4.1",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/inflate": "^0.2.6",
-        "strtok3": "^10.2.0",
-        "token-types": "^6.0.0",
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
         "uint8array-extras": "^1.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -6874,7 +7143,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6969,17 +7240,31 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/formidable": {
@@ -7003,13 +7288,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "license": "MIT",
@@ -7019,7 +7297,6 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -7077,6 +7354,35 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -7162,6 +7468,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/gcp-metadata": {
@@ -7348,11 +7667,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/global-dirs": {
       "version": "0.1.1",
       "dev": true,
@@ -7534,6 +7848,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -7546,7 +7873,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -8014,7 +8340,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8309,10 +8637,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -9142,7 +9466,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9199,6 +9525,8 @@
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9212,6 +9540,8 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9262,7 +9592,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9379,6 +9721,63 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "1.4.2",
       "license": "MIT",
@@ -9422,6 +9821,54 @@
     "node_modules/kuler": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -9637,7 +10084,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9657,6 +10106,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
     },
     "node_modules/listr2": {
       "version": "6.6.1",
@@ -9683,7 +10138,9 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9713,7 +10170,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -9725,6 +10184,36 @@
       "version": "4.5.0",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT"
@@ -9733,13 +10222,25 @@
       "version": "3.0.3",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -9752,6 +10253,12 @@
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
       "license": "MIT"
     },
     "node_modules/lodash.kebabcase": {
@@ -9793,9 +10300,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.upperfirst": {
@@ -9942,13 +10454,6 @@
       "version": "10.4.3",
       "license": "ISC"
     },
-    "node_modules/lru-queue": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "node_modules/luxon": {
       "version": "3.3.0",
       "license": "MIT",
@@ -10084,23 +10589,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/memoizee": {
-      "version": "0.4.17",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "es5-ext": "^0.10.64",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/meow": {
       "version": "8.1.2",
       "dev": true,
@@ -10178,7 +10666,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10270,6 +10760,128 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/minipass": {
@@ -10417,6 +11029,8 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -10470,19 +11084,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.2",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mute-stream": {
@@ -10514,221 +11131,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nest-csv-parser": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@nestjs/common": "7.3.2",
-        "@nestjs/core": "7.3.2",
-        "class-transformer": "0.2.3",
-        "csv-parser": "2.3.3",
-        "reflect-metadata": "0.1.13",
-        "rxjs": "6.6.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/@nestjs/common": {
-      "version": "7.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "0.19.2",
-        "cli-color": "2.0.0",
-        "iterare": "1.2.1",
-        "tslib": "2.0.0",
-        "uuid": "8.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "reflect-metadata": "^0.1.12",
-        "rxjs": "^6.0.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/@nestjs/common/node_modules/axios": {
-      "version": "0.19.2",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "1.5.10"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/@nestjs/core": {
-      "version": "7.3.2",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nuxtjs/opencollective": "0.2.2",
-        "fast-safe-stringify": "2.0.7",
-        "iterare": "1.2.1",
-        "object-hash": "2.0.3",
-        "path-to-regexp": "3.2.0",
-        "tslib": "2.0.0",
-        "uuid": "8.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0",
-        "reflect-metadata": "^0.1.12",
-        "rxjs": "^6.0.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/@nuxtjs/opencollective": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "consola": "^2.3.0",
-        "node-fetch": "^2.3.0"
-      },
-      "bin": {
-        "opencollective": "bin/opencollective.js"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/class-transformer": {
-      "version": "0.2.3",
-      "license": "MIT"
-    },
-    "node_modules/nest-csv-parser/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/nest-csv-parser/node_modules/csv-parser": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0",
-        "through2": "^3.0.1"
-      },
-      "bin": {
-        "csv-parser": "bin/csv-parser"
-      },
-      "engines": {
-        "node": ">= 8.16.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/debug": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/fast-safe-stringify": {
-      "version": "2.0.7",
-      "license": "MIT"
-    },
-    "node_modules/nest-csv-parser/node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "node_modules/nest-csv-parser/node_modules/object-hash": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/path-to-regexp": {
-      "version": "3.2.0",
-      "license": "MIT"
-    },
-    "node_modules/nest-csv-parser/node_modules/reflect-metadata": {
-      "version": "0.1.13",
-      "license": "Apache-2.0"
-    },
-    "node_modules/nest-csv-parser/node_modules/rxjs": {
-      "version": "6.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
-    "node_modules/nest-csv-parser/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nest-csv-parser/node_modules/tslib": {
-      "version": "2.0.0",
-      "license": "0BSD"
-    },
-    "node_modules/nest-csv-parser/node_modules/uuid": {
-      "version": "8.2.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "license": "ISC"
     },
     "node_modules/node-abi": {
       "version": "3.89.0",
@@ -10900,7 +11302,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11109,14 +11510,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "dev": true,
@@ -11183,6 +11576,12 @@
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -11495,35 +11894,12 @@
       }
     },
     "node_modules/postmark": {
-      "version": "3.11.0",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/postmark/-/postmark-4.0.7.tgz",
+      "integrity": "sha512-DjNniUl1XNCGUKhCR98ePd5gv16rlUAVKKaU9TUqnE3hDSqfT9XDulu1idjagQmdyGscqnRtXk/puAEiYMeevg==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.25.0"
-      }
-    },
-    "node_modules/postmark/node_modules/axios": {
-      "version": "0.25.0",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.7"
-      }
-    },
-    "node_modules/postmark/node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+        "axios": "^1.13.5"
       }
     },
     "node_modules/prebuild-install": {
@@ -11598,6 +11974,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/promise-coalesce": {
       "version": "1.5.0",
       "license": "BSD-3-Clause",
@@ -11646,8 +12028,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -11696,10 +12083,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -11864,6 +12254,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "dev": true,
@@ -11876,7 +12296,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12097,7 +12519,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -12257,6 +12681,18 @@
       "version": "2.1.2",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "3.3.0",
       "dev": true,
@@ -12384,6 +12820,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "license": "ISC"
@@ -12424,12 +12866,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -12441,11 +12885,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12679,6 +13125,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12688,6 +13136,8 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -12775,16 +13225,6 @@
       "version": "7.1.1",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/ssri": {
       "version": "8.0.1",
@@ -13129,7 +13569,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13174,7 +13616,6 @@
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -13198,7 +13639,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -13214,95 +13657,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13341,34 +13699,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/through2": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
-    "node_modules/timers-ext": {
-      "version": "0.1.8",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "dev": true,
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -13408,6 +13745,8 @@
     },
     "node_modules/token-types": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
@@ -13425,6 +13764,15 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -13604,10 +13952,6 @@
         "node": "*"
       }
     },
-    "node_modules/type": {
-      "version": "2.7.3",
-      "license": "ISC"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -13723,23 +14067,25 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -13823,7 +14169,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13883,7 +14231,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/typeorm/node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -13975,6 +14325,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -14119,11 +14523,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -14143,33 +14548,34 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.97.1",
+      "version": "5.108.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+      "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.22.2",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -14196,11 +14602,73 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-url": {
@@ -14343,20 +14811,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "dev": true,
@@ -14465,7 +14919,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14483,24 +14939,11 @@
         }
       }
     },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -14568,6 +15011,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@nestjs/websockets": "^10.2.6",
     "@sentry/node": "^7.73.0",
     "@sentry/tracing": "^7.73.0",
-    "axios": "^1.13.6",
+    "axios": "^1.18.1",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
     "cache-manager": "^7.2.7",
@@ -87,6 +87,7 @@
     "crypto": "^1.0.1",
     "csv-parse": "^6.1.0",
     "csv-parser": "^3.0.0",
+    "exceljs": "^4.4.0",
     "date-fns": "^2.30.0",
     "express-rate-limit": "^7.0.2",
     "express-validator": "^7.0.1",
@@ -94,24 +95,52 @@
     "google-libphonenumber": "^3.2.33",
     "googleapis": "^129.0.0",
     "helmet": "^7.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "minimist": "^1.2.8",
     "morgan": "^1.10.0",
-    "nest-csv-parser": "^2.0.4",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "password-validator": "^5.3.0",
     "pg": "^8.11.3",
-    "postmark": "^3.0.19",
+    "postmark": "^4.0.7",
     "redis": "^4.7.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^5.0.5",
     "rxjs": "^7.1.0",
     "swagger-ui-express": "^5.0.0",
-    "typeorm": "^0.3.17",
-    "winston": "^3.10.0",
-    "xlsx": "^0.18.5"
+    "typeorm": "^0.3.29",
+    "winston": "^3.10.0"
+  },
+  "overrides": {
+    "multer": "^2.2.0",
+    "form-data": "^4.0.6",
+    "qs": "^6.15.3",
+    "ws": "^8.21.0",
+    "fast-uri": "^3.1.2",
+    "lodash": "^4.18.1",
+    "ip-address": "^10.1.1",
+    "tmp": "^0.2.7",
+    "file-type": "^21.3.2",
+    "webpack": "^5.108.4",
+    "express": {
+      "path-to-regexp": "^0.1.13"
+    },
+    "typeorm": {
+      "uuid": "^11.1.1"
+    },
+    "exceljs": {
+      "uuid": "^11.1.1"
+    },
+    "gaxios": {
+      "uuid": "^11.1.1"
+    },
+    "googleapis-common": {
+      "uuid": "^11.1.1"
+    },
+    "@nestjs/swagger": {
+      "js-yaml": "^4.2.0"
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.2",

--- a/src/attendance/services/fellowship-attendance.service.spec.ts
+++ b/src/attendance/services/fellowship-attendance.service.spec.ts
@@ -1,0 +1,359 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { FellowshipAttendanceService } from './fellowship-attendance.service';
+import { Connection } from 'typeorm';
+import { TenantContext } from '../../shared/tenant/tenant-context';
+import { FellowshipSchedule } from '../entities/fellowship-schedule.entity';
+import { FellowshipInstance } from '../entities/fellowship-instance.entity';
+import { FellowshipAttendance } from '../entities/fellowship-attendance.entity';
+import Contact from '../../crm/entities/contact.entity';
+import Person from '../../crm/entities/person.entity';
+import GroupMembership from '../../groups/entities/groupMembership.entity';
+import { GroupRole } from '../../groups/enums/groupRole';
+import { GroupCategoryPurpose } from '../../groups/enums/groups';
+
+describe('FellowshipAttendanceService', () => {
+  let service: FellowshipAttendanceService;
+  let mockScheduleRepo: any;
+  let mockInstanceRepo: any;
+  let mockAttendanceRepo: any;
+  let mockContactRepo: any;
+  let mockMembershipRepo: any;
+  let mockConnection: any;
+  let mockTenantContext: any;
+
+  // Shared chainable query builder mock — tests override getRawMany per case
+  let mockQb: any;
+
+  const TENANT_ID = 1;
+  const CONTACT_ID = 42;
+
+  beforeEach(async () => {
+    mockQb = {
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+      getCount: jest.fn().mockResolvedValue(0),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+
+    mockScheduleRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((dto) => dto),
+      save: jest.fn((entity) => Promise.resolve({ id: 99, ...entity })),
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+    };
+    mockInstanceRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((dto) => dto),
+      save: jest.fn((entity) => Promise.resolve({ id: 77, ...entity })),
+    };
+    mockAttendanceRepo = {
+      create: jest.fn((dto) => dto),
+      save: jest.fn(),
+    };
+    mockContactRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+    };
+    mockMembershipRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+    };
+
+    mockConnection = {
+      getRepository: jest.fn((entity) => {
+        if (entity === FellowshipSchedule) return mockScheduleRepo;
+        if (entity === FellowshipInstance) return mockInstanceRepo;
+        if (entity === FellowshipAttendance) return mockAttendanceRepo;
+        if (entity === Contact) return mockContactRepo;
+        if (entity === Person) return {};
+        if (entity === GroupMembership) return mockMembershipRepo;
+        return {};
+      }),
+      transaction: jest.fn((fn) =>
+        fn({
+          save: jest.fn(),
+          find: jest.fn().mockResolvedValue([]),
+          remove: jest.fn(),
+          count: jest.fn().mockResolvedValue(0),
+          update: jest.fn(),
+          increment: jest.fn(),
+          create: jest.fn((_, dto) => dto),
+        }),
+      ),
+    };
+
+    mockTenantContext = {
+      requireTenant: jest.fn().mockReturnValue(TENANT_ID),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FellowshipAttendanceService,
+        { provide: 'CONNECTION', useValue: mockConnection },
+        { provide: TenantContext, useValue: mockTenantContext },
+      ],
+    }).compile();
+
+    service = module.get<FellowshipAttendanceService>(
+      FellowshipAttendanceService,
+    );
+  });
+
+  describe('getMyMembers', () => {
+    it('returns empty array when contact leads no fellowship groups', async () => {
+      mockQb.getRawMany.mockResolvedValue([]); // no fellowship group IDs
+
+      const result = await service.getMyMembers(CONTACT_ID);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when fellowship group has no active members', async () => {
+      mockQb.getRawMany
+        .mockResolvedValueOnce([{ groupId: 10 }]) // leads group 10
+        .mockResolvedValue([]); // no members
+      mockMembershipRepo.find.mockResolvedValue([]); // Step 2: no memberships
+
+      const result = await service.getMyMembers(CONTACT_ID);
+
+      expect(result).toEqual([]);
+    });
+
+    it('queries only fellowship groups (purpose = FELLOWSHIP) for the leader', async () => {
+      mockQb.getRawMany.mockResolvedValue([]); // short-circuits early
+
+      await service.getMyMembers(CONTACT_ID);
+
+      const qbCalls = mockMembershipRepo.createQueryBuilder.mock.calls;
+      expect(qbCalls.length).toBeGreaterThan(0);
+      // The andWhere for fellowship purpose must be applied
+      const andWhereCalls = mockQb.andWhere.mock.calls.map((c) => c[0]);
+      expect(andWhereCalls).toContain('c.purpose = :purpose');
+    });
+
+    it('resolves member contact details for found members', async () => {
+      const memberContactIds = [51, 52];
+      mockQb.getRawMany
+        .mockResolvedValueOnce([{ groupId: 10 }]) // Step 1: leads group 10
+        .mockResolvedValueOnce([
+          // Step 3: contact query
+          { id: 51, firstName: 'Jane', lastName: 'Doe', avatar: null },
+          { id: 52, firstName: 'John', lastName: 'Doe', avatar: null },
+        ]);
+      mockMembershipRepo.find.mockResolvedValue(
+        memberContactIds.map((contactId) => ({ contactId })),
+      );
+
+      const result = await service.getMyMembers(CONTACT_ID);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getMySchedule', () => {
+    it('returns { exists: false } when contact leads no fellowship groups', async () => {
+      mockQb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.getMySchedule(CONTACT_ID);
+
+      expect(result).toMatchObject({ exists: false });
+      expect(result).toHaveProperty('weekdays');
+    });
+
+    it('returns { exists: false } when no active schedule is configured', async () => {
+      mockQb.getRawMany.mockResolvedValue([{ groupId: 10 }]);
+      mockScheduleRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getMySchedule(CONTACT_ID);
+
+      expect(result).toMatchObject({ exists: false });
+    });
+
+    it('returns schedule details when an active schedule exists', async () => {
+      mockQb.getRawMany.mockResolvedValue([{ groupId: 10 }]);
+      mockScheduleRepo.findOne.mockResolvedValue({
+        id: 5,
+        meetingDay: 3, // Wednesday
+        startTime: '18:00:00',
+        frequency: 'weekly',
+        fellowshipGroupId: 10,
+      });
+
+      const result = await service.getMySchedule(CONTACT_ID);
+
+      expect(result).toMatchObject({
+        exists: true,
+        id: 5,
+        day: 3,
+        label: 'Wednesdays',
+        startTime: '18:00:00',
+        frequency: 'weekly',
+        fellowshipGroupId: 10,
+      });
+    });
+
+    it('is scoped to direct fellowship leaders — non-leaders get { exists: false }', async () => {
+      // A FOB leader is not a fellowship group leader, so getRawMany returns []
+      mockQb.getRawMany.mockResolvedValue([]);
+
+      const result = await service.getMySchedule(99 /* FOB leader contactId */);
+
+      // Must return exists:false, not throw or expose other groups' schedules
+      expect(result).toMatchObject({ exists: false });
+      expect(mockScheduleRepo.findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordReportAttendance', () => {
+    it('throws when submitter leads no fellowship group', async () => {
+      mockQb.getRawMany.mockResolvedValue([]);
+
+      await expect(
+        service.recordReportAttendance(CONTACT_ID, 1, 3, [51, 52]),
+      ).rejects.toThrow('No fellowship group found for submitting user');
+    });
+
+    it('creates a schedule when none exists for the fellowship group', async () => {
+      mockQb.getRawMany.mockResolvedValue([{ groupId: 10 }]);
+      mockScheduleRepo.findOne.mockResolvedValue(null); // no existing schedule
+      mockInstanceRepo.findOne.mockResolvedValue({ id: 77 });
+
+      await service.recordReportAttendance(CONTACT_ID, 1, 3, [51]);
+
+      expect(mockScheduleRepo.save).toHaveBeenCalled();
+    });
+
+    it('reuses an existing schedule when one is already configured', async () => {
+      const existingSchedule = { id: 5, fellowshipGroupId: 10 };
+      mockQb.getRawMany.mockResolvedValue([{ groupId: 10 }]);
+      mockScheduleRepo.findOne.mockResolvedValue(existingSchedule);
+      mockInstanceRepo.findOne.mockResolvedValue({ id: 77 });
+
+      await service.recordReportAttendance(CONTACT_ID, 1, 3, [51]);
+
+      expect(mockScheduleRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('replaces existing member attendance records on re-submission', async () => {
+      mockQb.getRawMany.mockResolvedValue([{ groupId: 10 }]);
+      mockScheduleRepo.findOne.mockResolvedValue({ id: 5 });
+      mockInstanceRepo.findOne.mockResolvedValue({ id: 77 });
+
+      const existingRecord = {
+        id: 1,
+        fellowshipInstanceId: 77,
+        isMember: true,
+      };
+      const mockManager = {
+        save: jest.fn(),
+        find: jest.fn().mockResolvedValue([existingRecord]),
+        remove: jest.fn(),
+        count: jest.fn().mockResolvedValue(0),
+        update: jest.fn(),
+        increment: jest.fn(),
+        create: jest.fn((_, dto) => dto),
+      };
+      mockConnection.transaction.mockImplementation((fn) => fn(mockManager));
+
+      await service.recordReportAttendance(CONTACT_ID, 1, 3, [51, 52]);
+
+      expect(mockManager.remove).toHaveBeenCalledWith(FellowshipAttendance, [
+        existingRecord,
+      ]);
+      expect(mockManager.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('createSchedule', () => {
+    it('saves a new schedule with the current tenant', async () => {
+      const dto = {
+        fellowshipGroupId: 10,
+        meetingDay: 3,
+        startTime: '18:00',
+        frequency: 'weekly',
+      };
+      const saved = { id: 99, ...dto };
+      mockScheduleRepo.save.mockResolvedValue(saved);
+
+      const result = await service.createSchedule(dto as any, 1);
+
+      expect(mockTenantContext.requireTenant).toHaveBeenCalled();
+      expect(mockScheduleRepo.save).toHaveBeenCalled();
+      expect(result).toEqual(saved);
+    });
+  });
+
+  describe('updateSchedule', () => {
+    it('throws NotFoundException when schedule does not exist', async () => {
+      mockScheduleRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateSchedule(999, { meetingDay: 2 } as any, CONTACT_ID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when contact is not the fellowship leader', async () => {
+      mockScheduleRepo.findOne.mockResolvedValue({
+        id: 5,
+        fellowshipGroupId: 10,
+      });
+      mockQb.getCount.mockResolvedValue(0); // not a leader
+
+      await expect(
+        service.updateSchedule(5, { meetingDay: 4 } as any, CONTACT_ID),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('saves changes when contact is the fellowship leader', async () => {
+      const schedule = { id: 5, fellowshipGroupId: 10, meetingDay: 3 };
+      mockScheduleRepo.findOne.mockResolvedValue(schedule);
+      mockQb.getCount.mockResolvedValue(1); // is leader
+      mockScheduleRepo.save.mockResolvedValue({ ...schedule, meetingDay: 4 });
+
+      const result = await service.updateSchedule(
+        5,
+        { meetingDay: 4 } as any,
+        CONTACT_ID,
+      );
+
+      expect(mockScheduleRepo.save).toHaveBeenCalled();
+      expect(result.meetingDay).toBe(4);
+    });
+  });
+
+  describe('getTodayFellowship', () => {
+    it('throws NotFoundException when no active schedule exists for the group', async () => {
+      mockScheduleRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getTodayFellowship(10)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException when the schedule day does not match today', async () => {
+      const today = new Date().getDay();
+      const wrongDay = (today + 1) % 7; // tomorrow
+      mockScheduleRepo.findOne.mockResolvedValue({
+        id: 5,
+        meetingDay: wrongDay,
+      });
+
+      await expect(service.getTodayFellowship(10)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/attendance/services/fellowship-attendance.service.spec.ts
+++ b/src/attendance/services/fellowship-attendance.service.spec.ts
@@ -160,6 +160,16 @@ describe('FellowshipAttendanceService', () => {
       const result = await service.getMyMembers(CONTACT_ID);
 
       expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: 51,
+        firstName: 'Jane',
+        lastName: 'Doe',
+      });
+      expect(result[1]).toMatchObject({
+        id: 52,
+        firstName: 'John',
+        lastName: 'Doe',
+      });
     });
   });
 
@@ -291,7 +301,9 @@ describe('FellowshipAttendanceService', () => {
       const result = await service.createSchedule(dto as any, 1);
 
       expect(mockTenantContext.requireTenant).toHaveBeenCalled();
-      expect(mockScheduleRepo.save).toHaveBeenCalled();
+      expect(mockScheduleRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ tenant: { id: TENANT_ID } }),
+      );
       expect(result).toEqual(saved);
     });
   });
@@ -354,6 +366,24 @@ describe('FellowshipAttendanceService', () => {
       await expect(service.getTodayFellowship(10)).rejects.toThrow(
         BadRequestException,
       );
+    });
+
+    it('returns the fellowship instance when schedule day matches today', async () => {
+      const today = new Date().getDay();
+      const existingInstance = {
+        id: 77,
+        scheduleId: 5,
+        fellowshipGroupId: 10,
+        meetingDate: new Date().toISOString().split('T')[0],
+        schedule: { id: 5 },
+        fellowshipGroup: { id: 10 },
+      };
+      mockScheduleRepo.findOne.mockResolvedValue({ id: 5, meetingDay: today });
+      mockInstanceRepo.findOne.mockResolvedValue(existingInstance);
+
+      const result = await service.getTodayFellowship(10);
+
+      expect(result).toEqual(existingInstance);
     });
   });
 });

--- a/src/crm/contacts.service.spec.ts
+++ b/src/crm/contacts.service.spec.ts
@@ -6,6 +6,7 @@ import { AddressesService } from './addresses.service';
 import { GroupTreeService } from '../groups/services/group-tree.service';
 import { AppLogger } from '../utils/app-logger.service';
 import { GroupsMembershipService } from '../groups/services/group-membership.service';
+import { TenantContext } from '../shared/tenant/tenant-context';
 import { Connection, Repository, TreeRepository } from 'typeorm';
 import Contact from './entities/contact.entity';
 import Person from './entities/person.entity';
@@ -105,6 +106,10 @@ describe('ContactsService', () => {
         {
           provide: GroupsMembershipService,
           useValue: { addMember: jest.fn() },
+        },
+        {
+          provide: TenantContext,
+          useValue: { requireTenant: jest.fn().mockReturnValue(1) },
         },
       ],
     }).compile();

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -173,12 +173,25 @@ export class ContactImportController {
   @Post('groupLeaders')
   @UseInterceptors(FileInterceptor('file'))
   async uploadGroupLeaders(@UploadedFile() file: Express.Multer.File) {
-    const list = parseCsv(file.buffer, {
-      columns: true,
-      skip_empty_lines: true,
-      delimiter: ',',
-      relax_column_count: false,
-    }) as any[];
+    if (!file) {
+      throw new BadRequestException({ message: 'No file was uploaded.' });
+    }
+
+    let list: any[];
+    try {
+      list = parseCsv(file.buffer, {
+        columns: true,
+        skip_empty_lines: true,
+        delimiter: ',',
+        relax_column_count: false,
+      }) as any[];
+    } catch (parseErr) {
+      throw new BadRequestException({
+        message:
+          'The CSV file could not be parsed. Please ensure every row has a value for each column and that the file uses comma-separated format.',
+      });
+    }
+
     const created = [];
     const notCreated = [];
     for (const [index, uploadedContact] of list.entries()) {

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -12,7 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { CsvParser } from 'nest-csv-parser';
+import { parse as parseCsv } from 'csv-parse/sync';
 import { ContactsService } from '../contacts.service';
 import { Express } from 'express';
 import { Repository, Connection } from 'typeorm';
@@ -33,15 +33,6 @@ import { generateRandomPassword } from 'src/utils/stringHelpers';
 import { TenantContextInterceptor } from 'src/interceptors/tenant-context.interceptor';
 import { ServiceRecordingService } from 'src/service-recording/service-recording.service';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Duplex = require('stream').Duplex; // core NodeJS API
-function bufferToStream(buffer) {
-  const stream = new Duplex();
-  stream.push(buffer);
-  stream.push(null);
-  return stream;
-}
-
 class Entity {
   name: string;
   phone: string;
@@ -58,7 +49,6 @@ export class ContactImportController {
   constructor(
     @Inject('CONNECTION') connection: Connection,
     private readonly service: ContactsService,
-    private readonly csvParser: CsvParser,
     private readonly groupMembershipService: GroupsMembershipService,
     private readonly groupsService: GroupsService,
     private readonly usersService: UsersService,
@@ -85,23 +75,20 @@ export class ContactImportController {
         req.tenantId,
       );
 
-    let parsedData: any;
+    let list: any[];
     try {
-      parsedData = await this.csvParser.parse(
-        bufferToStream(file.buffer),
-        Entity,
-        null,
-        null,
-        { strict: true, separator: ',' },
-      );
+      list = parseCsv(file.buffer, {
+        columns: true,
+        skip_empty_lines: true,
+        delimiter: ',',
+        relax_column_count: false,
+      }) as any[];
     } catch (parseErr) {
       throw new BadRequestException({
         message:
           'The CSV file could not be parsed. Please ensure every row has a value for each column and that the file uses comma-separated format.',
       });
     }
-
-    const { list } = parsedData;
     const created = [];
     const notCreated = [];
     const errors: string[] = [];
@@ -186,14 +173,12 @@ export class ContactImportController {
   @Post('groupLeaders')
   @UseInterceptors(FileInterceptor('file'))
   async uploadGroupLeaders(@UploadedFile() file: Express.Multer.File) {
-    const parsedData = await this.csvParser.parse(
-      bufferToStream(file.buffer),
-      Entity,
-      null,
-      null,
-      { strict: true, separator: ',' },
-    );
-    const { list } = parsedData;
+    const list = parseCsv(file.buffer, {
+      columns: true,
+      skip_empty_lines: true,
+      delimiter: ',',
+      relax_column_count: false,
+    }) as any[];
     const created = [];
     const notCreated = [];
     for (const [index, uploadedContact] of list.entries()) {

--- a/src/crm/crm.module.ts
+++ b/src/crm/crm.module.ts
@@ -3,7 +3,6 @@ import { HttpModule } from '@nestjs/axios';
 import { ContactsService } from './contacts.service';
 import { ContactsController } from './contollers/contacts.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CsvModule } from 'nest-csv-parser';
 import { PeopleController } from './contollers/people.controller';
 import { CompaniesController } from './contollers/companies.controller';
 import { EmailsController } from './contollers/emails.controller';
@@ -34,12 +33,7 @@ import { ServiceRecordingService } from 'src/service-recording/service-recording
 
 @Global()
 @Module({
-  imports: [
-    CsvModule,
-    HttpModule,
-    TypeOrmModule.forFeature(appEntities),
-    VendorModule,
-  ],
+  imports: [HttpModule, TypeOrmModule.forFeature(appEntities), VendorModule],
   providers: [
     ContactsService,
     GoogleService,

--- a/src/finance/services/transactions.service.ts
+++ b/src/finance/services/transactions.service.ts
@@ -98,12 +98,25 @@ export class TransactionsService {
     });
 
     const workbook = new Workbook();
-    await workbook.xlsx.load(file.buffer);
+    try {
+      await workbook.xlsx.load(file.buffer);
+    } catch {
+      throw new BadRequestException(
+        'The uploaded file could not be read. Please upload a valid .xlsx file.',
+      );
+    }
     const worksheet = workbook.worksheets[0];
+    if (!worksheet) {
+      throw new BadRequestException(
+        'The uploaded workbook contains no sheets.',
+      );
+    }
     const headers: string[] = [];
     worksheet
       .getRow(1)
-      .eachCell((cell) => headers.push(String(cell.value ?? '')));
+      .eachCell({ includeEmpty: true }, (cell) =>
+        headers.push(String(cell.value ?? '')),
+      );
     const rows: any[] = [];
     worksheet.eachRow((row, rowNumber) => {
       if (rowNumber === 1) return;

--- a/src/finance/services/transactions.service.ts
+++ b/src/finance/services/transactions.service.ts
@@ -12,7 +12,7 @@ import {
   MoreThanOrEqual,
   LessThanOrEqual,
 } from 'typeorm';
-import * as XLSX from 'xlsx';
+import { Workbook } from 'exceljs';
 import Transaction from '../entities/transaction.entity';
 import FinancialAccount from '../entities/financial-account.entity';
 import {
@@ -97,10 +97,22 @@ export class TransactionsService {
       metadata: { accountId, fileName: file.originalname },
     });
 
-    const workbook = XLSX.read(file.buffer, { type: 'buffer' });
-    const sheetName = workbook.SheetNames[0];
-    const worksheet = workbook.Sheets[sheetName];
-    const rows: any[] = XLSX.utils.sheet_to_json(worksheet);
+    const workbook = new Workbook();
+    await workbook.xlsx.load(file.buffer);
+    const worksheet = workbook.worksheets[0];
+    const headers: string[] = [];
+    worksheet
+      .getRow(1)
+      .eachCell((cell) => headers.push(String(cell.value ?? '')));
+    const rows: any[] = [];
+    worksheet.eachRow((row, rowNumber) => {
+      if (rowNumber === 1) return;
+      const obj: any = {};
+      headers.forEach((header, i) => {
+        obj[header] = row.getCell(i + 1).value;
+      });
+      rows.push(obj);
+    });
 
     const dateColumn = options.dateColumn || 'Date';
     const amountColumn = options.amountColumn || 'Amount';

--- a/src/groups/controllers/group-membership.controller.spec.ts
+++ b/src/groups/controllers/group-membership.controller.spec.ts
@@ -72,7 +72,7 @@ describe('Group Membership', () => {
     };
     const result = await controller.create(dto);
     expect(result).toEqual({
-      message: 'Operation succeeded',
+      message: 'Members added successfully',
       inserted: dto.members.length,
     });
   });

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -14,8 +14,19 @@ describe('GroupsMembershipService', () => {
   let mockGroupRepository: any;
   let mockAppLogger: any;
   let mockContextLogger: any;
+  let mockQb: any;
 
   beforeEach(async () => {
+    mockQb = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+
     mockMembershipRepository = {
       find: jest.fn().mockResolvedValue([]),
       findOne: jest.fn(),
@@ -30,6 +41,7 @@ describe('GroupsMembershipService', () => {
       create: jest.fn((membership) => membership),
       update: jest.fn(),
       delete: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
     };
 
     mockGroupRepository = {
@@ -51,6 +63,10 @@ describe('GroupsMembershipService', () => {
       getRepository: jest.fn().mockImplementation((entity) => {
         if (entity === Group) return mockGroupRepository;
         return mockMembershipRepository;
+      }),
+      getTreeRepository: jest.fn().mockReturnValue({
+        ...mockGroupRepository,
+        findDescendants: jest.fn().mockResolvedValue([]),
       }),
       createQueryBuilder: jest.fn().mockReturnValue({
         update: jest.fn().mockReturnThis(),
@@ -91,7 +107,7 @@ describe('GroupsMembershipService', () => {
 
   it('should initialize repositories', () => {
     expect(mockConnection.getRepository).toHaveBeenCalledWith(GroupMembership);
-    expect(mockConnection.getRepository).toHaveBeenCalledWith(Group);
+    expect(mockConnection.getTreeRepository).toHaveBeenCalledWith(Group);
     expect(mockAppLogger.createContextLogger).toHaveBeenCalledWith(
       'GroupsMembershipService',
     );
@@ -177,6 +193,7 @@ describe('GroupsMembershipService', () => {
     const parentGroup = { id: 9, name: 'Parent Group' };
     mockGroupRepository.findOneOrFail.mockResolvedValue(parentGroup);
     mockGroupRepository.query.mockResolvedValue([{ id: 10 }]);
+    mockQb.getRawMany.mockResolvedValue([{ contactId: 51 }, { contactId: 52 }]);
     mockMembershipRepository.find.mockResolvedValue([
       {
         id: 101,

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -15,8 +15,11 @@ describe('GroupsMembershipService', () => {
   let mockAppLogger: any;
   let mockContextLogger: any;
   let mockQb: any;
+  let mockFindDescendants: jest.Mock;
 
   beforeEach(async () => {
+    mockFindDescendants = jest.fn().mockResolvedValue([]);
+
     mockQb = {
       select: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
@@ -66,7 +69,7 @@ describe('GroupsMembershipService', () => {
       }),
       getTreeRepository: jest.fn().mockReturnValue({
         ...mockGroupRepository,
-        findDescendants: jest.fn().mockResolvedValue([]),
+        findDescendants: mockFindDescendants,
       }),
       createQueryBuilder: jest.fn().mockReturnValue({
         update: jest.fn().mockReturnThis(),
@@ -192,7 +195,7 @@ describe('GroupsMembershipService', () => {
   it('should list memberships for a group and its descendants', async () => {
     const parentGroup = { id: 9, name: 'Parent Group' };
     mockGroupRepository.findOneOrFail.mockResolvedValue(parentGroup);
-    mockGroupRepository.query.mockResolvedValue([{ id: 10 }]);
+    mockFindDescendants.mockResolvedValue([{ id: 10, name: 'Child Group' }]);
     mockQb.getRawMany.mockResolvedValue([{ contactId: 51 }, { contactId: 52 }]);
     mockMembershipRepository.find.mockResolvedValue([
       {
@@ -234,6 +237,7 @@ describe('GroupsMembershipService', () => {
     expect(mockGroupRepository.findOneOrFail).toHaveBeenCalledWith({
       where: { id: 9 },
     });
+    expect(mockFindDescendants).toHaveBeenCalledWith(parentGroup);
     expect(memberships).toEqual([
       expect.objectContaining({
         id: 101,

--- a/src/groups/services/group-permissions.service.spec.ts
+++ b/src/groups/services/group-permissions.service.spec.ts
@@ -1,0 +1,183 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupPermissionsService } from './group-permissions.service';
+import { Connection } from 'typeorm';
+import Group from '../entities/group.entity';
+import GroupMembership from '../entities/groupMembership.entity';
+import { GroupRole } from '../enums/groupRole';
+import ClientFriendlyException from '../../shared/exceptions/client-friendly.exception';
+import { roleAdmin } from '../../auth/constants';
+
+describe('GroupPermissionsService', () => {
+  let service: GroupPermissionsService;
+  let mockMembershipRepo: any;
+  let mockGroupRepo: any;
+  let mockTreeRepo: any;
+
+  const adminUser = { contactId: 1, roles: [roleAdmin.role] };
+  const regularUser = { contactId: 2, roles: [] };
+
+  beforeEach(async () => {
+    mockMembershipRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    mockGroupRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+    mockTreeRepo = {
+      findAncestors: jest.fn().mockResolvedValue([]),
+      findDescendants: jest.fn().mockResolvedValue([]),
+    };
+
+    const mockConnection = {
+      getRepository: jest.fn((entity) => {
+        if (entity === Group) return mockGroupRepo;
+        return mockMembershipRepo;
+      }),
+      getTreeRepository: jest.fn().mockReturnValue(mockTreeRepo),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GroupPermissionsService,
+        { provide: 'CONNECTION', useValue: mockConnection },
+      ],
+    }).compile();
+
+    service = module.get<GroupPermissionsService>(GroupPermissionsService);
+  });
+
+  describe('hasPermissionForGroup', () => {
+    it('returns true for admin users without hitting the database', async () => {
+      const result = await service.hasPermissionForGroup(adminUser, 42);
+
+      expect(result).toBe(true);
+      expect(mockMembershipRepo.count).not.toHaveBeenCalled();
+    });
+
+    it('returns true when user is a direct leader of the group', async () => {
+      mockMembershipRepo.count.mockResolvedValue(1);
+
+      const result = await service.hasPermissionForGroup(regularUser, 42);
+
+      expect(result).toBe(true);
+      expect(mockMembershipRepo.count).toHaveBeenCalledWith({
+        where: {
+          contactId: regularUser.contactId,
+          role: GroupRole.Leader,
+          groupId: 42,
+        },
+      });
+    });
+
+    it('returns true when user leads an ancestor group', async () => {
+      const targetGroup = { id: 42, name: 'MC' } as Group;
+      const parentGroup = { id: 10, name: 'Zone' } as Group;
+      mockMembershipRepo.count
+        .mockResolvedValueOnce(0) // not a direct leader
+        .mockResolvedValueOnce(1); // leads an ancestor
+      mockGroupRepo.findOne.mockResolvedValue(targetGroup);
+      mockTreeRepo.findAncestors.mockResolvedValue([parentGroup]);
+
+      const result = await service.hasPermissionForGroup(regularUser, 42);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when group does not exist', async () => {
+      mockMembershipRepo.count.mockResolvedValue(0);
+      mockGroupRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.hasPermissionForGroup(regularUser, 999);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when user leads neither the group nor any ancestor', async () => {
+      const targetGroup = { id: 42 } as Group;
+      mockMembershipRepo.count.mockResolvedValue(0);
+      mockGroupRepo.findOne.mockResolvedValue(targetGroup);
+      mockTreeRepo.findAncestors.mockResolvedValue([{ id: 10 }]);
+
+      const result = await service.hasPermissionForGroup(regularUser, 42);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('assertPermissionForGroup', () => {
+    it('does not throw when user has permission', async () => {
+      mockMembershipRepo.count.mockResolvedValue(1);
+
+      await expect(
+        service.assertPermissionForGroup(regularUser, 42),
+      ).resolves.not.toThrow();
+    });
+
+    it('throws ClientFriendlyException when user lacks permission', async () => {
+      mockMembershipRepo.count.mockResolvedValue(0);
+      mockGroupRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.assertPermissionForGroup(regularUser, 42),
+      ).rejects.toThrow(ClientFriendlyException);
+    });
+  });
+
+  describe('getUserGroupIds', () => {
+    it('returns direct and descendant group IDs', async () => {
+      mockMembershipRepo.find.mockResolvedValue([
+        { groupId: 10 },
+        { groupId: 20 },
+      ]);
+      mockTreeRepo.findDescendants
+        .mockResolvedValueOnce([{ id: 11 }, { id: 12 }]) // children of group 10
+        .mockResolvedValueOnce([]); // group 20 has no children
+
+      const ids = await service.getUserGroupIds(regularUser);
+
+      expect(ids).toEqual(expect.arrayContaining([10, 11, 12, 20]));
+      expect(ids).toHaveLength(4);
+    });
+
+    it('deduplicates group IDs when a group appears in multiple hierarchies', async () => {
+      mockMembershipRepo.find.mockResolvedValue([
+        { groupId: 10 },
+        { groupId: 20 },
+      ]);
+      mockTreeRepo.findDescendants
+        .mockResolvedValueOnce([{ id: 30 }])
+        .mockResolvedValueOnce([{ id: 30 }]); // same child appears under both groups
+
+      const ids = await service.getUserGroupIds(regularUser);
+
+      expect(ids.filter((id) => id === 30)).toHaveLength(1);
+    });
+
+    it('returns empty array when user has no group memberships', async () => {
+      mockMembershipRepo.find.mockResolvedValue([]);
+
+      const ids = await service.getUserGroupIds(regularUser);
+
+      expect(ids).toEqual([]);
+    });
+  });
+
+  describe('getUserIsMemberLeaderGroupIds', () => {
+    it('includes groups where user is a member (not just leader)', async () => {
+      mockMembershipRepo.find.mockResolvedValue([{ groupId: 5 }]);
+      mockTreeRepo.findDescendants.mockResolvedValue([]);
+
+      const ids = await service.getUserIsMemberLeaderGroupIds(regularUser);
+
+      expect(ids).toContain(5);
+      expect(mockMembershipRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contactId: regularUser.contactId,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/groups/services/group-tree.service.spec.ts
+++ b/src/groups/services/group-tree.service.spec.ts
@@ -1,0 +1,172 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { GroupTreeService } from './group-tree.service';
+import { Connection } from 'typeorm';
+import Group from '../entities/group.entity';
+import GroupCategory from '../entities/groupCategory.entity';
+
+describe('GroupTreeService', () => {
+  let service: GroupTreeService;
+  let mockGroupRepo: any;
+  let mockTreeRepo: any;
+  let mockCategoryRepo: any;
+  let mockCache: any;
+
+  beforeEach(async () => {
+    mockGroupRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    mockTreeRepo = {
+      findDescendants: jest.fn().mockResolvedValue([]),
+      findAncestors: jest.fn().mockResolvedValue([]),
+    };
+    mockCategoryRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    };
+    mockCache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockConnection = {
+      getRepository: jest.fn((entity) => {
+        if (entity === GroupCategory) return mockCategoryRepo;
+        return mockGroupRepo;
+      }),
+      getTreeRepository: jest.fn().mockReturnValue(mockTreeRepo),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GroupTreeService,
+        { provide: 'CONNECTION', useValue: mockConnection },
+        { provide: CACHE_MANAGER, useValue: mockCache },
+      ],
+    }).compile();
+
+    service = module.get<GroupTreeService>(GroupTreeService);
+  });
+
+  describe('getGroupAndAllChildren', () => {
+    it('returns empty array for empty input', async () => {
+      const result = await service.getGroupAndAllChildren([]);
+      expect(result).toEqual([]);
+      expect(mockCache.get).not.toHaveBeenCalled();
+    });
+
+    it('returns cached result when available', async () => {
+      mockCache.get.mockResolvedValue([1, 2, 3]);
+
+      const result = await service.getGroupAndAllChildren([1]);
+
+      expect(result).toEqual([1, 2, 3]);
+      expect(mockGroupRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('calculates and caches descendants on cache miss', async () => {
+      const parentGroup = { id: 10 } as Group;
+      mockGroupRepo.findOne.mockResolvedValue(parentGroup);
+      mockTreeRepo.findDescendants.mockResolvedValue([{ id: 11 }, { id: 12 }]);
+
+      const result = await service.getGroupAndAllChildren([10]);
+
+      expect(result).toEqual(expect.arrayContaining([10, 11, 12]));
+      expect(mockCache.set).toHaveBeenCalled();
+    });
+
+    it('gracefully skips groups that do not exist', async () => {
+      mockGroupRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getGroupAndAllChildren([999]);
+
+      expect(result).toEqual([999]);
+    });
+  });
+
+  describe('getCategoriesForGroups', () => {
+    it('returns empty array for empty input', async () => {
+      const result = await service.getCategoriesForGroups([]);
+      expect(result).toEqual([]);
+    });
+
+    it('returns cached result when available', async () => {
+      mockCache.get.mockResolvedValue(['fellowship', 'location']);
+
+      const result = await service.getCategoriesForGroups([1]);
+
+      expect(result).toEqual(['fellowship', 'location']);
+      expect(mockGroupRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('collects categories from groups and their ancestors', async () => {
+      const category1 = { name: 'fellowship' } as GroupCategory;
+      const category2 = { name: 'location' } as GroupCategory;
+      const group = { id: 1, category: category1 } as Group;
+      const ancestorGroup = {
+        id: 10,
+        category: category2,
+      } as Group;
+
+      mockGroupRepo.find.mockResolvedValue([group]);
+      mockTreeRepo.findAncestors.mockResolvedValue([{ id: 10 }]);
+      mockGroupRepo.findOne.mockResolvedValue(ancestorGroup);
+
+      const result = await service.getCategoriesForGroups([1]);
+
+      expect(result).toEqual(
+        expect.arrayContaining(['fellowship', 'location']),
+      );
+    });
+
+    it('deduplicates categories when multiple groups share the same category', async () => {
+      const category = { name: 'fellowship' } as GroupCategory;
+      const groups = [
+        { id: 1, category },
+        { id: 2, category },
+      ] as Group[];
+
+      mockGroupRepo.find.mockResolvedValue(groups);
+      mockTreeRepo.findAncestors.mockResolvedValue([]);
+
+      const result = await service.getCategoriesForGroups([1, 2]);
+
+      expect(result.filter((c) => c === 'fellowship')).toHaveLength(1);
+    });
+  });
+
+  describe('clearGroupTreeCache', () => {
+    it('deletes cache entries for specified group IDs', async () => {
+      await service.clearGroupTreeCache([1, 2]);
+
+      expect(mockCache.del).toHaveBeenCalledTimes(2);
+    });
+
+    it('logs a warning when called with no group IDs', async () => {
+      await service.clearGroupTreeCache([]);
+
+      expect(mockCache.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getReportAccessibleGroups', () => {
+    it('returns separate canSubmitTo and canViewFrom sets', async () => {
+      mockCache.get.mockResolvedValue(null);
+      const manageableGroup = { id: 10 } as Group;
+      const viewableGroup = { id: 20 } as Group;
+
+      mockGroupRepo.findOne
+        .mockResolvedValueOnce(manageableGroup)
+        .mockResolvedValueOnce(viewableGroup);
+      mockTreeRepo.findDescendants
+        .mockResolvedValueOnce([{ id: 11 }])
+        .mockResolvedValueOnce([{ id: 21 }]);
+
+      const result = await service.getReportAccessibleGroups([10], [20]);
+
+      expect(result.canSubmitTo).toEqual(expect.arrayContaining([10, 11]));
+      expect(result.canViewFrom).toEqual(expect.arrayContaining([20, 21]));
+    });
+  });
+});

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { ReportsService } from './reports.service';
 import { UsersService } from '../users/users.service';
 import { GroupsService } from '../groups/services/groups.service';
@@ -9,6 +10,7 @@ import { TenantContext } from '../shared/tenant/tenant-context';
 import { FellowshipAttendanceService } from '../attendance/services/fellowship-attendance.service';
 import { Connection, Repository, TreeRepository } from 'typeorm';
 import { Report } from './entities/report.entity';
+import { ReportStatus } from './enums/report.enum';
 import { ReportSubmission } from './entities/report.submission.entity';
 import { ReportSubmissionData } from './entities/report.submission.data.entity';
 import { User } from '../users/entities/user.entity';
@@ -123,6 +125,8 @@ describe('ReportsService', () => {
         endTracking: jest.fn(),
         apiLog: jest.fn(),
         business: jest.fn(),
+        dataAccess: jest.fn(),
+        security: jest.fn(),
         error: jest.fn(),
       }),
     };
@@ -188,5 +192,290 @@ describe('ReportsService', () => {
     expect(mockConnection.getRepository).toHaveBeenCalledWith(ReportSubmission);
     expect(mockConnection.getRepository).toHaveBeenCalledWith(User);
     expect(mockConnection.getTreeRepository).toHaveBeenCalledWith(Group);
+  });
+
+  describe('getReport', () => {
+    it('returns the report when it exists and is active', async () => {
+      const mockReport = {
+        id: 1,
+        name: 'Weekly Report',
+        status: ReportStatus.ACTIVE,
+        fields: [],
+      } as unknown as Report;
+      mockRepositories.report.findOne.mockResolvedValue(mockReport);
+
+      const result = await service.getReport(1);
+
+      expect(result).toEqual(mockReport);
+      expect(mockRepositories.report.findOne).toHaveBeenCalledWith({
+        where: { id: 1, status: ReportStatus.ACTIVE },
+        relations: ['fields', 'targetGroupCategory'],
+      });
+    });
+
+    it('throws NotFoundException when report does not exist', async () => {
+      mockRepositories.report.findOne.mockResolvedValue(null);
+
+      await expect(service.getReport(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getAllReports', () => {
+    it('returns all active reports without filtering when no user is provided', async () => {
+      const mockReports = [
+        { id: 1, name: 'Report A', status: ReportStatus.ACTIVE },
+        { id: 2, name: 'Report B', status: ReportStatus.ACTIVE },
+      ] as unknown as Report[];
+      mockRepositories.report.find.mockResolvedValue(mockReports);
+
+      const result = await service.getAllReports();
+
+      expect(result.reports).toHaveLength(2);
+      expect(mockRepositories.report.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: ReportStatus.ACTIVE },
+        }),
+      );
+    });
+
+    it('returns empty array when no active reports exist', async () => {
+      mockRepositories.report.find.mockResolvedValue([]);
+
+      const result = await service.getAllReports();
+
+      expect(result.reports).toEqual([]);
+    });
+  });
+
+  describe('updateReport', () => {
+    it('throws NotFoundException when report to update does not exist', async () => {
+      mockRepositories.report.update = jest.fn().mockResolvedValue(undefined);
+      mockRepositories.report.findOne.mockResolvedValue(null);
+
+      // No fields so updateReportFields is skipped and the NotFoundException path is reached
+      await expect(
+        service.updateReport(999, { name: 'New Name' } as any),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns the updated report when update succeeds', async () => {
+      const updatedReport = {
+        id: 1,
+        name: 'New Name',
+        fields: [],
+      } as unknown as Report;
+      mockRepositories.report.update = jest.fn().mockResolvedValue(undefined);
+      mockRepositories.reportField.find.mockResolvedValue([]);
+      mockRepositories.report.findOne.mockResolvedValue(updatedReport);
+
+      const result = await service.updateReport(1, {
+        name: 'New Name',
+        fields: [],
+      } as any);
+
+      expect(result).toEqual(updatedReport);
+    });
+  });
+
+  describe('getWeekNumber', () => {
+    it('returns week 1 for the first day of a month', () => {
+      expect(service.getWeekNumber(new Date('2024-01-01'))).toBe(1);
+    });
+
+    it('returns a higher week number for later dates', () => {
+      const week1 = service.getWeekNumber(new Date('2024-01-01'));
+      const week2 = service.getWeekNumber(new Date('2024-01-08'));
+      expect(week2).toBeGreaterThan(week1);
+    });
+  });
+
+  describe('getMySubmissions', () => {
+    const mockUser = { id: 7, contactId: 3 };
+
+    const makeSubmission = (id: number) => ({
+      id,
+      report: { id: 1, name: 'Weekly Report' },
+      group: { id: 10, name: 'MC Nairobi' },
+      user: { id: 7, username: 'shepherd' },
+      submittedAt: new Date('2024-06-10'),
+      submissionData: [
+        { reportField: { name: 'attendance' }, fieldValue: '25' },
+      ],
+    });
+
+    it('returns paginated submissions for the current user', async () => {
+      const subs = [makeSubmission(1), makeSubmission(2)];
+      mockRepositories.reportSubmission.find.mockResolvedValue(subs);
+      mockRepositories.reportSubmission.count = jest.fn().mockResolvedValue(2);
+
+      const result = await service.getMySubmissions(mockUser, {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.submissions).toHaveLength(2);
+      expect(result.pagination).toMatchObject({
+        total: 2,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      });
+      expect(mockRepositories.reportSubmission.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { user: { id: mockUser.id } } }),
+      );
+    });
+
+    it('filters by reportId when provided', async () => {
+      mockRepositories.reportSubmission.find.mockResolvedValue([]);
+      mockRepositories.reportSubmission.count = jest.fn().mockResolvedValue(0);
+
+      await service.getMySubmissions(mockUser, { reportId: 5 });
+
+      expect(mockRepositories.reportSubmission.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { user: { id: mockUser.id }, report: { id: 5 } },
+        }),
+      );
+    });
+
+    it('sets hasMore correctly when more pages exist', async () => {
+      mockRepositories.reportSubmission.find.mockResolvedValue(
+        Array.from({ length: 20 }, (_, i) => makeSubmission(i + 1)),
+      );
+      mockRepositories.reportSubmission.count = jest.fn().mockResolvedValue(50);
+
+      const result = await service.getMySubmissions(mockUser, {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.pagination.hasMore).toBe(true);
+    });
+
+    it('maps submission data fields into a keyed object', async () => {
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        makeSubmission(1),
+      ]);
+      mockRepositories.reportSubmission.count = jest.fn().mockResolvedValue(1);
+
+      const result = await service.getMySubmissions(mockUser, {});
+
+      expect(result.submissions[0].data).toEqual({ attendance: '25' });
+    });
+  });
+
+  describe('getMyGroupsSubmissions', () => {
+    const mockUser = { id: 7, contactId: 3 };
+
+    const makeSubmission = (id: number, groupId = 10) => ({
+      id,
+      report: { id: 1, name: 'Weekly Report' },
+      group: { id: groupId, name: 'MC Nairobi' },
+      user: { id: 7, username: 'shepherd' },
+      submittedAt: new Date('2024-06-10'),
+      submissionData: [
+        { reportField: { name: 'attendance' }, fieldValue: '30' },
+      ],
+    });
+
+    it('returns empty result when user has no accessible groups', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([]);
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+      expect(result.submissions).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+    });
+
+    it('returns submissions for all groups accessible to the user', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10, 11]);
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        makeSubmission(1, 10),
+        makeSubmission(2, 11),
+      ]);
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+      expect(result.submissions).toHaveLength(2);
+    });
+
+    it('applies date filtering when startDate/endDate are provided', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+
+      const before = new Date('2024-06-01');
+      const after = new Date('2024-06-20');
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        { ...makeSubmission(1), submittedAt: before },
+        { ...makeSubmission(2), submittedAt: after },
+      ]);
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {
+        startDate: new Date('2024-06-10'),
+        endDate: new Date('2024-06-15'),
+      });
+
+      expect(result.submissions).toHaveLength(0); // both outside the window
+    });
+
+    it('applies pagination to the filtered result set', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+      mockRepositories.reportSubmission.find.mockResolvedValue(
+        Array.from({ length: 5 }, (_, i) => makeSubmission(i + 1)),
+      );
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {
+        limit: 2,
+        offset: 0,
+      });
+
+      expect(result.submissions).toHaveLength(2);
+      expect(result.pagination).toMatchObject({
+        total: 5,
+        limit: 2,
+        hasMore: true,
+      });
+    });
+
+    it('includes column metadata when reportId is specified', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        makeSubmission(1),
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue({
+        id: 1,
+        fields: [{ name: 'attendance', label: 'Attendance Count' }],
+      });
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {
+        reportId: 1,
+      });
+
+      expect(result.columns).toEqual([
+        { name: 'attendance', label: 'Attendance Count' },
+      ]);
+    });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -3,6 +3,8 @@ import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 import { ContactsService } from '../crm/contacts.service';
 import { JwtHelperService } from '../auth/jwt-helpers.service';
+import { GroupsMembershipService } from '../groups/services/group-membership.service';
+import { TenantContext } from '../shared/tenant/tenant-context';
 import { Connection, Repository } from 'typeorm';
 import Email from '../crm/entities/email.entity';
 import Roles from './entities/roles.entity';
@@ -81,6 +83,14 @@ describe('UsersService', () => {
         {
           provide: JwtHelperService,
           useValue: mockJwtHelperService,
+        },
+        {
+          provide: GroupsMembershipService,
+          useValue: { create: jest.fn(), findAll: jest.fn() },
+        },
+        {
+          provide: TenantContext,
+          useValue: { requireTenant: jest.fn().mockReturnValue(1) },
         },
       ],
     }).compile();


### PR DESCRIPTION
## Summary

- **Fixed 4 broken test suites** (12 failing tests) caused by stale mocks — missing TenantContext, GroupsMembershipService, and getTreeRepository mocks introduced after the tests were last updated
- **Added 3 new spec files** covering critical paths that had zero test coverage: GroupPermissionsService, GroupTreeService, and FellowshipAttendanceService
- **Expanded ReportsService spec** with 17 new behavioural tests covering getReport, getAllReports, updateReport, getMySubmissions, and getMyGroupsSubmissions
- **Wired tests into CI**: new test.yml workflow runs on every PR; test step activated in main.yml and staging.yml so tests gate all deployments
- **Applied code-review fixes**: input validation for file uploads, tighter CI flags, stronger spec assertions

## What's tested (new coverage)

| Service | Key paths covered |
|---|---|
| GroupPermissionsService | Admin bypass, direct leadership, ancestor-walk, assertPermissionForGroup, getUserGroupIds dedup |
| GroupTreeService | Cache hit/miss, descendant expansion, category collection and dedup, getReportAccessibleGroups |
| FellowshipAttendanceService | Direct-leader scoping for getMyMembers/getMySchedule, recordReportAttendance replace semantics, schedule create-vs-reuse, all error paths |
| ReportsService | getMySubmissions pagination and data mapping, getMyGroupsSubmissions date filter, group access guard, columns |

## CI changes

- `.github/workflows/test.yml` — new workflow, runs `npm test` on every PR and non-deploy push
- `.github/workflows/main.yml` — test step enabled; tests now block production deploys on failure
- `.github/workflows/staging.yml` — same for staging
- Removed `--passWithNoTests` flag from all three so CI fails if Jest discovers no tests

## Production code fixes (from code review)

- **`contact-import.controller.ts`** — `uploadGroupLeaders`: added null file guard and try-catch around `parseCsv`; malformed CSV now returns 400 instead of a 500
- **`transactions.service.ts`** — wrapped `workbook.xlsx.load` in try-catch for corrupt files; guard for empty workbook; added `{ includeEmpty: true }` to `eachCell` so blank header columns no longer silently shift the column mapping

## Spec quality improvements

- `fellowship-attendance.service.spec.ts`: `createSchedule` asserts tenant propagation into saved entity; `getTodayFellowship` has a happy-path test; `getMyMembers` checks actual field values not just array length
- `group-membership.service.spec.ts`: `findDescendants` extracted as a named mock for per-test override; `findAll` test now exercises the real descendant-lookup path and asserts it was called with the parent group

## Test plan

Run locally before merging:

```
npm test -- --forceExit
```

Expected: 36 suites, 127 tests, 0 failures

## Remaining gaps (tracked in ZOE_TODO.md)

Priority 1: ServiceAttendanceService, ReportsService.submitReport
Priority 2: GroupsService, ContactsService behavioural tests, ReportsService.generateReport
Priority 3: Finance module services, DashboardService

Generated with Claude Code
