### PR TITLE
fix(fellowship): allow MC leaders to create schedule from report form

### DIFF
--- a/src/attendance/services/fellowship-attendance.service.ts
+++ b/src/attendance/services/fellowship-attendance.service.ts
@@ -382,7 +382,7 @@ export class FellowshipAttendanceService {
       .then((rows) => rows.map((r) => r.groupId));
 
     if (fellowshipGroupIds.length === 0) {
-      return { exists: false, weekdays: WEEKDAYS };
+      return { exists: false, isLeader: false, weekdays: WEEKDAYS };
     }
 
     const schedule = await this.scheduleRepo.findOne({
@@ -394,12 +394,18 @@ export class FellowshipAttendanceService {
     });
 
     if (!schedule) {
-      return { exists: false, weekdays: WEEKDAYS };
+      return {
+        exists: false,
+        isLeader: true,
+        fellowshipGroupId: fellowshipGroupIds[0],
+        weekdays: WEEKDAYS,
+      };
     }
 
     const dayName = WEEKDAY_NAMES[schedule.meetingDay];
     return {
       exists: true,
+      isLeader: true,
       id: schedule.id,
       day: schedule.meetingDay,
       label: `${dayName}s`,


### PR DESCRIPTION
## Summary
- `getMySchedule` now returns `isLeader: false` when the user has no fellowship leader role, so the client can show an accurate message instead of a generic admin prompt
- Returns `isLeader: true` + `fellowshipGroupId` when a direct MC leader exists but has no schedule yet, enabling inline schedule creation from the report form
- Returns `isLeader: true` on the existing-schedule response for consistency

## Test plan
- [ ] User who is not an MC leader sees "You are not assigned as a leader of any Missional Community" on the report form
- [ ] MC leader with no schedule sees a "Set up" button and can create one inline
- [ ] MC leader with an existing schedule sees the schedule and can edit it via "Change"
- [ ] Confirm `my-schedule` response shape for all three states

🤖 Generated with [Claude Code](https://claude.com/claude-code)