### PR TITLE
Feat/group search same location - and use them in the TASKS frontend dropdown to allocate MCs without having to belong to them

### DIFF
--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -123,6 +123,7 @@ export class ContactImportController {
           const groupData = await this.groupsService.findOne(
             effectiveGroupId,
             false,
+            req.user,
           );
           if (!groupData) {
             throw new BadRequestException({

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -173,7 +173,10 @@ export class ContactImportController {
 
   @Post('groupLeaders')
   @UseInterceptors(FileInterceptor('file'))
-  async uploadGroupLeaders(@UploadedFile() file: Express.Multer.File) {
+  async uploadGroupLeaders(
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: any,
+  ) {
     if (!file) {
       throw new BadRequestException({ message: 'No file was uploaded.' });
     }
@@ -212,6 +215,7 @@ export class ContactImportController {
             groupData = await this.groupsService.findOne(
               uploadedContact.groupId,
               false,
+              req.user,
             );
             if (!groupData) {
               throw new BadRequestException({

--- a/src/groups/controllers/group-membership-request.contoller.ts
+++ b/src/groups/controllers/group-membership-request.contoller.ts
@@ -29,7 +29,6 @@ export class GroupMembershipReqeustController {
   async findAll(
     @Query() req: GroupMembershipRequestSearchDto,
   ): Promise<GroupMembershipRequestDto[]> {
-    console.log('*****-----', req);
     return await this.service.findAll(req);
   }
 
@@ -37,7 +36,6 @@ export class GroupMembershipReqeustController {
   async create(
     @Body() data: NewRequestDto,
   ): Promise<GroupMembershipRequestDto | any> {
-    console.log('****', data);
     return await this.service.create(data);
   }
 

--- a/src/groups/services/group-membership-request.service.ts
+++ b/src/groups/services/group-membership-request.service.ts
@@ -69,7 +69,6 @@ export class GroupMembershipRequestService {
   }
 
   async create(data: NewRequestDto): Promise<GroupMembershipRequestDto | any> {
-    console.log('%%%', data);
     const user = await this.contactRepository.findOne({
       where: { id: data.contactId },
       relations: ['person'],

--- a/src/groups/services/group-permissions.service.ts
+++ b/src/groups/services/group-permissions.service.ts
@@ -135,6 +135,7 @@ export class GroupPermissionsService {
     const memberships = await this.membershipRepository.find({
       where: { contactId, isActive: true },
       relations: { group: { category: true } },
+      order: { groupId: 'ASC' },
     });
 
     const directLocation = memberships.find(

--- a/src/groups/services/group-permissions.service.ts
+++ b/src/groups/services/group-permissions.service.ts
@@ -3,6 +3,7 @@ import { Connection, In, Repository, TreeRepository } from 'typeorm';
 import Group from '../entities/group.entity';
 import GroupMembership from '../entities/groupMembership.entity';
 import { GroupRole } from '../enums/groupRole';
+import { GroupCategoryPurpose } from '../enums/groups';
 import ClientFriendlyException from '../../shared/exceptions/client-friendly.exception';
 import { roleAdmin } from '../../auth/constants';
 
@@ -50,7 +51,9 @@ export class GroupPermissionsService {
 
     // Replacing crashing TypeORM 0.3.29 findAncestors tree method
     const ancestorIds: number[] = [];
-    let currentParentId = targetGroup.parentId ? Number(targetGroup.parentId) : null;
+    let currentParentId = targetGroup.parentId
+      ? Number(targetGroup.parentId)
+      : null;
     const visitedParentIds = new Set<number>();
     while (currentParentId !== null && !isNaN(currentParentId)) {
       if (visitedParentIds.has(currentParentId)) {
@@ -62,8 +65,11 @@ export class GroupPermissionsService {
         where: { id: currentParentId },
         select: ['id', 'parentId'],
       });
-      currentParentId = parentNode?.parentId ? Number(parentNode.parentId) : null;
-    }    if (ancestorIds.length > 0) {
+      currentParentId = parentNode?.parentId
+        ? Number(parentNode.parentId)
+        : null;
+    }
+    if (ancestorIds.length > 0) {
       const parentLeadership = await this.membershipRepository.count({
         where: {
           contactId: user.contactId,
@@ -115,6 +121,67 @@ export class GroupPermissionsService {
     const descendantIds = await this.getGroupAndAllDescendants(membershipIds);
     const idList = new Set([...membershipIds, ...descendantIds]);
     return Array.from(idList);
+  }
+
+  // Resolves the LOCATION-purpose group a contact belongs to. A direct
+  // membership in a LOCATION-purpose group always wins; only when the
+  // contact has no such direct membership do we fall back to walking up
+  // from their other memberships (e.g. a fellowship) to find a LOCATION
+  // ancestor. Without this priority, a contact who is, say, a fellowship
+  // leader at one location but also a plain member of a *different* home
+  // location would non-deterministically resolve to whichever membership
+  // row happened to be scanned first.
+  async getContactLocationGroupId(contactId: number): Promise<number | null> {
+    const memberships = await this.membershipRepository.find({
+      where: { contactId, isActive: true },
+      relations: { group: { category: true } },
+    });
+
+    const directLocation = memberships.find(
+      (m) => m.group?.category?.purpose === GroupCategoryPurpose.LOCATION,
+    );
+    if (directLocation) {
+      return directLocation.groupId;
+    }
+
+    const groupIds = memberships
+      .map((it) => Number(it.groupId))
+      .filter((id) => !isNaN(id));
+
+    for (const groupId of groupIds) {
+      const locationId = await this.findLocationAncestor(groupId);
+      if (locationId !== null) {
+        return locationId;
+      }
+    }
+    return null;
+  }
+
+  private async findLocationAncestor(groupId: number): Promise<number | null> {
+    let currentId: number | null = groupId;
+    const visited = new Set<number>();
+    while (currentId !== null && !visited.has(currentId)) {
+      visited.add(currentId);
+      const group = await this.repository.findOne({
+        where: { id: currentId },
+        relations: { category: true },
+      });
+      if (!group) {
+        return null;
+      }
+      if (group.category?.purpose === GroupCategoryPurpose.LOCATION) {
+        return group.id;
+      }
+      currentId = group.parentId ? Number(group.parentId) : null;
+    }
+    return null;
+  }
+
+  // Public wrapper so callers outside this service (e.g. GroupsService's
+  // sameLocation scoping) can expand a set of root groups to their full
+  // descendant set without duplicating the traversal.
+  async getDescendantGroupIds(rootGroupIds: number[]): Promise<number[]> {
+    return this.getGroupAndAllDescendants(rootGroupIds);
   }
 
   async getUserIsMemberLeaderGroupIds(user: any) {

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -76,6 +76,20 @@ export class GroupsService {
   }
 
   async findAll(req: SearchDto, user?: any): Promise<any[]> {
+    // Scoped to the requesting user's own location rather than their
+    // leader/member access - e.g. staff updating another contact's task need
+    // to see all fellowship/serving-team groups at their own location even
+    // though they don't lead any of them. Note: this can't be scoped to the
+    // *target* contact's location instead, since that contact typically has
+    // no group memberships yet - that's exactly what the task is tracking.
+    if (req.purpose && req.sameLocation && user?.contactId) {
+      return this.findGroupsByPurposeForContactLocation(
+        req.purpose as GroupCategoryPurpose,
+        req.parentId,
+        Number(user.contactId),
+      );
+    }
+
     // Groups the user leads (directly or via an ancestor) or, for admins,
     // null meaning unrestricted. Mirrors GroupPermissionsService.hasPermissionForGroup.
     const accessibleGroupIds =
@@ -179,6 +193,26 @@ export class GroupsService {
     }
 
     return query.orderBy('group.name', 'ASC').getMany();
+  }
+
+  private async findGroupsByPurposeForContactLocation(
+    purpose: GroupCategoryPurpose,
+    parentId: string | undefined,
+    contactId: number,
+  ): Promise<Group[]> {
+    const locationGroupId =
+      await this.groupsPermissionsService.getContactLocationGroupId(contactId);
+    if (locationGroupId === null) {
+      return [];
+    }
+
+    const descendantIds =
+      await this.groupsPermissionsService.getDescendantGroupIds([
+        locationGroupId,
+      ]);
+    const scopedGroupIds = [locationGroupId, ...descendantIds];
+
+    return this.findGroupsByPurpose(purpose, parentId, scopedGroupIds);
   }
 
   private async buildGroupTree(
@@ -588,7 +622,9 @@ export class GroupsService {
 
       const parentIds: number[] = [];
       const visitedParentIds = new Set<number>();
-      let currentParentId: number | null = data.parentId ? Number(data.parentId) : null;
+      let currentParentId: number | null = data.parentId
+        ? Number(data.parentId)
+        : null;
       while (currentParentId !== null && !isNaN(currentParentId)) {
         if (visitedParentIds.has(currentParentId)) break;
         visitedParentIds.add(currentParentId);
@@ -597,10 +633,13 @@ export class GroupsService {
           where: { id: currentParentId },
           select: ['id', 'parentId'],
         });
-        
+
         // Coerce the next lookup property into a clean primitive digit or null break flag
-        currentParentId = parentNode?.parentId ? Number(parentNode.parentId) : null;
-      }      groupData.parents = parentIds;
+        currentParentId = parentNode?.parentId
+          ? Number(parentNode.parentId)
+          : null;
+      }
+      groupData.parents = parentIds;
       const childGroupIds: number[] = [data.id];
       const pendingParentIds: number[] = [data.id];
 
@@ -706,24 +745,27 @@ export class GroupsService {
 
     let parentGroup: Group | undefined;
     if (hasValue(dto.parentId)) {
-      parentGroup = (await this.treeRepository.findOne({
-        where: { id: dto.parentId },
-      })) ?? undefined;
+      parentGroup =
+        (await this.treeRepository.findOne({
+          where: { id: dto.parentId },
+        })) ?? undefined;
     }
     let category = currGroup.category;
     if (hasValue(dto.categoryId)) {
-      category = (await this.groupCategoryRepository.findOne({
-        where: {
-          id: dto.categoryId,
-        },
-      })) ?? undefined;
+      category =
+        (await this.groupCategoryRepository.findOne({
+          where: {
+            id: dto.categoryId,
+          },
+        })) ?? undefined;
     }
     if (hasValue(dto.categoryName)) {
-      category = (await this.groupCategoryRepository.findOne({
-        where: {
-          name: dto.categoryName,
-        },
-      })) ?? undefined;
+      category =
+        (await this.groupCategoryRepository.findOne({
+          where: {
+            name: dto.categoryName,
+          },
+        })) ?? undefined;
     }
 
     const result = await this.repository
@@ -845,21 +887,23 @@ export class GroupsService {
     const numericLimit = Number(limit) || 50;
     const numericOffset = Number(offset) || 0;
 
-    const memberships = await this.membershipRepository.createQueryBuilder('membership')
+    const memberships = await this.membershipRepository
+      .createQueryBuilder('membership')
       .leftJoinAndSelect('membership.contact', 'contact')
       .leftJoinAndSelect('contact.person', 'person')
       .leftJoinAndSelect('contact.emails', 'emails')
       .where('membership.groupId = :groupId', { groupId: numericGroupId })
-      .skip(numericOffset) 
+      .skip(numericOffset)
       .take(numericLimit)
       .getMany();
 
     const members = memberships.map((membership) => {
       const firstName = membership.contact?.person?.firstName ?? '';
       const lastName = membership.contact?.person?.lastName ?? '';
-      const fullName = (firstName || lastName)
-        ? `${firstName} ${lastName}`.trim()
-        : (membership.contact?.emails?.[0]?.value ?? 'Unknown Member');
+      const fullName =
+        firstName || lastName
+          ? `${firstName} ${lastName}`.trim()
+          : membership.contact?.emails?.[0]?.value ?? 'Unknown Member';
 
       return {
         id: membership.contact?.id,
@@ -869,14 +913,17 @@ export class GroupsService {
       };
     });
 
-    const total = await this.membershipRepository.count({ where: { groupId: numericGroupId } });
+    const total = await this.membershipRepository.count({
+      where: { groupId: numericGroupId },
+    });
 
     return {
       members,
       total,
       limit: numericLimit,
       offset: numericOffset,
-    };  }
+    };
+  }
 
   async getPublicLocations(): Promise<{ fobs: any[] }> {
     this.logger.business('log', 'Fetching public locations for signup', {

--- a/src/shared/dto/search.dto.ts
+++ b/src/shared/dto/search.dto.ts
@@ -1,5 +1,11 @@
-import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
-import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 
 export default class SearchDto {
   @IsString()
@@ -13,6 +19,14 @@ export default class SearchDto {
   @IsString()
   @IsOptional()
   parentId?: string;
+
+  // When true (with purpose), returns all groups of that purpose under the
+  // requesting user's own location, regardless of their leader/member access
+  // to those specific groups.
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  @IsOptional()
+  sameLocation?: boolean;
 
   @Type(() => Number)
   @IsNumber()

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -43,7 +43,8 @@ export class TasksController {
     @Query('status') status?: string | string[],
     @Query('type') type?: string | string[],
     @Query('assignedToId') assignedToId?: string,
-    @Query('locationGroupIds') locationGroupIds?: string | string[],
+    @Query('locationGroupIds')
+    locationGroupIds?: string | string[] | Record<string, string>,
   ) {
     const filters: {
       status?: TaskStatus[];
@@ -65,12 +66,24 @@ export class TasksController {
         assignedToId === 'unassigned' ? 'unassigned' : Number(assignedToId);
     }
     if (locationGroupIds !== undefined) {
-      filters.locationGroupIds = (
-        Array.isArray(locationGroupIds) ? locationGroupIds : [locationGroupIds]
-      ).map(Number);
+      const ids = this.toNumberArray(locationGroupIds);
+      if (ids.length) filters.locationGroupIds = ids;
     }
 
     return this.tasksService.findAll(Number(page), Number(limit), filters);
+  }
+
+  // qs (used by Express/Nest to parse query strings) only decodes repeated
+  // keys (e.g. `?locationGroupIds=1&locationGroupIds=2...`) into an array up
+  // to its default arrayLimit of 20 entries; beyond that it falls back to a
+  // plain object keyed "0", "1", ... instead, so this must handle all shapes.
+  private toNumberArray(value: string | string[] | Record<string, string>) {
+    const values = Array.isArray(value)
+      ? value
+      : typeof value === 'object'
+      ? Object.values(value)
+      : [value];
+    return values.map(Number).filter((id) => Number.isFinite(id));
   }
 
   @Get('contact/:contactId')


### PR DESCRIPTION
feat(groups): scope sameLocation search by acting user, not target contact

- GroupPermissionsService: `getContactLocationGroupId` now prioritises   a direct `LOCATION-purpose` membership over inferring one through an unrelated fellowship membership, fixing a nondeterministic edge case
  found while testing (a user who's a fellowship leader in location A but a plain member of location B).

- `GroupsService.findAll` now takes a new path: when `purpose + sameLocation=true + locationContactId` are all present, it resolves the contact's location and returns all groups of that purpose under it — bypassing the normal leader/member accessibleGroupIds restriction entirely. `findAll` now resolves location from `user.contactId`
  (the JWT-authenticated caller), not a client-supplied contact.

- `search.dto.ts`: has `sameLocation` remains.

# Ticket No
- GoLive202

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location-based filtering for groups and tasks.
  * Added support for querying groups within a contact’s location and descendant locations.
  * Improved contact imports by validating groups using the requesting user’s context.
  * Added reliable handling for location group filters in task searches.

* **Bug Fixes**
  * Improved group hierarchy traversal and location resolution.
  * Group member results now include accurate membership counts.
  * Removed unnecessary debug output from group membership operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->