### PR TITLE
fix: preserve existing group membership role when PATCH omits it

### DIFF
--- a/src/crm/contacts.service.spec.ts
+++ b/src/crm/contacts.service.spec.ts
@@ -18,6 +18,7 @@ import GroupMembership from '../groups/entities/groupMembership.entity';
 import Group from '../groups/entities/group.entity';
 import GroupMembershipRequest from '../groups/entities/groupMembershipRequest.entity';
 import { Tenant } from '../tenants/entities/tenant.entity';
+import { GroupRole } from '../groups/enums/groupRole';
 
 describe('ContactsService', () => {
   let service: ContactsService;
@@ -44,7 +45,11 @@ describe('ContactsService', () => {
       phone: { save: jest.fn() },
       email: { save: jest.fn() },
       address: { save: jest.fn() },
-      membership: { find: jest.fn(), save: jest.fn() },
+      membership: {
+        find: jest.fn(),
+        save: jest.fn(),
+        createQueryBuilder: jest.fn(),
+      },
       groupTree: { findDescendants: jest.fn() },
       gmRequest: { save: jest.fn() },
       tenant: { findOne: jest.fn() },
@@ -97,15 +102,16 @@ describe('ContactsService', () => {
             createContextLogger: jest.fn().mockReturnValue({
               startTracking: jest.fn().mockReturnValue('tracking-id'),
               endTracking: jest.fn(),
-              businessLog: jest.fn(),
-              dataAccessLog: jest.fn(),
+              business: jest.fn(),
+              dataAccess: jest.fn(),
+              security: jest.fn(),
               error: jest.fn(),
             }),
           },
         },
         {
           provide: GroupsMembershipService,
-          useValue: { addMember: jest.fn() },
+          useValue: { create: jest.fn().mockResolvedValue(1) },
         },
         {
           provide: TenantContext,
@@ -134,5 +140,115 @@ describe('ContactsService', () => {
     );
     expect(mockConnection.getRepository).toHaveBeenCalledWith(Tenant);
     expect(mockConnection.getTreeRepository).toHaveBeenCalledWith(Group);
+  });
+
+  describe('handleGroupMembershipsUpdate', () => {
+    let qbMock: any;
+    let groupsMembershipServiceMock: { create: jest.Mock };
+
+    beforeEach(() => {
+      qbMock = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue(undefined),
+      };
+      mockRepositories.membership.createQueryBuilder.mockReturnValue(qbMock);
+
+      groupsMembershipServiceMock = { create: jest.fn().mockResolvedValue(1) };
+      (service as any).groupsMembershipService = groupsMembershipServiceMock;
+    });
+
+    const buildContact = (groupMemberships: any[]) =>
+      ({ id: 1, groupMemberships }) as any;
+
+    const invoke = (contact: any, newGroups: any[]) =>
+      (service as any).handleGroupMembershipsUpdate(contact, newGroups);
+
+    it('leaves an existing LEADER membership untouched when the caller omits its role', async () => {
+      const contact = buildContact([
+        { id: 10, groupId: 100, role: GroupRole.Leader, isActive: true },
+        { id: 11, groupId: 200, role: GroupRole.Member, isActive: true },
+      ]);
+
+      // Patching e.g. firstName re-sends the current groups without roles
+      await invoke(contact, [{ id: 100 }, { id: 200 }]);
+
+      expect(qbMock.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ role: expect.anything() }),
+      );
+      expect(groupsMembershipServiceMock.create).not.toHaveBeenCalled();
+    });
+
+    it('updates the role when the caller explicitly sends a different role', async () => {
+      const contact = buildContact([
+        { id: 10, groupId: 100, role: GroupRole.Leader, isActive: true },
+      ]);
+
+      await invoke(contact, [{ id: 100, role: GroupRole.Member }]);
+
+      expect(qbMock.set).toHaveBeenCalledWith({ role: GroupRole.Member });
+      expect(qbMock.where).toHaveBeenCalledWith('id = :id', { id: 10 });
+    });
+
+    it('does nothing for a membership whose explicit role matches the current role', async () => {
+      const contact = buildContact([
+        { id: 10, groupId: 100, role: GroupRole.Leader, isActive: true },
+      ]);
+
+      await invoke(contact, [{ id: 100, role: GroupRole.Leader }]);
+
+      expect(qbMock.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ role: expect.anything() }),
+      );
+    });
+
+    it('defaults a brand new membership to Member when no role is given', async () => {
+      const contact = buildContact([]);
+
+      await invoke(contact, [{ id: 300 }]);
+
+      expect(groupsMembershipServiceMock.create).toHaveBeenCalledWith({
+        groupId: 300,
+        members: [1],
+        role: GroupRole.Member,
+      });
+    });
+
+    it('creates a new membership with the explicitly requested role', async () => {
+      const contact = buildContact([]);
+
+      await invoke(contact, [{ id: 300, role: GroupRole.Leader }]);
+
+      expect(groupsMembershipServiceMock.create).toHaveBeenCalledWith({
+        groupId: 300,
+        members: [1],
+        role: GroupRole.Leader,
+      });
+    });
+
+    it('deactivates memberships for groups no longer present in the new list', async () => {
+      const contact = buildContact([
+        { id: 10, groupId: 100, role: GroupRole.Leader, isActive: true },
+        { id: 11, groupId: 200, role: GroupRole.Member, isActive: true },
+      ]);
+
+      await invoke(contact, [{ id: 100, role: GroupRole.Leader }]);
+
+      expect(qbMock.set).toHaveBeenCalledWith(
+        expect.objectContaining({ isActive: false }),
+      );
+      expect(qbMock.where).toHaveBeenCalledWith('id = :id', { id: 11 });
+    });
+
+    it('throws when no groups are provided', async () => {
+      const contact = buildContact([
+        { id: 10, groupId: 100, role: GroupRole.Leader, isActive: true },
+      ]);
+
+      await expect(invoke(contact, [])).rejects.toThrow(
+        'Contact must be assigned to at least one group',
+      );
+    });
   });
 });

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -740,15 +740,20 @@ export class ContactsService {
         (m) => !newGroupIds.has(m.groupId),
       );
 
