### PR TITLE
Fix/report weekly limit per group instead of user

### DIFF
--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -123,6 +123,7 @@ export class ContactImportController {
           const groupData = await this.groupsService.findOne(
             effectiveGroupId,
             false,
+            req.user,
           );
           if (!groupData) {
             throw new BadRequestException({

--- a/src/migrations/1783922603436-ReportSubmissionWeeklyLimitUniqueIndexes.ts
+++ b/src/migrations/1783922603436-ReportSubmissionWeeklyLimitUniqueIndexes.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ReportSubmissionWeeklyLimitUniqueIndexes1783922603436
+  implements MigrationInterface
+{
+  name = 'ReportSubmissionWeeklyLimitUniqueIndexes1783922603436';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_report_submission_group_period_unique"
+        ON "report_submission" ("reportId", "groupId", "reportingPeriod")
+        WHERE "groupId" IS NOT NULL
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_report_submission_user_period_unique"
+        ON "report_submission" ("reportId", "userId", "reportingPeriod")
+        WHERE "groupId" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX "public"."IDX_report_submission_user_period_unique"',
+    );
+    await queryRunner.query(
+      'DROP INDEX "public"."IDX_report_submission_group_period_unique"',
+    );
+  }
+}

--- a/src/reports/entities/report.submission.entity.ts
+++ b/src/reports/entities/report.submission.entity.ts
@@ -14,6 +14,16 @@ import Group from 'src/groups/entities/group.entity';
 
 @Entity()
 @Index(['submittedAt'])
+@Index(
+  'IDX_report_submission_group_period_unique',
+  ['report', 'group', 'reportingPeriod'],
+  { unique: true, where: '"groupId" IS NOT NULL' },
+)
+@Index(
+  'IDX_report_submission_user_period_unique',
+  ['report', 'user', 'reportingPeriod'],
+  { unique: true, where: '"groupId" IS NULL' },
+)
 export class ReportSubmission {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ReportsService } from './reports.service';
 import { UsersService } from '../users/users.service';
 import { GroupsService } from '../groups/services/groups.service';
@@ -17,6 +17,10 @@ import { User } from '../users/entities/user.entity';
 import { ReportField } from './entities/report.field.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
 import Group from '../groups/entities/group.entity';
+
+jest.mock('src/utils/mailer', () => ({
+  sendEmail: jest.fn().mockResolvedValue('mock-message-id'),
+}));
 
 describe('ReportsService', () => {
   let service: ReportsService;
@@ -60,10 +64,12 @@ describe('ReportsService', () => {
       },
       groupMembership: {
         find: jest.fn(),
+        findOne: jest.fn(),
       },
       groupTree: {
         findDescendants: jest.fn(),
         findAncestors: jest.fn(),
+        findOne: jest.fn(),
       },
     };
 
@@ -476,6 +482,128 @@ describe('ReportsService', () => {
       expect(result.columns).toEqual([
         { name: 'attendance', label: 'Attendance Count' },
       ]);
+    });
+  });
+
+  describe('submitReport - weekly duplicate limit', () => {
+    const mockUser = { id: 7, contactId: 3 } as any;
+
+    const baseReport = {
+      id: 1,
+      name: 'Weekly Report',
+      status: ReportStatus.ACTIVE,
+      groupFieldName: 'groupId',
+      targetGroupCategory: undefined,
+      fields: [],
+    } as unknown as Report;
+
+    const savedUser = { id: 7, contactId: 3, username: 'shepherd@example.com' };
+
+    const makeGroup = (id: number, name: string) => ({ id, name }) as Group;
+
+    beforeEach(() => {
+      mockRepositories.report.findOne.mockResolvedValue(baseReport);
+      mockRepositories.user.findOne.mockResolvedValue(savedUser);
+      mockRepositories.reportField.find.mockResolvedValue([]);
+      mockRepositories.reportSubmissionData.save.mockResolvedValue([]);
+      mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
+        Promise.resolve({
+          id: 99,
+          ...sub,
+        }),
+      );
+      // Membership grants permission to submit for the target group.
+      mockRepositories.groupMembership.findOne.mockResolvedValue({
+        group: { id: 10, category: undefined },
+      });
+      mockGroupPermissionsService.hasPermissionForGroup = jest
+        .fn()
+        .mockResolvedValue(true);
+    });
+
+    it('blocks a second submission of the same report for the same group in the same week', async () => {
+      mockRepositories.groupTree.findOne.mockResolvedValue(
+        makeGroup(10, 'MC Nairobi'),
+      );
+      // Simulate an existing submission already on file for group 10.
+      mockRepositories.reportSubmission.findOne.mockResolvedValue({
+        id: 55,
+        report: { id: 1 },
+        group: { id: 10 },
+      });
+
+      await expect(
+        service.submitReport(1, { data: { groupId: '10' } }, mockUser),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            report: { id: 1 },
+            group: { id: 10 },
+          }),
+        }),
+      );
+      expect(mockRepositories.reportSubmission.save).not.toHaveBeenCalled();
+    });
+
+    it('allows submitting the same report again for a different group in the same week', async () => {
+      mockRepositories.groupTree.findOne.mockResolvedValue(
+        makeGroup(11, 'MC Kampala'),
+      );
+      mockRepositories.groupMembership.findOne.mockResolvedValue({
+        group: { id: 11, category: undefined },
+      });
+      // No existing submission for group 11.
+      mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+
+      const result = await service.submitReport(
+        1,
+        { data: { groupId: '11' } },
+        mockUser,
+      );
+
+      expect(result.status).toBe(200);
+      expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            report: { id: 1 },
+            group: { id: 11 },
+          }),
+        }),
+      );
+      expect(mockRepositories.reportSubmission.save).toHaveBeenCalled();
+    });
+
+    it('falls back to per-user limiting when the report has no associated group', async () => {
+      const noGroupReport = {
+        ...baseReport,
+        groupFieldName: undefined,
+        targetGroupCategory: undefined,
+        fields: [],
+      } as unknown as Report;
+      mockRepositories.report.findOne.mockResolvedValue(noGroupReport);
+      mockRepositories.reportSubmission.findOne.mockResolvedValue({
+        id: 77,
+        report: { id: 1 },
+        user: { id: 7 },
+      });
+
+      await expect(
+        service.submitReport(1, { data: {} }, mockUser),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            report: { id: 1 },
+            user: { id: 7 },
+          }),
+        }),
+      );
     });
   });
 });

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -131,23 +131,6 @@ export class ReportsService {
       throw new NotFoundException(`User with ID ${user.id} not found`);
     }
 
