### PR TITLE
Fix/tasks location group ids qs array limit

### DIFF
--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -123,6 +123,7 @@ export class ContactImportController {
           const groupData = await this.groupsService.findOne(
             effectiveGroupId,
             false,
+            req.user,
           );
           if (!groupData) {
             throw new BadRequestException({

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -173,7 +173,10 @@ export class ContactImportController {
 
   @Post('groupLeaders')
   @UseInterceptors(FileInterceptor('file'))
-  async uploadGroupLeaders(@UploadedFile() file: Express.Multer.File) {
+  async uploadGroupLeaders(
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: any,
+  ) {
     if (!file) {
       throw new BadRequestException({ message: 'No file was uploaded.' });
     }
@@ -212,6 +215,7 @@ export class ContactImportController {
             groupData = await this.groupsService.findOne(
               uploadedContact.groupId,
               false,
+              req.user,
             );
             if (!groupData) {
               throw new BadRequestException({

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -43,7 +43,8 @@ export class TasksController {
     @Query('status') status?: string | string[],
     @Query('type') type?: string | string[],
     @Query('assignedToId') assignedToId?: string,
-    @Query('locationGroupIds') locationGroupIds?: string | string[],
+    @Query('locationGroupIds')
+    locationGroupIds?: string | string[] | Record<string, string>,
   ) {
     const filters: {
       status?: TaskStatus[];
@@ -65,12 +66,24 @@ export class TasksController {
         assignedToId === 'unassigned' ? 'unassigned' : Number(assignedToId);
     }
     if (locationGroupIds !== undefined) {
-      filters.locationGroupIds = (
-        Array.isArray(locationGroupIds) ? locationGroupIds : [locationGroupIds]
-      ).map(Number);
+      const ids = this.toNumberArray(locationGroupIds);
+      if (ids.length) filters.locationGroupIds = ids;
     }
 
     return this.tasksService.findAll(Number(page), Number(limit), filters);
+  }
+
+  // qs (used by Express/Nest to parse query strings) only decodes repeated
+  // keys (e.g. `?locationGroupIds=1&locationGroupIds=2...`) into an array up
+  // to its default arrayLimit of 20 entries; beyond that it falls back to a
+  // plain object keyed "0", "1", ... instead, so this must handle all shapes.
+  private toNumberArray(value: string | string[] | Record<string, string>) {
+    const values = Array.isArray(value)
+      ? value
+      : typeof value === 'object'
+      ? Object.values(value)
+      : [value];
+    return values.map(Number).filter((id) => Number.isFinite(id));
   }
 
   @Get('contact/:contactId')

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -66,7 +66,7 @@ export class TasksController {
         assignedToId === 'unassigned' ? 'unassigned' : Number(assignedToId);
     }
     if (locationGroupIds !== undefined) {
-      const ids = this.toNumberArray(locationGroupIds);
+      const ids = TasksController.toNumberArray(locationGroupIds);
       if (ids.length) filters.locationGroupIds = ids;
     }
 
@@ -77,7 +77,9 @@ export class TasksController {
   // keys (e.g. `?locationGroupIds=1&locationGroupIds=2...`) into an array up
   // to its default arrayLimit of 20 entries; beyond that it falls back to a
   // plain object keyed "0", "1", ... instead, so this must handle all shapes.
-  private toNumberArray(value: string | string[] | Record<string, string>) {
+  private static toNumberArray(
+    value: string | string[] | Record<string, string>,
+  ) {
     const values = Array.isArray(value)
       ? value
       : typeof value === 'object'


### PR DESCRIPTION
Root cause: `qs (Express/Nest's query-string parser)` only decodes repeated query keys like `locationGroupIds=1&locationGroupIds=2...` into an array up to its default arrayLimit of 20 entries. Past that, it silently falls back to a plain object `({"0": "142", "1": "70", ...}).` The controller's `Array.isArray(locationGroupIds)` check then failed, wrapped the whole object into a single-element array, and Number(object) produced NaN — the exact single NaN parameter seen crashing the SQL query in `tasks.service.ts:178.`

Fix ([tasks.controller.ts:46-80](vscode-webview://0r2qf483ilgpe7kp3ckdl10b3q080e006j1b2m8rkfqo4poeqdbf/src/tasks/tasks.controller.ts#L46-L80)): widened the param type to include the object shape and added a toNumberArray helper that handles all three shapes (string, string[], or the qs fallback object), converting via Object.values() when needed and filtering out any non-finite results before they ever reach tasks.service.ts.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact import group resolution by applying the current user’s access context.
  * Fixed task filtering when location group IDs are provided in different query formats.
  * Invalid or empty location group values are now ignored instead of producing unintended filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->