-      // Groups to update role (in both, but role might be different)
+      // Groups to update role (in both, but role explicitly differs).
+      // An omitted role means "leave the existing role as is" — it must
+      // NOT be treated as a request to reset the role to Member, otherwise
+      // patching unrelated contact fields (e.g. firstName) would silently
+      // demote existing Leaders to Members whenever the caller sends group
+      // ids without a role for memberships it isn't trying to change.
       const groupsToUpdate = newGroups.filter((g) => {
+        if (g.role === undefined || g.role === null) {
+          return false;
+        }
         const currentMembership = activeMemberships.find(
           (m) => m.groupId === g.id,
         );
-        return (
-          currentMembership &&
-          currentMembership.role !== (g.role || GroupRole.Member)
-        );
+        return currentMembership && currentMembership.role !== g.role;
       });
 
       this.logger.business('log', 'Group membership changes calculated', {
@@ -793,7 +798,7 @@ export class ContactsService {
         const currentMembership = activeMemberships.find(
           (m) => m.groupId === groupUpdate.id,
         );
-        const newRole = groupUpdate.role || GroupRole.Member;
+        const newRole = groupUpdate.role;
 
         this.logger.business('log', 'Updating role in existing group', {
           operation: 'updateContact',


### PR DESCRIPTION
handleGroupMembershipsUpdate defaulted an omitted role to Member when comparing against a contact's current memberships, so patching unrelated contact fields (firstName, email, etc.) while re-sending existing group ids without roles silently demoted Leaders to Members. An omitted role now means "leave as is"; only an explicitly provided, differing role triggers an update. New memberships still default to Member when no role is given.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group membership roles are now preserved unless a different role is explicitly selected.
  * New group memberships now default to a standard role when no role is provided.
  * Removed groups are properly deactivated when updating a contact’s group list.
  * An error is now shown when attempting to update group memberships without providing any groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->