### PR TITLE
Fix/tasks location scoped visibility

### DIFF
--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -45,6 +45,7 @@ export class TasksController {
     @Query('assignedToId') assignedToId?: string,
     @Query('locationGroupIds')
     locationGroupIds?: string | string[] | Record<string, string>,
+    @Request() req?: any,
   ) {
     const filters: {
       status?: TaskStatus[];
@@ -70,7 +71,12 @@ export class TasksController {
       if (ids.length) filters.locationGroupIds = ids;
     }
 
-    return this.tasksService.findAll(Number(page), Number(limit), filters);
+    return this.tasksService.findAll(
+      Number(page),
+      Number(limit),
+      filters,
+      req.user,
+    );
   }
 
   // qs (used by Express/Nest to parse query strings) only decodes repeated
@@ -89,8 +95,11 @@ export class TasksController {
   }
 
   @Get('contact/:contactId')
-  async findAllForContact(@Param('contactId') contactId: number) {
-    return this.tasksService.findAllForContact(contactId);
+  async findAllForContact(
+    @Param('contactId') contactId: number,
+    @Request() req: any,
+  ) {
+    return this.tasksService.findAllForContact(contactId, req.user);
   }
 
   @Get('retention-report')
@@ -124,8 +133,8 @@ export class TasksController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: number) {
-    return this.tasksService.findOne(id);
+  async findOne(@Param('id') id: number, @Request() req: any) {
+    return this.tasksService.findOne(id, req.user);
   }
 
   @Patch(':id')

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -4,13 +4,20 @@ import { Task } from './entities/task.entity';
 import { TaskComment } from './entities/task-comment.entity';
 import { TaskAttachment } from './entities/task-attachment.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
+import { GroupsModule } from '../groups/groups.module';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
 import { RetentionReportService } from './retention-report.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Task, TaskComment, TaskAttachment, GroupMembership]),
+    TypeOrmModule.forFeature([
+      Task,
+      TaskComment,
+      TaskAttachment,
+      GroupMembership,
+    ]),
+    GroupsModule,
   ],
   controllers: [TasksController],
   providers: [TasksService, RetentionReportService],

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,302 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Connection } from 'typeorm';
+import { TasksService } from './tasks.service';
+import { Task } from './entities/task.entity';
+import { TaskComment } from './entities/task-comment.entity';
+import { TaskAttachment } from './entities/task-attachment.entity';
+import GroupMembership from '../groups/entities/groupMembership.entity';
+import Group from '../groups/entities/group.entity';
+import { TenantContext } from '../shared/tenant/tenant-context';
+import { ContactActivityService } from '../crm/contact-activity.service';
+import { GroupPermissionsService } from '../groups/services/group-permissions.service';
+import { roleAdmin } from '../auth/constants';
+
+const TENANT_ID = 1;
+
+function createChainableQb(terminalMethods: Record<string, jest.Mock>) {
+  return {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    innerJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    ...terminalMethods,
+  } as any;
+}
+
+describe('TasksService — location-based visibility scoping', () => {
+  let service: TasksService;
+  let mockGroupPermissionsService: {
+    getAccessibleGroupIds: jest.Mock;
+  };
+  let mockTaskRepo: any;
+  let mockCommentRepo: any;
+  let mockMembershipRepo: any;
+  let mockGroupRepo: any;
+  let taskQb: any;
+  let groupQb: any;
+  let membershipQb: any;
+  let commentQb: any;
+
+  const buildUser = (overrides: Record<string, any> = {}) => ({
+    id: 100,
+    contactId: 10,
+    roles: [],
+    ...overrides,
+  });
+
+  const buildAdmin = () => buildUser({ roles: [roleAdmin.role] });
+
+  beforeEach(async () => {
+    taskQb = createChainableQb({
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    });
+    groupQb = createChainableQb({
+      getMany: jest.fn().mockResolvedValue([]),
+    });
+    membershipQb = createChainableQb({
+      getCount: jest.fn().mockResolvedValue(0),
+    });
+    commentQb = createChainableQb({
+      getRawMany: jest.fn().mockResolvedValue([]),
+    });
+
+    mockTaskRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(taskQb),
+      findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    mockCommentRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(commentQb),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    mockMembershipRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(membershipQb),
+    };
+    mockGroupRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(groupQb),
+    };
+
+    const mockConnection: Partial<Connection> = {
+      getRepository: jest.fn((entity: any) => {
+        if (entity === Task) return mockTaskRepo;
+        if (entity === TaskComment) return mockCommentRepo;
+        if (entity === TaskAttachment) return {};
+        if (entity === GroupMembership) return mockMembershipRepo;
+        if (entity === Group) return mockGroupRepo;
+        throw new Error(`Unexpected entity requested: ${entity}`);
+      }) as any,
+      transaction: jest.fn((fn: any) => fn({})) as any,
+    };
+
+    mockGroupPermissionsService = {
+      getAccessibleGroupIds: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        { provide: 'CONNECTION', useValue: mockConnection },
+        {
+          provide: TenantContext,
+          useValue: { requireTenant: jest.fn().mockReturnValue(TENANT_ID) },
+        },
+        {
+          provide: ContactActivityService,
+          useValue: { record: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: GroupPermissionsService,
+          useValue: mockGroupPermissionsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TasksService>(TasksService);
+  });
+
+  describe('findAll', () => {
+    it('is unrestricted for admins and never queries the group hierarchy', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue(null);
+
+      await service.findAll(1, 20, {}, buildAdmin());
+
+      expect(mockGroupRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(mockTaskRepo.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('returns an empty page without querying tasks when the user has no accessible groups', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([]);
+
+      const result = await service.findAll(1, 20, {}, buildUser());
+
+      expect(result).toEqual({ data: [], groups: [], total: 0 });
+      expect(mockTaskRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('scopes tasks to a single location for a direct location leader', async () => {
+      // getAccessibleGroupIds already expands leadership to include descendants
+      // (GroupPermissionsService.getUserGroupIds); a location leader's only
+      // LOCATION-purpose descendant is their own location.
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([55]);
+      groupQb.getMany.mockResolvedValue([{ id: 55 }]);
+
+      await service.findAll(1, 20, {}, buildUser());
+
+      expect(mockGroupRepo.createQueryBuilder).toHaveBeenCalledWith('group');
+      expect(taskQb.andWhere).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('scopes tasks across every location beneath a higher-level (e.g. FOB) leader', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([
+        1, 30, 40, 999,
+      ]);
+      // Only the LOCATION-purpose groups among the accessible ids survive.
+      groupQb.getMany.mockResolvedValue([{ id: 30 }, { id: 40 }]);
+
+      await service.findAll(1, 20, {}, buildUser());
+
+      expect(taskQb.andWhere).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('intersects a client-supplied locationGroupIds filter with the accessible set instead of trusting it outright', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([
+        30, 40,
+      ]);
+      groupQb.getMany.mockResolvedValue([{ id: 30 }, { id: 40 }]);
+
+      await service.findAll(
+        1,
+        20,
+        { locationGroupIds: [40, 9999] },
+        buildUser(),
+      );
+
+      // 40 is a legitimate overlap, so the query still runs.
+      expect(mockTaskRepo.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('returns an empty page when the requested locationGroupIds do not overlap the accessible set', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([30]);
+      groupQb.getMany.mockResolvedValue([{ id: 30 }]);
+
+      const result = await service.findAll(
+        1,
+        20,
+        { locationGroupIds: [9999] },
+        buildUser(),
+      );
+
+      expect(result).toEqual({ data: [], groups: [], total: 0 });
+      expect(mockTaskRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    const TASK_ID = 5;
+    const CONTACT_ID = 77;
+
+    const mockTask = () => ({
+      id: TASK_ID,
+      contact: { id: CONTACT_ID },
+      assignedTo: null,
+      createdBy: null,
+      comments: [],
+    });
+
+    it('throws NotFoundException before checking location access when the task does not exist', async () => {
+      mockTaskRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne(TASK_ID, buildUser())).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(
+        mockGroupPermissionsService.getAccessibleGroupIds,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('lets an admin view any task regardless of location', async () => {
+      mockTaskRepo.findOne.mockResolvedValue(mockTask());
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue(null);
+
+      const result = await service.findOne(TASK_ID, buildAdmin());
+
+      expect(result.id).toBe(TASK_ID);
+    });
+
+    it('lets a location leader view a task for a contact in their location', async () => {
+      mockTaskRepo.findOne.mockResolvedValue(mockTask());
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([55]);
+      groupQb.getMany.mockResolvedValue([{ id: 55 }]);
+      membershipQb.getCount.mockResolvedValue(1);
+
+      const result = await service.findOne(TASK_ID, buildUser());
+
+      expect(result.id).toBe(TASK_ID);
+    });
+
+    it('throws ForbiddenException when the task belongs to a contact outside the accessible locations', async () => {
+      mockTaskRepo.findOne.mockResolvedValue(mockTask());
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([55]);
+      groupQb.getMany.mockResolvedValue([{ id: 55 }]);
+      membershipQb.getCount.mockResolvedValue(0);
+
+      await expect(service.findOne(TASK_ID, buildUser())).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('throws ForbiddenException immediately when the user has no accessible location groups at all', async () => {
+      mockTaskRepo.findOne.mockResolvedValue(mockTask());
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([]);
+
+      await expect(service.findOne(TASK_ID, buildUser())).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockMembershipRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAllForContact', () => {
+    const CONTACT_ID = 77;
+
+    it('returns tasks when the user has access to the contact location', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([55]);
+      groupQb.getMany.mockResolvedValue([{ id: 55 }]);
+      membershipQb.getCount.mockResolvedValue(1);
+      mockTaskRepo.find.mockResolvedValue([]);
+
+      const result = await service.findAllForContact(CONTACT_ID, buildUser());
+
+      expect(result).toEqual([]);
+      expect(mockTaskRepo.find).toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException and never queries tasks when the user lacks access to the contact location', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue([55]);
+      groupQb.getMany.mockResolvedValue([{ id: 55 }]);
+      membershipQb.getCount.mockResolvedValue(0);
+
+      await expect(
+        service.findAllForContact(CONTACT_ID, buildUser()),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockTaskRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('lets an admin view any contact tasks without a location check', async () => {
+      mockGroupPermissionsService.getAccessibleGroupIds.mockResolvedValue(null);
+      mockTaskRepo.find.mockResolvedValue([]);
+
+      await service.findAllForContact(CONTACT_ID, buildAdmin());
+
+      expect(mockGroupRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(mockTaskRepo.find).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -180,6 +180,25 @@ describe('TasksService — location-based visibility scoping', () => {
 
       // 40 is a legitimate overlap, so the query still runs.
       expect(mockTaskRepo.createQueryBuilder).toHaveBeenCalled();
+
+      // Inspect the subquery the callback builds to confirm it only binds
+      // the effective intersection ([40]), never the untrusted 9999.
+      const andWhereCallback = taskQb.andWhere.mock.calls
+        .map(([arg]: [any]) => arg)
+        .find((arg: any) => typeof arg === 'function');
+      expect(andWhereCallback).toBeDefined();
+
+      const subQb = createChainableQb({
+        from: jest.fn().mockReturnThis(),
+        getQuery: jest.fn().mockReturnValue('SELECT 1'),
+      });
+      const subQueryBuilder = { subQuery: jest.fn().mockReturnValue(subQb) };
+      andWhereCallback(subQueryBuilder);
+
+      const locationFilterCall = subQb.andWhere.mock.calls.find(
+        ([, params]: [string, any]) => params?.locationGroupIds,
+      );
+      expect(locationFilterCall[1]).toEqual({ locationGroupIds: [40] });
     });
 
     it('returns an empty page when the requested locationGroupIds do not overlap the accessible set', async () => {

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -12,6 +12,13 @@ import { ContactActivityService } from '../crm/contact-activity.service';
 import { GroupPermissionsService } from '../groups/services/group-permissions.service';
 import { roleAdmin } from '../auth/constants';
 
+// TenantAwareRepository requires a real TypeORM EntityManager; intercept its
+// constructor so the test can supply mockGroupRepo without a live connection.
+let groupRepoForTest: any;
+jest.mock('../shared/repository/tenant-aware.repository', () => ({
+  TenantAwareRepository: jest.fn().mockImplementation(() => groupRepoForTest),
+}));
+
 const TENANT_ID = 1;
 
 function createChainableQb(terminalMethods: Record<string, jest.Mock>) {
@@ -82,6 +89,9 @@ describe('TasksService — location-based visibility scoping', () => {
     mockGroupRepo = {
       createQueryBuilder: jest.fn().mockReturnValue(groupQb),
     };
+    // Must be set before module.compile() so the TenantAwareRepository mock
+    // returns the current mockGroupRepo when the service is constructed.
+    groupRepoForTest = mockGroupRepo;
 
     const mockConnection: Partial<Connection> = {
       getRepository: jest.fn((entity: any) => {
@@ -89,9 +99,9 @@ describe('TasksService — location-based visibility scoping', () => {
         if (entity === TaskComment) return mockCommentRepo;
         if (entity === TaskAttachment) return {};
         if (entity === GroupMembership) return mockMembershipRepo;
-        if (entity === Group) return mockGroupRepo;
         throw new Error(`Unexpected entity requested: ${entity}`);
       }) as any,
+      manager: {} as any,
       transaction: jest.fn((fn: any) => fn({})) as any,
     };
 

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -125,7 +125,7 @@ export class TasksService {
       assignedToId?: number | 'unassigned';
       locationGroupIds?: number[];
     } = {},
-    user?: any,
+    user: any,
   ): Promise<TaskListPayload> {
     const tenantId = this.tenantContext.requireTenant();
 
@@ -248,7 +248,7 @@ export class TasksService {
     };
   }
 
-  async findAllForContact(contactId: number, user?: any): Promise<Task[]> {
+  async findAllForContact(contactId: number, user: any): Promise<Task[]> {
     const tenantId = this.tenantContext.requireTenant();
     await this.assertContactLocationAccess(contactId, user);
     const tasks = await this.taskRepository.find({
@@ -267,7 +267,7 @@ export class TasksService {
     return tasks;
   }
 
-  async findOne(taskId: number, user?: any): Promise<Task> {
+  async findOne(taskId: number, user: any): Promise<Task> {
     const tenantId = this.tenantContext.requireTenant();
     const task = await this.findTaskWithRelations(taskId, tenantId);
     await this.assertContactLocationAccess(task.contact.id, user);

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -13,6 +13,7 @@ import GroupMembership from '../groups/entities/groupMembership.entity';
 import Group from '../groups/entities/group.entity';
 import { GroupPermissionsService } from '../groups/services/group-permissions.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
+import { TenantAwareRepository } from '../shared/repository/tenant-aware.repository';
 import { ContactActivityService } from '../crm/contact-activity.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
@@ -70,7 +71,7 @@ export class TasksService {
   private readonly commentRepository: Repository<TaskComment>;
   private readonly attachmentRepository: Repository<TaskAttachment>;
   private readonly membershipRepository: Repository<GroupMembership>;
-  private readonly groupRepository: Repository<Group>;
+  private readonly groupRepository: TenantAwareRepository<Group>;
 
   constructor(
     @Inject('CONNECTION') connection: Connection,
@@ -83,7 +84,11 @@ export class TasksService {
     this.commentRepository = connection.getRepository(TaskComment);
     this.attachmentRepository = connection.getRepository(TaskAttachment);
     this.membershipRepository = connection.getRepository(GroupMembership);
-    this.groupRepository = connection.getRepository(Group);
+    this.groupRepository = new TenantAwareRepository(
+      Group,
+      connection.manager,
+      tenantContext,
+    );
   }
 
   async create(createdById: number, dto: CreateTaskDto): Promise<Task> {

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Inject,
   Injectable,
   NotFoundException,
@@ -10,6 +11,7 @@ import { TaskComment } from './entities/task-comment.entity';
 import { TaskAttachment } from './entities/task-attachment.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
 import Group from '../groups/entities/group.entity';
+import { GroupPermissionsService } from '../groups/services/group-permissions.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { ContactActivityService } from '../crm/contact-activity.service';
 import { CreateTaskDto } from './dto/create-task.dto';
@@ -74,6 +76,7 @@ export class TasksService {
     @Inject('CONNECTION') connection: Connection,
     private readonly tenantContext: TenantContext,
     private readonly contactActivityService: ContactActivityService,
+    private readonly groupPermissionsService: GroupPermissionsService,
   ) {
     this.connection = connection;
     this.taskRepository = connection.getRepository(Task);
@@ -122,8 +125,27 @@ export class TasksService {
       assignedToId?: number | 'unassigned';
       locationGroupIds?: number[];
     } = {},
+    user?: any,
   ): Promise<TaskListPayload> {
     const tenantId = this.tenantContext.requireTenant();
+
+    const accessibleLocationGroupIds =
+      await this.resolveAccessibleLocationGroupIds(user);
+    if (accessibleLocationGroupIds !== null) {
+      const requestedLocationGroupIds = filters.locationGroupIds?.length
+        ? new Set(filters.locationGroupIds)
+        : null;
+      const effectiveLocationGroupIds = requestedLocationGroupIds
+        ? accessibleLocationGroupIds.filter((id) =>
+            requestedLocationGroupIds.has(id),
+          )
+        : accessibleLocationGroupIds;
+
+      if (effectiveLocationGroupIds.length === 0) {
+        return { data: [], groups: [], total: 0 };
+      }
+      filters = { ...filters, locationGroupIds: effectiveLocationGroupIds };
+    }
 
     const qb = this.taskRepository
       .createQueryBuilder('task')
@@ -226,8 +248,9 @@ export class TasksService {
     };
   }
 
-  async findAllForContact(contactId: number): Promise<Task[]> {
+  async findAllForContact(contactId: number, user?: any): Promise<Task[]> {
     const tenantId = this.tenantContext.requireTenant();
+    await this.assertContactLocationAccess(contactId, user);
     const tasks = await this.taskRepository.find({
       where: {
         tenant: { id: tenantId },
@@ -244,9 +267,11 @@ export class TasksService {
     return tasks;
   }
 
-  async findOne(taskId: number): Promise<Task> {
+  async findOne(taskId: number, user?: any): Promise<Task> {
     const tenantId = this.tenantContext.requireTenant();
-    return this.findTaskWithRelations(taskId, tenantId);
+    const task = await this.findTaskWithRelations(taskId, tenantId);
+    await this.assertContactLocationAccess(task.contact.id, user);
+    return task;
   }
 
   async update(
@@ -486,6 +511,66 @@ export class TasksService {
     if (!contact) return;
     contact.address = contact.addresses?.[0]?.freeForm ?? null;
     delete contact.addresses;
+  }
+
+  // Returns the location-purpose group ids the user may view tasks for, or
+  // null when the user is unrestricted (admin) and should see every location.
+  // A leader's accessible groups already expand to include all descendants
+  // (see GroupPermissionsService.getUserGroupIds), so a leader of a
+  // structure group above location (FOB/region/network/movement) naturally
+  // resolves to every location beneath it, while a location leader resolves
+  // to just their own location.
+  private async resolveAccessibleLocationGroupIds(
+    user: any,
+  ): Promise<number[] | null> {
+    const accessibleGroupIds =
+      await this.groupPermissionsService.getAccessibleGroupIds(user);
+    if (accessibleGroupIds === null) {
+      return null;
+    }
+    if (accessibleGroupIds.length === 0) {
+      return [];
+    }
+
+    const tenantId = this.tenantContext.requireTenant();
+    const locationGroups = await this.groupRepository
+      .createQueryBuilder('group')
+      .innerJoin('group.category', 'category')
+      .where('group.id IN (:...groupIds)', { groupIds: accessibleGroupIds })
+      .andWhere('group.tenantId = :tenantId', { tenantId })
+      .andWhere('category.purpose = :purpose', {
+        purpose: GroupCategoryPurpose.LOCATION,
+      })
+      .select(['group.id'])
+      .getMany();
+
+    return locationGroups.map((group) => group.id);
+  }
+
+  private async assertContactLocationAccess(
+    contactId: number,
+    user: any,
+  ): Promise<void> {
+    const accessibleLocationGroupIds =
+      await this.resolveAccessibleLocationGroupIds(user);
+    if (accessibleLocationGroupIds === null) {
+      return;
+    }
+
+    const hasAccess = accessibleLocationGroupIds.length
+      ? await this.membershipRepository
+          .createQueryBuilder('gm')
+          .where('gm.contactId = :contactId', { contactId })
+          .andWhere('gm.groupId IN (:...groupIds)', {
+            groupIds: accessibleLocationGroupIds,
+          })
+          .andWhere('gm.isActive = true')
+          .getCount()
+      : 0;
+
+    if (!hasAccess) {
+      throw new ForbiddenException('You do not have access to this task');
+    }
   }
 
   private async attachLocationGroups(


### PR DESCRIPTION
fix(tasks): scope task visibility to the user's location hierarchy

Restrict TasksController's `findAll/findOne/findAllForContact `so a
logged-in user only sees tasks for their own location, unless they
lead a group higher in the hierarchy (movement/network/region/FOB),
in which case they see every location beneath it. Admins remain
unrestricted.

- TasksService gains `resolveAccessibleLocationGroupIds(user)`, which
  reuses `GroupPermissionsService.getAccessibleGroupIds `(already
  expands a leader's groups to all descendants) and filters it down
  to LOCATION-purpose groups, and `assertContactLocationAccess` to gate
  single-resource reads.
- `findAll` now derives/intersects locationGroupIds from the user's
  access instead of trusting the client-supplied query param.
- `findOne/findAllForContact` throw ForbiddenException when the task's
  contact is outside the user's accessible locations (NotFoundException
  still takes precedence when the task itself doesn't exist).
- TasksModule imports GroupsModule to get GroupPermissionsService.
- Added `tasks.service.spec.ts` covering admin bypass, single-location
  scoping, multi-location scoping for higher-level leaders, client
  param intersection, and Forbidden/NotFound behavior.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
EOF

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location-based access controls for viewing tasks.
  * Task lists now respect accessible location groups, including requested location filters.
  * Task details and contact task lists are restricted to authorized locations.
  * Administrators retain unrestricted task access.

* **Bug Fixes**
  * Invalid location filter values are normalized and excluded from task searches.
  * Unauthorized requests now return appropriate empty or forbidden results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->