### PR TITLE
Fix: Return real total count from group membership listing

### DIFF
--- a/src/groups/controllers/group-membership.controller.ts
+++ b/src/groups/controllers/group-membership.controller.ts
@@ -30,7 +30,7 @@ export class GroupMembershipController {
   @Get()
   async findAll(
     @Query() req: GroupMembershipSearchDto,
-  ): Promise<GroupMembershipDto[]> {
+  ): Promise<{ data: GroupMembershipDto[]; total: number }> {
     return this.service.findAll(req);
   }
 

--- a/src/groups/entities/groupMembership.entity.ts
+++ b/src/groups/entities/groupMembership.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -14,6 +15,7 @@ import Contact from '../../crm/entities/contact.entity';
 
 @Entity()
 @Unique(['contactId', 'groupId'])
+@Index(['groupId', 'isActive', 'contactId'])
 export default class GroupMembership {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -22,6 +22,7 @@ describe('GroupsMembershipService', () => {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
       offset: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
@@ -30,6 +31,7 @@ describe('GroupsMembershipService', () => {
 
     mockMembershipRepository = {
       find: jest.fn().mockResolvedValue([]),
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
       findOne: jest.fn(),
       save: jest.fn((memberships) =>
         Promise.resolve(
@@ -191,6 +193,52 @@ describe('GroupsMembershipService', () => {
     expect(inserted).toBe(1);
   });
 
+  it('should list memberships by contactId', async () => {
+    const membership = {
+      id: 201,
+      groupId: 9,
+      contactId: 51,
+      role: GroupRole.Member,
+      joinedAt: new Date('2024-01-02T00:00:00.000Z'),
+      leftAt: null,
+      isActive: true,
+      contact: {
+        id: 51,
+        person: { firstName: 'Jane', lastName: 'Doe' },
+      },
+      group: {
+        id: 9,
+        name: 'Parent Group',
+        category: { id: 1, name: 'Location' },
+      },
+    };
+    mockMembershipRepository.findAndCount.mockResolvedValue([[membership], 7]);
+
+    const memberships = await service.findAll({ contactId: 51 });
+
+    expect(mockMembershipRepository.findAndCount).toHaveBeenCalledWith({
+      relations: ['contact', 'contact.person', 'group', 'group.category'],
+      where: { contactId: 51, isActive: true },
+      skip: 0,
+      take: 100,
+    });
+    expect(memberships).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 201,
+          groupId: 9,
+          contactId: 51,
+          contact: { id: 51, name: 'Jane Doe' },
+          group: { id: 9, name: 'Parent Group' },
+          category: { id: 1, name: 'Location' },
+          isInferred: true,
+          isActive: true,
+        }),
+      ],
+      total: 7,
+    });
+  });
+
   // Fix 2: Refactored assertions to follow our non-crashing manual sub-group lookup flow
   it('should list memberships for a group and its descendants', async () => {
     const parentGroup = { id: 9, name: 'Parent Group' };
@@ -253,6 +301,7 @@ describe('GroupsMembershipService', () => {
       where: { parentId: 10 },
       select: ['id'],
     });
+    expect(mockQb.orderBy).toHaveBeenCalledWith('m.contactId', 'ASC');
     expect(memberships.total).toBe(2);
     expect(memberships.data).toEqual([
       expect.objectContaining({

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -219,6 +219,7 @@ describe('GroupsMembershipService', () => {
     expect(mockMembershipRepository.findAndCount).toHaveBeenCalledWith({
       relations: ['contact', 'contact.person', 'group', 'group.category'],
       where: { contactId: 51, isActive: true },
+      order: { id: 'ASC' },
       skip: 0,
       take: 100,
     });

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -25,6 +25,7 @@ describe('GroupsMembershipService', () => {
       offset: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
+      getRawOne: jest.fn().mockResolvedValue({ count: '0' }),
     };
 
     mockMembershipRepository = {
@@ -117,7 +118,7 @@ describe('GroupsMembershipService', () => {
   it('should insert every member in a bulk membership request', async () => {
     const inserted = await service.create({
       groupId: 9,
-      members:[51, 7],
+      members: [51, 7],
       role: GroupRole.Member,
     });
 
@@ -146,7 +147,7 @@ describe('GroupsMembershipService', () => {
         metadata: expect.objectContaining({
           created: 2,
           reactivated: 0,
-          contactIds:[51, 7],
+          contactIds: [51, 7],
           role: GroupRole.Member,
         }),
       }),
@@ -165,7 +166,7 @@ describe('GroupsMembershipService', () => {
     ]);
 
     await expect(
-      service.create({ groupId: 9, members:[51], role: GroupRole.Member }),
+      service.create({ groupId: 9, members: [51], role: GroupRole.Member }),
     ).rejects.toThrow(BadRequestException);
   });
 
@@ -183,7 +184,7 @@ describe('GroupsMembershipService', () => {
 
     const inserted = await service.create({
       groupId: 9,
-      members:[51],
+      members: [51],
       role: GroupRole.Leader,
     });
 
@@ -194,11 +195,12 @@ describe('GroupsMembershipService', () => {
   it('should list memberships for a group and its descendants', async () => {
     const parentGroup = { id: 9, name: 'Parent Group' };
     mockGroupRepository.findOneOrFail.mockResolvedValue(parentGroup);
-    
+
     // Simulate finding direct children manually via .find()
     mockGroupRepository.find.mockResolvedValue([{ id: 10 }]);
-    
+
     mockQb.getRawMany.mockResolvedValue([{ contactId: 51 }, { contactId: 52 }]);
+    mockQb.getRawOne.mockResolvedValue({ count: '2' });
     mockMembershipRepository.find.mockResolvedValue([
       {
         id: 101,
@@ -238,20 +240,21 @@ describe('GroupsMembershipService', () => {
 
     expect(mockGroupRepository.findOne).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ id: 9 })
-      })
+        where: expect.objectContaining({ id: 9 }),
+      }),
     );
-    
+
     expect(mockGroupRepository.find).toHaveBeenCalledWith({
       where: { parentId: 9 },
-      select: ['id']
+      select: ['id'],
     });
 
     expect(mockGroupRepository.find).toHaveBeenCalledWith({
       where: { parentId: 10 },
-      select: ['id']
+      select: ['id'],
     });
-    expect(memberships).toEqual([
+    expect(memberships.total).toBe(2);
+    expect(memberships.data).toEqual([
       expect.objectContaining({
         id: 101,
         groupId: 9,

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -127,6 +127,7 @@ export class GroupsMembershipService {
     const [data, total] = await this.repository.findAndCount({
       relations: ['contact', 'contact.person', 'group', 'group.category'],
       where: filter,
+      order: { id: 'ASC' },
       skip: req.skip ?? 0,
       take: req.limit ?? 100,
     });

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -88,17 +88,19 @@ export class GroupsMembershipService {
         return qb;
       };
 
-      const totalResult = await buildQb()
-        .select('COUNT(DISTINCT m.contactId)', 'count')
-        .getRawOne<{ count: string }>();
+      const [totalResult, rows] = await Promise.all([
+        buildQb()
+          .select('COUNT(DISTINCT m.contactId)', 'count')
+          .getRawOne<{ count: string }>(),
+        buildQb()
+          .select('m.contactId', 'contactId')
+          .groupBy('m.contactId')
+          .orderBy('m.contactId', 'ASC')
+          .offset(req.skip ?? 0)
+          .limit(req.limit ?? 100)
+          .getRawMany<{ contactId: number }>(),
+      ]);
       const total = Number(totalResult?.count ?? 0);
-
-      const rows: { contactId: number }[] = await buildQb()
-        .select('m.contactId', 'contactId')
-        .groupBy('m.contactId')
-        .offset(req.skip ?? 0)
-        .limit(req.limit ?? 100)
-        .getRawMany();
 
       if (rows.length === 0) return { data: [], total };
 

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -35,14 +35,16 @@ export class GroupsMembershipService {
     this.logger = this.appLogger.createContextLogger('GroupsMembershipService');
   }
 
-  async findAll(req: GroupMembershipSearchDto): Promise<GroupMembershipDto[]> {
+  async findAll(
+    req: GroupMembershipSearchDto,
+  ): Promise<{ data: GroupMembershipDto[]; total: number }> {
     const filter: Record<string, any> = {};
 
     if (hasValue(req.contactId)) {
       filter.contactId = req.contactId;
     }
 
-        let groupIds: number[] = [];
+    let groupIds: number[] = [];
     if (hasValue(req.groupId)) {
       const numericGroupId = Number(req.groupId);
       const parentGroup = await this.groupRepository.findOne({
@@ -71,25 +73,34 @@ export class GroupsMembershipService {
       // Two-step: paginate distinct contactIds first so that limit/skip count
       // unique contacts rather than raw membership rows (a contact in multiple
       // sub-groups would otherwise consume multiple row slots per page).
-      const qb = this.repository
-        .createQueryBuilder('m')
+      const buildQb = () => {
+        const qb = this.repository
+          .createQueryBuilder('m')
+          .where('m.groupId IN (:...groupIds)', { groupIds });
+        if (activeOnly) {
+          qb.andWhere('m.isActive = :isActive', { isActive: true });
+        }
+        if (hasValue(req.contactId)) {
+          qb.andWhere('m.contactId = :contactId', {
+            contactId: req.contactId,
+          });
+        }
+        return qb;
+      };
+
+      const totalResult = await buildQb()
+        .select('COUNT(DISTINCT m.contactId)', 'count')
+        .getRawOne<{ count: string }>();
+      const total = Number(totalResult?.count ?? 0);
+
+      const rows: { contactId: number }[] = await buildQb()
         .select('m.contactId', 'contactId')
-        .where('m.groupId IN (:...groupIds)', { groupIds })
-        .groupBy('m.contactId');
-
-      if (activeOnly) {
-        qb.andWhere('m.isActive = :isActive', { isActive: true });
-      }
-      if (hasValue(req.contactId)) {
-        qb.andWhere('m.contactId = :contactId', { contactId: req.contactId });
-      }
-
-      const rows: { contactId: number }[] = await qb
+        .groupBy('m.contactId')
         .offset(req.skip ?? 0)
         .limit(req.limit ?? 100)
         .getRawMany();
 
-      if (rows.length === 0) return [];
+      if (rows.length === 0) return { data: [], total };
 
       const contactIds = rows.map((r) => r.contactId);
       const data = await this.repository.find({
@@ -105,19 +116,23 @@ export class GroupsMembershipService {
           best.set(m.contactId, m);
         }
       }
-      return [...best.values()].map((it) => this.toDto(it, req.groupId ?? 0));
+      return {
+        data: [...best.values()].map((it) => this.toDto(it, req.groupId ?? 0)),
+        total,
+      };
     }
 
-    const data = await this.repository.find({
+    const [data, total] = await this.repository.findAndCount({
       relations: ['contact', 'contact.person', 'group', 'group.category'],
       where: filter,
+      skip: req.skip ?? 0,
+      take: req.limit ?? 100,
     });
 
-    const skip = req.skip ?? 0;
-    const limit = req.limit ?? 100;
-    return data
-      .slice(skip, skip + limit)
-      .map((it) => this.toDto(it, req.groupId ?? 0));
+    return {
+      data: data.map((it) => this.toDto(it, req.groupId ?? 0)),
+      total,
+    };
   }
 
   private async findDescendantGroupIds(groupId: number): Promise<number[]> {
@@ -156,7 +171,8 @@ export class GroupsMembershipService {
       contact: {
         name: contact?.person ? getPersonFullName(contact.person) : '',
         id: contact?.id,
-      },      joinedAt: membership.joinedAt,
+      },
+      joinedAt: membership.joinedAt,
       leftAt: membership.leftAt,
       isActive: membership.isActive,
     } as GroupMembershipDto;

--- a/src/migrations/1784897629557-GroupMembershipGroupIdIsActiveContactIdIndex.ts
+++ b/src/migrations/1784897629557-GroupMembershipGroupIdIsActiveContactIdIndex.ts
@@ -4,16 +4,17 @@ export class GroupMembershipGroupIdIsActiveContactIdIndex1784897629557
   implements MigrationInterface
 {
   name = 'GroupMembershipGroupIdIsActiveContactIdIndex1784897629557';
+  transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      'CREATE INDEX "IDX_70871bc95820363218c334143b" ON "group_membership" ("groupId", "isActive", "contactId") ',
+      'CREATE INDEX CONCURRENTLY "IDX_70871bc95820363218c334143b" ON "group_membership" ("groupId", "isActive", "contactId")',
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      'DROP INDEX "public"."IDX_70871bc95820363218c334143b"',
+      'DROP INDEX CONCURRENTLY "public"."IDX_70871bc95820363218c334143b"',
     );
   }
 }

--- a/src/migrations/1784897629557-GroupMembershipGroupIdIsActiveContactIdIndex.ts
+++ b/src/migrations/1784897629557-GroupMembershipGroupIdIsActiveContactIdIndex.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class GroupMembershipGroupIdIsActiveContactIdIndex1784897629557
+  implements MigrationInterface
+{
+  name = 'GroupMembershipGroupIdIsActiveContactIdIndex1784897629557';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX "IDX_70871bc95820363218c334143b" ON "group_membership" ("groupId", "isActive", "contactId") ',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX "public"."IDX_70871bc95820363218c334143b"',
+    );
+  }
+}


### PR DESCRIPTION
GroupsMembershipService.findAll only ever returned a page of raw rows with no way for callers to know how many members a group actually has, so the group details page's pagination had to guess (assuming another page existed whenever a full page came back). This under-reported large groups (e.g. a 600-member group appeared to have only 100).

findAll now returns { data, total }, computing total via a real COUNT(DISTINCT contactId) query for the groupId+descendants path and via findAndCount for the plain contactId lookup path, matching the { data, total } pattern already used by the tasks module.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group membership listings now return paginated results with `data` and `total`.
  * Descendant membership searches provide distinct total counts alongside results.
* **Bug Fixes**
  * Empty membership searches now consistently return an empty `data` list with an accurate total.
* **Performance**
  * Improved efficiency for group membership searches, including active-membership and descendant filtering.
* **Tests**
  * Expanded coverage for pagination, totals, inferred memberships, and count-based search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->