### PR TITLE
fix(tasks): attach locationGroup in findAllForContact

### DIFF
--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -253,7 +253,7 @@ export class TasksService {
     };
   }
 
-  async findAllForContact(contactId: number, user: any): Promise<Task[]> {
+  async findAllForContact(contactId: number, user: any): Promise<TaskWithLocationGroup[]> {
     const tenantId = this.tenantContext.requireTenant();
     await this.assertContactLocationAccess(contactId, user);
     const tasks = await this.taskRepository.find({
@@ -264,12 +264,12 @@ export class TasksService {
       relations: [...TASK_DETAIL_RELATIONS],
       order: { createdAt: 'DESC' },
     });
-
-    tasks.forEach((task) => {
+    const tasksWithLocationGroups = await this.attachLocationGroups(tasks, tenantId);
+    tasksWithLocationGroups.forEach((task) => {
       this.sanitizeTaskUsers(task);
       this.attachContactAddress(task);
     });
-    return tasks;
+    return tasksWithLocationGroups;
   }
 
   async findOne(taskId: number, user: any): Promise<Task> {


### PR DESCRIPTION
## Ticket No - Ticket: 
N/A — internal bug fix (tasks not appearing on ContactTasksTab)

### Improvements Implemented
- `TasksService.findAllForContact` now calls `attachLocationGroups(tasks, tenantId)` before sanitizing/returning results, matching the same pattern already used in `findAll`.
- Return type updated from `Promise<Task[]>` to `Promise<TaskWithLocationGroup[]>` to reflect the enriched shape.

### Notes for Reviewers
- Root cause: `findAll` attaches `locationGroup` to every task before returning it, but `findAllForContact` never did. The frontend's location-scoping logic (`isTaskInLocationScope`) filters out any task where `locationGroup` is missing, so every task fetched via `GET /tasks/contact/:contactId` was silently excluded from the ContactTasksTab UI — not just newly created tasks, all of them.
- This is a straightforward parity fix — no changes to `attachLocationGroups` itself, no schema changes, no changes to `findAll` or the `AssignTasks` page flow.
- Separately (not part of this PR): if a specific contact's tasks still don't show up after this fix, confirm that contact has an active `GroupMembership` row pointing to a location-purpose group — `attachLocationGroups` will correctly return `locationGroup: null` for contacts with no such membership, and the frontend will (correctly) exclude those from scoped views.

### How Has This Been Tested?
- Created a task for a contact with an active location-group membership via the Contact Detail page → confirmed the task now appears in `ContactTasksTab` immediately after creation, without needing a manual refresh.
- Verified `GET /tasks/contact/:contactId` response now includes `locationGroup: { id, name }` on each task, matching the shape already returned by `GET /tasks`.
- Regression-checked `AssignTasks` page (`GET /tasks`) to confirm no change in behavior there, since `findAll` was untouched.
- Spot-checked a contact with no active location membership — endpoint correctly returns `locationGroup: null` for their tasks (expected, matches `findAll` behavior for the same case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Contact task results now include associated location-group information.
  * Task users are sanitized and contact addresses are included in the returned results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->