-    // A user may only submit a given report once per week (week starts Sunday)
-    const weekStart = this.getStartOfWeek(new Date());
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-    const existingSubmission = await this.reportSubmissionRepository.findOne({
-      where: {
-        report: { id: reportId },
-        user: { id: submittingUser.id },
-        submittedAt: Between(weekStart, weekEnd),
-      },
-    });
-    if (existingSubmission) {
-      throw new BadRequestException(
-        `You have already submitted "${report.name}" for this week`,
-      );
-    }
-
     let targetGroup: Group | null = null;
     let selectedGroupId: number | null = null;
 
@@ -248,6 +231,34 @@ export class ReportsService {
       }
 
       targetGroup = userGroups[0];
+    }
+
+    // A report may only be submitted once per week per group (week starts
+    // Sunday). This allows a user managing multiple groups to submit the same
+    // report once for each group, and to submit other reports freely during
+    // the week. Reports with no associated group fall back to limiting the
+    // submitting user to one submission per week.
+    const weekStart = this.getStartOfWeek(new Date());
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+    const duplicateSubmissionWhere: any = {
+      report: { id: reportId },
+      submittedAt: Between(weekStart, weekEnd),
+    };
+    if (targetGroup) {
+      duplicateSubmissionWhere.group = { id: targetGroup.id };
+    } else {
+      duplicateSubmissionWhere.user = { id: submittingUser.id };
+    }
+    const existingSubmission = await this.reportSubmissionRepository.findOne({
+      where: duplicateSubmissionWhere,
+    });
+    if (existingSubmission) {
+      throw new BadRequestException(
+        targetGroup
+          ? `"${report.name}" has already been submitted for ${targetGroup.name} this week`
+          : `You have already submitted "${report.name}" for this week`,
+      );
     }
 
     // Create and save the report submission

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -266,11 +266,24 @@ export class ReportsService {
     reportSubmission.report = report;
     reportSubmission.submittedAt = new Date();
     reportSubmission.user = submittingUser;
+    reportSubmission.reportingPeriod = weekStart.toISOString().slice(0, 10);
     if (targetGroup) {
       reportSubmission.group = targetGroup;
     }
-    const savedSubmission =
-      await this.reportSubmissionRepository.save(reportSubmission);
+    let savedSubmission: ReportSubmission;
+    try {
+      savedSubmission =
+        await this.reportSubmissionRepository.save(reportSubmission);
+    } catch (err) {
+      if ((err as any).code === '23505') {
+        throw new BadRequestException(
+          targetGroup
+            ? `"${report.name}" has already been submitted for ${targetGroup.name} this week`
+            : `You have already submitted "${report.name}" for this week`,
+        );
+      }
+      throw err;
+    }
 
     // Retrieve all fields for the report to map field names to their respective entities
     const fields = await this.reportFieldRepository.find({

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -83,7 +83,9 @@ export class TasksController {
       : typeof value === 'object'
       ? Object.values(value)
       : [value];
-    return values.map(Number).filter((id) => Number.isFinite(id));
+    return values
+      .map((v) => Number(v))
+      .filter((id) => Number.isInteger(id) && id > 0);
   }
 
   @Get('contact/:contactId')

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -43,7 +43,8 @@ export class TasksController {
     @Query('status') status?: string | string[],
     @Query('type') type?: string | string[],
     @Query('assignedToId') assignedToId?: string,
-    @Query('locationGroupIds') locationGroupIds?: string | string[],
+    @Query('locationGroupIds')
+    locationGroupIds?: string | string[] | Record<string, string>,
   ) {
     const filters: {
       status?: TaskStatus[];
@@ -65,12 +66,24 @@ export class TasksController {
         assignedToId === 'unassigned' ? 'unassigned' : Number(assignedToId);
     }
     if (locationGroupIds !== undefined) {
-      filters.locationGroupIds = (
-        Array.isArray(locationGroupIds) ? locationGroupIds : [locationGroupIds]
-      ).map(Number);
+      const ids = this.toNumberArray(locationGroupIds);
+      if (ids.length) filters.locationGroupIds = ids;
     }
 
     return this.tasksService.findAll(Number(page), Number(limit), filters);
+  }
+
+  // qs (used by Express/Nest to parse query strings) only decodes repeated
+  // keys (e.g. `?locationGroupIds=1&locationGroupIds=2...`) into an array up
+  // to its default arrayLimit of 20 entries; beyond that it falls back to a
+  // plain object keyed "0", "1", ... instead, so this must handle all shapes.
+  private toNumberArray(value: string | string[] | Record<string, string>) {
+    const values = Array.isArray(value)
+      ? value
+      : typeof value === 'object'
+      ? Object.values(value)
+      : [value];
+    return values.map(Number).filter((id) => Number.isFinite(id));
   }
 
   @Get('contact/:contactId')


### PR DESCRIPTION
Scope weekly submission limit by group instead of user

A user managing multiple groups was blocked from submitting the same
report more than once a week, even for different groups. The weekly
duplicate check now applies per (report, group), falling back to the
old per-user check only when a report has no associated group.

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Weekly report submission limits now apply once per report per week for each group (and fall back to per-user limits when no group is associated).

- **Bug Fixes**
  - Duplicate report submissions return clearer feedback, including the relevant group name when applicable.
  - Contact imports now resolve group handling more accurately within each upload request.
  - Task location-group filtering now supports additional query formats and skips empty/invalid selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->