### PR TITLE
fix(reports): accept selectedGroupId in submission DTO for multi-group leaders

### DIFF
--- a/src/reports/dto/report-submission.dto.ts
+++ b/src/reports/dto/report-submission.dto.ts
@@ -1,7 +1,11 @@
-import { IsDefined, IsObject } from 'class-validator';
+import { IsDefined, IsObject, IsNumber, IsOptional } from 'class-validator';
 
 export class ReportSubmissionDto {
   @IsDefined()
   @IsObject()
   data: Record<string, any>;
+
+  @IsOptional()
+  @IsNumber()
+  selectedGroupId?: number;
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -149,7 +149,7 @@ export class ReportsService {
     }
 
     let targetGroup: Group | null = null;
-    let selectedGroupId: number | null = null;
+    let selectedGroupId: number | null = submissionDto.selectedGroupId ?? null;
 
     // The designated group field can either be configured explicitly via
     // report.groupFieldName, or inferred from a field marked as a
@@ -177,8 +177,12 @@ export class ReportsService {
       },
     });
 
-    // Check if report has a designated group field
-    if (groupFieldName && submissionDto.data[groupFieldName]) {
+    // Check if report has a designated group field (skip if caller already supplied selectedGroupId)
+    if (
+      !selectedGroupId &&
+      groupFieldName &&
+      submissionDto.data[groupFieldName]
+    ) {
       selectedGroupId = parseInt(submissionDto.data[groupFieldName], 10);
       if (Number.isNaN(selectedGroupId)) {
         throw new BadRequestException(
@@ -229,8 +233,8 @@ export class ReportsService {
         );
       }
     }
-    // Fallback to current automatic detection
-    else if (report.targetGroupCategory) {
+    // Fallback to automatic detection when no group has been resolved yet
+    else if (!selectedGroupId && report.targetGroupCategory) {
       const userGroups = await this.getUserGroupsInCategory(
         submittingUser.contactId,
         report.targetGroupCategory.id,


### PR DESCRIPTION
## Summary
- Adds optional `selectedGroupId` to `ReportSubmissionDto`
- The service uses it first, before field-based group resolution and auto-detection
- Existing single-group and dynamic_group_selector flows are completely unaffected

## Test plan
- [ ] Single-group leader submits normally — no change in behaviour
- [ ] Report with a `dynamic_group_selector` field still resolves group via that field
- [ ] Multi-group leader passes `selectedGroupId` — submission succeeds and is attributed to the correct group
- [ ] Omitting `selectedGroupId` on a multi-group leader still returns the existing error (fallback path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)