### PR TITLE
feat: add weekly MC attendance total to reports summary

### DIFF
--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -17,6 +17,7 @@ import { User } from '../users/entities/user.entity';
 import { ReportField } from './entities/report.field.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
 import Group from '../groups/entities/group.entity';
+import { GroupCategoryNames } from '../groups/enums/groups';
 
 jest.mock('src/utils/mailer', () => ({
   sendEmail: jest.fn().mockResolvedValue('mock-message-id'),
@@ -70,6 +71,7 @@ describe('ReportsService', () => {
         findDescendants: jest.fn(),
         findAncestors: jest.fn(),
         findOne: jest.fn(),
+        find: jest.fn(),
       },
     };
 
@@ -371,6 +373,10 @@ describe('ReportsService', () => {
   });
 
   describe('getMyGroupsSubmissions', () => {
+    beforeEach(() => {
+      mockRepositories.groupTree.find.mockResolvedValue([]);
+    });
+
     const mockUser = { id: 7, contactId: 3 };
 
     const makeSubmission = (id: number, groupId = 10) => ({
@@ -484,109 +490,168 @@ describe('ReportsService', () => {
       ]);
     });
 
-    it('calculates weekly attendance total from attendance submissions', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValue([
-        { groupId: 10 },
-      ]);
+    describe('weekly attendance total calculation', () => {
+      beforeEach(() => {
+        mockRepositories.groupMembership.find.mockResolvedValue([
+          { groupId: 10 },
+        ]);
 
-      mockGroupTreeService.getGroupAndAllChildren = jest
-        .fn()
-        .mockResolvedValue([10]);
+        mockGroupTreeService.getGroupAndAllChildren = jest
+          .fn()
+          .mockResolvedValue([10]);
 
-      mockRepositories.reportSubmission.find.mockResolvedValue([
-        {
-          ...makeSubmission(1),
-          submissionData: [
-            {
-              reportField: { name: 'smallGroupAttendanceCount' },
-              fieldValue: '10',
+        mockRepositories.report.findOne.mockResolvedValue({
+          id: 99,
+          name: 'MC Attendance Report',
+        });
+
+        mockRepositories.groupTree.find.mockResolvedValue([
+          {
+            id: 10,
+            category: {
+              name: GroupCategoryNames.MC,
             },
-          ],
-        },
-        {
-          ...makeSubmission(2),
-          submissionData: [
+          },
+        ]);
+      });
+
+      it('calculates weekly attendance total from attendance submissions', async () => {
+        mockRepositories.reportSubmission.find
+          .mockResolvedValueOnce([
+            // normal getMyGroupsSubmissions query
+            makeSubmission(1),
+            makeSubmission(2),
+          ])
+          .mockResolvedValueOnce([
+            // weekly attendance query
             {
-              reportField: { name: 'smallGroupAttendanceCount' },
-              fieldValue: '15',
+              ...makeSubmission(1),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '10',
+                },
+              ],
             },
-          ],
-        },
-      ]);
-
-      const result = await service.getMyGroupsSubmissions(mockUser, {});
-
-      expect(result.summary.weeklyAttendanceTotal).toBe(25);
-    });
-
-    it('ignores submissions without attendance field', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValue([
-        { groupId: 10 },
-      ]);
-
-      mockGroupTreeService.getGroupAndAllChildren = jest
-        .fn()
-        .mockResolvedValue([10]);
-
-      mockRepositories.reportSubmission.find.mockResolvedValue([
-        {
-          ...makeSubmission(1),
-          submissionData: [
             {
-              reportField: { name: 'otherField' },
-              fieldValue: '10',
+              ...makeSubmission(2),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '15',
+                },
+              ],
             },
-          ],
-        },
-        {
-          ...makeSubmission(2),
-          submissionData: [
+          ]);
+
+        const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(result.summary.weeklyAttendanceTotal).toBe(25);
+      });
+
+      it('ignores invalid attendance values', async () => {
+        mockRepositories.reportSubmission.find
+          .mockResolvedValueOnce([makeSubmission(1)])
+          .mockResolvedValueOnce([
             {
-              reportField: { name: 'smallGroupAttendanceCount' },
-              fieldValue: '15',
+              ...makeSubmission(1),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: 'abc',
+                },
+              ],
             },
-          ],
-        },
-      ]);
-
-      const result = await service.getMyGroupsSubmissions(mockUser, {});
-
-      expect(result.summary.weeklyAttendanceTotal).toBe(15);
-    });
-
-    it('ignores invalid attendance values', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValue([
-        { groupId: 10 },
-      ]);
-
-      mockGroupTreeService.getGroupAndAllChildren = jest
-        .fn()
-        .mockResolvedValue([10]);
-
-      mockRepositories.reportSubmission.find.mockResolvedValue([
-        {
-          ...makeSubmission(1),
-          submissionData: [
             {
-              reportField: { name: 'smallGroupAttendanceCount' },
-              fieldValue: 'abc', // invalid number
+              ...makeSubmission(2),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '15',
+                },
+              ],
             },
-          ],
-        },
-        {
-          ...makeSubmission(2),
-          submissionData: [
-            {
-              reportField: { name: 'smallGroupAttendanceCount' },
-              fieldValue: '15',
+          ]);
+
+        const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(result.summary.weeklyAttendanceTotal).toBe(15);
+      });
+
+      it('looks up the MC Attendance Report by name instead of using a hardcoded ID', async () => {
+        mockRepositories.reportSubmission.find.mockResolvedValue([]);
+
+        await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(mockRepositories.report.findOne).toHaveBeenCalledWith({
+          where: {
+            name: 'MC Attendance Report',
+          },
+        });
+
+        expect(mockRepositories.reportSubmission.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              report: {
+                id: 99,
+              },
+            }),
+          }),
+        );
+      });
+
+      it('returns zero attendance when the MC Attendance Report does not exist', async () => {
+        mockRepositories.report.findOne.mockResolvedValue(null);
+
+        mockRepositories.reportSubmission.find.mockResolvedValue([]);
+
+        const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(result.summary.weeklyAttendanceTotal).toBe(0);
+
+        expect(mockRepositories.reportSubmission.find).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns zero when accessible groups are not MC groups', async () => {
+        mockRepositories.groupTree.find.mockResolvedValue([
+          {
+            id: 10,
+            category: {
+              name: 'Zone',
             },
-          ],
-        },
-      ]);
+          },
+        ]);
 
-      const result = await service.getMyGroupsSubmissions(mockUser, {});
+        mockRepositories.reportSubmission.find.mockResolvedValue([
+          makeSubmission(1),
+        ]);
 
-      expect(result.summary.weeklyAttendanceTotal).toBe(15);
+        const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(result.summary.weeklyAttendanceTotal).toBe(0);
+
+        expect(mockRepositories.report.findOne).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -483,6 +483,111 @@ describe('ReportsService', () => {
         { name: 'attendance', label: 'Attendance Count' },
       ]);
     });
+
+    it('calculates weekly attendance total from attendance submissions', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        {
+          ...makeSubmission(1),
+          submissionData: [
+            {
+              reportField: { name: 'smallGroupAttendanceCount' },
+              fieldValue: '10',
+            },
+          ],
+        },
+        {
+          ...makeSubmission(2),
+          submissionData: [
+            {
+              reportField: { name: 'smallGroupAttendanceCount' },
+              fieldValue: '15',
+            },
+          ],
+        },
+      ]);
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+      expect(result.summary.weeklyAttendanceTotal).toBe(25);
+    });
+
+    it('ignores submissions without attendance field', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        {
+          ...makeSubmission(1),
+          submissionData: [
+            {
+              reportField: { name: 'otherField' },
+              fieldValue: '10',
+            },
+          ],
+        },
+        {
+          ...makeSubmission(2),
+          submissionData: [
+            {
+              reportField: { name: 'smallGroupAttendanceCount' },
+              fieldValue: '15',
+            },
+          ],
+        },
+      ]);
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+      expect(result.summary.weeklyAttendanceTotal).toBe(15);
+    });
+
+    it('ignores invalid attendance values', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        {
+          ...makeSubmission(1),
+          submissionData: [
+            {
+              reportField: { name: 'smallGroupAttendanceCount' },
+              fieldValue: 'abc', // invalid number
+            },
+          ],
+        },
+        {
+          ...makeSubmission(2),
+          submissionData: [
+            {
+              reportField: { name: 'smallGroupAttendanceCount' },
+              fieldValue: '15',
+            },
+          ],
+        },
+      ]);
+
+      const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+      expect(result.summary.weeklyAttendanceTotal).toBe(15);
+    });
   });
 
   describe('submitReport - weekly duplicate limit', () => {

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -598,7 +598,7 @@ describe('ReportsService', () => {
         expect(result.summary.weeklyAttendanceTotal).toBe(15);
       });
 
-      it('looks up the MC Attendance Report by name instead of using a hardcoded ID', async () => {
+      it('looks up the MC Attendance Report by name within the current tenant', async () => {
         mockRepositories.reportSubmission.find.mockResolvedValue([]);
 
         await service.getMyGroupsSubmissions(mockUser, {});
@@ -606,6 +606,9 @@ describe('ReportsService', () => {
         expect(mockRepositories.report.findOne).toHaveBeenCalledWith({
           where: {
             name: 'MC Attendance Report',
+            tenant: {
+              id: 1,
+            },
           },
         });
 
@@ -618,6 +621,83 @@ describe('ReportsService', () => {
             }),
           }),
         );
+      });
+
+      it('returns zero weekly attendance summary when user has no accessible groups', async () => {
+        jest
+          .spyOn(service as any, 'getUserAccessibleGroups')
+          .mockResolvedValue([]);
+
+        const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(result.summary.weeklyAttendanceTotal).toBe(0);
+      });
+
+      it('ignores malformed, decimal and negative attendance values', async () => {
+        mockRepositories.reportSubmission.find
+          .mockResolvedValueOnce([makeSubmission(1)])
+          .mockResolvedValueOnce([
+            {
+              ...makeSubmission(1),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '10',
+                },
+              ],
+            },
+            {
+              ...makeSubmission(2),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '15people',
+                },
+              ],
+            },
+            {
+              ...makeSubmission(3),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '15.5',
+                },
+              ],
+            },
+            {
+              ...makeSubmission(4),
+              report: {
+                id: 99,
+                name: 'MC Attendance Report',
+              },
+              reportingPeriod: new Date('2024-06-10'),
+              submissionData: [
+                {
+                  reportField: { name: 'smallGroupAttendanceCount' },
+                  fieldValue: '-5',
+                },
+              ],
+            },
+          ]);
+
+        const result = await service.getMyGroupsSubmissions(mockUser, {});
+
+        expect(result.summary.weeklyAttendanceTotal).toBe(10);
       });
 
       it('returns zero attendance when the MC Attendance Report does not exist', async () => {

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -474,18 +474,6 @@ export class ReportsService {
           user,
         );
 
-        // filteredReports = reports;
-
-        console.log({
-          totalReports: reports.length,
-          reports: reports.map((r) => ({
-            id: r.id,
-            name: r.name,
-            category: r.targetGroupCategory?.name,
-          })),
-          userId: user.id,
-        });
-
         this.logger.security('log', 'Permission filtering completed', {
           operation: 'getAllReports',
           userId: user?.id,
@@ -1304,7 +1292,6 @@ export class ReportsService {
 
     // Get user's accessible groups using the new permission system
     const userGroupIds = await this.getUserAccessibleGroups(user);
-    console.log('USER GROUP IDS:', userGroupIds);
 
     const where: any = {};
     if (reportId) {
@@ -1347,21 +1334,6 @@ export class ReportsService {
 
     const weeklyAttendanceTotal =
       this.calculateAttendanceTotal(filteredSubmissions);
-
-    // if (weeklyAttendanceTotal > 0) {
-    //   this.logger.business('log', 'Weekly attendance total calculated', {
-    //     operation: 'getMyGroupsSubmissions',
-    //     userId: user?.id,
-    //     contactId: user?.contactId,
-    //     metadata: { weeklyAttendanceTotal },
-    //   });
-    // } else {
-    //   this.logger.business('log', 'No attendance data found for the week', {
-    //     operation: 'getMyGroupsSubmissions',
-    //     userId: user?.id,
-    //     contactId: user?.contactId,
-    //   });
-    // }
 
     // Apply pagination
     const paginatedSubmissions = filteredSubmissions.slice(

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -474,6 +474,18 @@ export class ReportsService {
           user,
         );
 
+        // filteredReports = reports;
+
+        console.log({
+          totalReports: reports.length,
+          reports: reports.map((r) => ({
+            id: r.id,
+            name: r.name,
+            category: r.targetGroupCategory?.name,
+          })),
+          userId: user.id,
+        });
+
         this.logger.security('log', 'Permission filtering completed', {
           operation: 'getAllReports',
           userId: user?.id,
@@ -1258,6 +1270,26 @@ export class ReportsService {
     };
   }
 
+  private calculateAttendanceTotal(submissions: ReportSubmission[]): number {
+    let totalAttendance = 0;
+
+    for (const submission of submissions) {
+      const attendanceField = submission.submissionData.find(
+        (sd) => sd.reportField.name === 'smallGroupAttendanceCount',
+      );
+
+      if (attendanceField) {
+        const attendanceValue = parseInt(attendanceField.fieldValue, 10);
+
+        if (!isNaN(attendanceValue)) {
+          totalAttendance += attendanceValue;
+        }
+      }
+    }
+
+    return totalAttendance;
+  }
+
   async getMyGroupsSubmissions(
     user: any,
     options: {
@@ -1272,6 +1304,7 @@ export class ReportsService {
 
     // Get user's accessible groups using the new permission system
     const userGroupIds = await this.getUserAccessibleGroups(user);
+    console.log('USER GROUP IDS:', userGroupIds);
 
     const where: any = {};
     if (reportId) {
@@ -1311,6 +1344,24 @@ export class ReportsService {
     }
 
     const total = filteredSubmissions.length;
+
+    const weeklyAttendanceTotal =
+      this.calculateAttendanceTotal(filteredSubmissions);
+
+    // if (weeklyAttendanceTotal > 0) {
+    //   this.logger.business('log', 'Weekly attendance total calculated', {
+    //     operation: 'getMyGroupsSubmissions',
+    //     userId: user?.id,
+    //     contactId: user?.contactId,
+    //     metadata: { weeklyAttendanceTotal },
+    //   });
+    // } else {
+    //   this.logger.business('log', 'No attendance data found for the week', {
+    //     operation: 'getMyGroupsSubmissions',
+    //     userId: user?.id,
+    //     contactId: user?.contactId,
+    //   });
+    // }
 
     // Apply pagination
     const paginatedSubmissions = filteredSubmissions.slice(
@@ -1363,6 +1414,9 @@ export class ReportsService {
         limit,
         offset,
         hasMore: total > offset + limit,
+      },
+      summary: {
+        weeklyAttendanceTotal,
       },
     };
   }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1258,6 +1258,84 @@ export class ReportsService {
     };
   }
 
+  private async getWeeklyMcAttendanceTotal(
+    user: any,
+    startDate?: Date,
+    endDate?: Date,
+  ): Promise<number> {
+    // Get groups the user can access based on current permission rules
+    const accessibleGroups = await this.getUserAccessibleGroups(user);
+
+    if (!accessibleGroups.length) {
+      return 0;
+    }
+
+    // Get groups with their categories
+    const groups = await this.treeRepository.find({
+      where: {
+        id: In(accessibleGroups),
+      },
+      relations: ['category'],
+    });
+
+    // Keep only Missional Communities
+    const mcGroups = groups.filter(
+      (group) => group.category?.name === GroupCategoryNames.MC,
+    );
+
+    if (!mcGroups.length) {
+      return 0;
+    }
+
+    const mcIds = mcGroups.map((group) => group.id);
+    const MC_ATTENDANCE_REPORT_NAME = 'MC Attendance Report';
+
+    // Find MC Attendance Report dynamically instead of relying on a fixed ID
+    const mcAttendanceReport = await this.reportRepository.findOne({
+      where: {
+        name: MC_ATTENDANCE_REPORT_NAME,
+      },
+    });
+
+    if (!mcAttendanceReport) {
+      return 0;
+    }
+
+    // Fetch MC Attendance Report submissions
+    const submissions = await this.reportSubmissionRepository.find({
+      where: {
+        report: {
+          id: mcAttendanceReport.id,
+        },
+        group: {
+          id: In(mcIds),
+        },
+      },
+      relations: ['submissionData', 'submissionData.reportField'],
+    });
+
+    // Apply reporting period filtering
+    const filteredSubmissions = submissions.filter((submission) => {
+      if (!submission.reportingPeriod) {
+        return false;
+      }
+
+      const reportingDate = new Date(submission.reportingPeriod);
+
+      if (startDate && reportingDate < startDate) {
+        return false;
+      }
+
+      if (endDate && reportingDate > endDate) {
+        return false;
+      }
+
+      return true;
+    });
+
+    return this.calculateAttendanceTotal(filteredSubmissions);
+  }
+
   private calculateAttendanceTotal(submissions: ReportSubmission[]): number {
     let totalAttendance = 0;
 
@@ -1322,18 +1400,27 @@ export class ReportsService {
 
     // Apply date filtering
     let filteredSubmissions = submissions;
+
     if (startDate || endDate) {
       filteredSubmissions = submissions.filter((sub) => {
-        if (startDate && sub.submittedAt < startDate) return false;
-        if (endDate && sub.submittedAt > endDate) return false;
+        if (!sub.reportingPeriod) return false;
+
+        const reportingDate = new Date(sub.reportingPeriod);
+
+        if (startDate && reportingDate < startDate) return false;
+        if (endDate && reportingDate > endDate) return false;
+
         return true;
       });
     }
 
     const total = filteredSubmissions.length;
 
-    const weeklyAttendanceTotal =
-      this.calculateAttendanceTotal(filteredSubmissions);
+    const weeklyAttendanceTotal = await this.getWeeklyMcAttendanceTotal(
+      user,
+      startDate,
+      endDate,
+    );
 
     // Apply pagination
     const paginatedSubmissions = filteredSubmissions.slice(

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1294,6 +1294,9 @@ export class ReportsService {
     const mcAttendanceReport = await this.reportRepository.findOne({
       where: {
         name: MC_ATTENDANCE_REPORT_NAME,
+        tenant: {
+          id: this.tenantContext.requireTenant(),
+        },
       },
     });
 
@@ -1345,10 +1348,10 @@ export class ReportsService {
       );
 
       if (attendanceField) {
-        const attendanceValue = parseInt(attendanceField.fieldValue, 10);
+        const value = attendanceField.fieldValue;
 
-        if (!isNaN(attendanceValue)) {
-          totalAttendance += attendanceValue;
+        if (/^\d+$/.test(value)) {
+          totalAttendance += Number(value);
         }
       }
     }
@@ -1383,6 +1386,9 @@ export class ReportsService {
         submissions: [],
         columns: [],
         pagination: { total: 0, limit, offset, hasMore: false },
+        summary: {
+          weeklyAttendanceTotal: 0,
+        },
       };
     }
 


### PR DESCRIPTION
# Feat: Add weekly MC attendance total to reports summary

## Problem

The Reports page displayed individual MC Attendance Report submissions, but there was no aggregated view showing the total number of people who attended MCs within the selected reporting period. Leaders of parent groups were not able to view the total MC attendance.

Users had to manually calculate the combined attendance across multiple MC submissions.

## Root Cause

The existing `getMyGroupsSubmissions()` endpoint already retrieved all accessible report submissions for a user, but the response only returned the paginated submission data.
There was no summary calculation performed on the filtered submissions before returning the response.

## Fix

Added a backend calculation that:

- Filters submissions using the existing report visibility and date filtering logic.
- Extracts values from the `smallGroupAttendanceCount` report field.
- Safely ignores submissions without an attendance field.
- Ignores invalid attendance values instead of affecting the total.

The calculated value is returned through the existing response `summary` object:

```typescript
summary: {
  weeklyAttendanceTotal,
}
```

The frontend consumes this existing summary value and displays it only for the **MC Attendance Report.**

No new endpoint was introduced.

## Files Changed
- `reports.service.ts`
   - Added weekly attendance aggregation logic.
   - Added weeklyAttendanceTotal to the reports summary response.
   - Added getWeeklyMcAttendanceTotal to get the total attendance of groups under a parent
  
- `reports.service.spec.ts`
  - **Added tests covering:**
    - Attendance summation from MC Attendance Reports.
    - Invalid attendance values.
    - Missing MC Attendance Report handling.
    - Dynamic report lookup instead of hardcoded IDs.
    - Non-MC accessible groups returning zero attendance.

## Testing Done
Backend unit tests:
- Calculates total attendance from smallGroupAttendanceCount
- Ignores submissions without attendance fields
- Ignores invalid attendance values
- Finds out the smallgroups a leader of a parent group leads and shows their total attendance

Commands run:
```bash
npm test -- reports.service.spec.ts -t "attendance"
```
Result:
```
3 passing
```
Full backend test suite:
```bash
npm test
```
Result:
```
155 passing
```

## Out of Scope
- Additional report summary metrics.
- Changes to attendance report design/styling.
- Changes to existing report visibility or permission logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
- **New Features**
  - Added a weekly attendance total to group submission summaries.
  - The total is calculated from MC attendance submissions within the selected reporting period and returned as `0` when no qualifying data is available.
- **Bug Fixes**
  - Updated date filtering to use the submission reporting period (instead of submission timestamp), while excluding submissions missing a reporting period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->