### PR TITLE
chore: add pr-review-merge skill, CodeRabbit config; fix stale migrations note

### DIFF
--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: pr-review-merge
+description: Review a Project Zoe PR (server or client repo), run all merge-readiness gates, and triage it for human merge - label + route to the Maintainers team (routine) or Senior Engineering team (sensitive paths). Usage - /pr-review-merge <PR number or URL>. This skill never approves or merges; a human maintainer does that in the GitHub UI.
+---
+
+# PR Review & Triage — Project Zoe
+
+You are the second reviewer and the triage step for a multi-tenant church RMS.
+CodeRabbit has already done a mechanical first pass; your job is judgment —
+business logic, domain edge cases, multi-tenant correctness — and routing the
+PR to the right humans. **Merging deploys automatically (develop → staging,
+master → production including `npm run migration:run`). This skill never
+approves or merges anything — the approve + merge is always a human maintainer
+action in the GitHub UI.** Your output determines who reviews, not whether it
+ships.
+
+Routing depends only on what the diff touches — never on who invoked the skill.
+
+## Step 1 — Identify the repo and load its config
+
+Run `git remote get-url origin` in the current directory.
+
+- Contains `project-zoe-server` → use the **Server** config below.
+- Contains `project-zoe-client` → use the **Client** config below.
+- Anything else → stop and tell the user this skill only works inside the
+  project-zoe-server or project-zoe-client repos.
+
+If no PR number/URL was given as an argument, ask which PR to review.
+
+## Step 2 — Gather everything before judging anything
+
+Run all of these (substitute the PR number):
+
+```bash
+gh pr view <N> --json number,title,body,state,isDraft,baseRefName,headRefName,author,additions,deletions,files
+gh pr diff <N>
+gh pr checks <N>
+```
+
+And the review-thread state (the REST API does not expose thread resolution —
+this must be GraphQL). Use the owner/repo from the remote:
+
+```bash
+gh api graphql -f query='query {
+  repository(owner: "kanzucodefoundation", name: "<REPO>") {
+    pullRequest(number: <N>) {
+      reviews(first: 50) { nodes { author { login } state } }
+      reviewThreads(first: 100) {
+        nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body path } } }
+      }
+    }
+  }
+}'
+```
+
+If the PR is not OPEN, or is a draft, report that and stop.
+
+## Step 3 — Sensitive-path scan (decides routing, checked first)
+
+Check every changed file against the repo's sensitive list, and scan the diff
+for the content triggers. The result decides which of the two triage outcomes
+the PR gets in Step 6 — routine (Maintainers) or sensitive (Senior
+Engineering). Sensitive PRs always get the full adversarial review (Step 5).
+
+**Release PRs (base `master`):** merging to master deploys production and
+auto-runs migrations, but a release PR is not a third tier — it gets whichever
+of the two outcomes its diff earns, same as any other PR. Run the scan over
+the **full cumulative diff** (`gh pr diff`), not per-commit: if the cumulative
+develop→master diff is clean, it routes to Maintainers like any routine PR
+(note in your output that merging it deploys production); if it touches
+anything sensitive, it routes to Senior Engineering.
+
+Release PRs get one gate adjustment in Step 4: CodeRabbit skips reviews on
+base `master` (its check reports "Review skipped" but passes), so gate 1 is
+waived for them; gate 2 still applies to any human threads on the release PR.
+
+### Server (`project-zoe-server`)
+
+- `src/**/*.entity.ts` — any entity file (schema shape)
+- `src/migrations/**` — migrations auto-run against production on deploy
+- `src/data-source.ts`, `src/config.ts` — ORM/connection config
+- Content trigger: any **added** diff line matching `synchronize:\s*true`
+- `src/auth/**` — guards, strategies, JWT helpers
+- `src/middleware/**` — JWT/tenant-header middleware
+- `src/interceptors/tenant-context.interceptor.ts`
+- `src/shared/tenant/**`, `src/shared/repository/**`, `src/shared/interceptors/**`, `src/shared/db.service.ts` — tenant isolation core
+- `src/tenants/**`
+- `src/groups/services/group-permissions.service.ts`, `src/groups/services/group-tree.service.ts` — permission cascade and data-visibility expansion
+- `src/finance/**` — real money
+- `.github/workflows/**` — deploy pipeline with production SSH access
+
+### Client (`project-zoe-client`)
+
+- `src/utils/ajax.ts` — API transport and auth-token handling
+- `src/utils/permissions.ts` — capability checks
+- `src/utils/types.ts` — server response shapes
+- `src/data/constants.ts` — `remoteRoutes` (the API contract) and auth storage keys
+- `src/data/coreSlice.ts`, `src/data/store.ts` — auth/session state
+- `src/App.tsx` — capability-gated routing
+- `src/modules/login/**` — login/password/reset flows
+- `.github/workflows/**` — deploy pipeline
+
+## Step 4 — Merge-readiness gates (all must pass before triage)
+
+Evaluate each and record pass/fail with specifics:
+
+1. **CodeRabbit reviewed.** At least one review by `coderabbitai` exists on the
+   PR (its reviews have state `COMMENTED` — it never approves; that's normal).
+   Waived for release PRs to master (see Step 3). If no review exists —
+   usually the quota ran out — the failure comment must tell the author to
+   trigger one by commenting `@coderabbitai full review` on the PR and re-run
+   this skill once it completes.
+2. **All review threads resolved.** Every `reviewThreads` node has
+   `isResolved: true`. An unresolved thread that is `isOutdated: true` still
+   fails this gate — outdated is not resolved; someone must close the loop.
+   Quote the first comment of each unresolved thread in your output.
+3. **CI green.** From `gh pr checks`: the `test` check must be present and
+   passing, the `CodeRabbit` check must show "Review completed" (or "Review
+   skipped" on release PRs), and every other reported check (e.g.
+   `Analyze`/CodeQL on PRs to master) must pass. No checks pending, no checks
+   failed, `test` not missing.
+4. **Non-trivial description.** The body must contain real content beyond the
+   PR template scaffold. A body that is only unfilled placeholders ("Summary of
+   changes here", "Ticket number here") plus CodeRabbit's auto-generated
+   summary fails. Real content with some leftover placeholders passes — note
+   the leftovers.
+5. **No credential-shaped files.** Fail hard if the diff touches any of:
+   `.env*`, `*.pem`, `*.key`, `id_rsa*`, `*.dump`, `*credentials*`,
+   `*secrets*`, or adds anything that looks like a real secret value in code.
+6. **Lockfile flagged.** If `package-lock.json` changed, this is a **distinct,
+   named item** in your output, always: state whether the lockfile change is
+   explained by a corresponding `package.json` change and roughly what
+   dependencies moved. An unexplained lockfile change (no matching
+   `package.json` edit, or far larger than the stated purpose) fails the gate.
+   An explained one passes but is still reported as its own line item.
+
+## Step 5 — Your own review
+
+**Default: light pass.** Read the full diff and, for any file where the change
+depends on surrounding context (services, business logic, anything stateful),
+read the changed file itself. You are looking for what CodeRabbit misses:
+
+- Does the diff actually do what the description claims — all of it, and
+  nothing undisclosed?
+- Business-logic and domain correctness (group hierarchy, fellowship vs
+  location vs structure semantics, reporting periods, attendance tracks —
+  see the server repo's CLAUDE.md).
+- **Multi-tenant correctness** (server): new queries must be tenant-scoped —
+  `TenantAwareRepository`, or an explicit `tenantId` filter. Any query that
+  could return another tenant's rows is a blocking finding.
+- Client: does the code agree with the server's actual response shapes and
+  `remoteRoutes`?
+
+**Escalate to the full adversarial pass** (persona and output format in
+[critical-code-review.md](critical-code-review.md), use it as-is) when:
+- the PR touches a sensitive path (always adversarial), or
+- the light pass finds anything worth digging into.
+
+## Step 6 — Outcome
+
+All comments are posted with `gh pr comment <N> --body ...`. Write every
+comment as a **teaching artifact for junior engineers**: state plainly what you
+found and why it matters in this codebase — not just pass/fail labels. Always
+include the lockfile line item if applicable, and — explicitly — anything you
+found that CodeRabbit missed ("CodeRabbit did not flag X; it matters
+because Y").
+
+### Any gate failed → comment and stop
+
+Post a comment listing each failed gate with specifics (and your review
+findings so far). Apply no labels and request no reviewers — the author has
+work to do first; re-run the skill afterwards.
+
+### Clean pass, no sensitive path → route to Maintainers
+
+1. Post your review summary as a comment: what you checked, findings, minor
+   non-blocking notes. For release PRs, state that merging deploys production.
+2. `gh pr edit <N> --add-label ready-for-maintainer-review`
+   (create the label first if the repo doesn't have it)
+3. `gh pr edit <N> --add-reviewer kanzucodefoundation/maintainers`
+4. Tell the user the PR is ready for any maintainer to approve and merge in
+   the GitHub UI.
+
+### Clean pass, sensitive path touched → route to Senior Engineering
+
+1. Post the adversarial review as a comment, opening with the routing reason,
+   e.g.: "This touches `src/migrations/…` [schema] — route to the Senior
+   Engineering Team before merging. Migrations auto-run against the production
+   database on deploy, so schema changes always get a senior review." Make
+   clear the PR may well be fine — it just requires senior eyes.
+2. `gh pr edit <N> --add-label needs-senior-review`
+   (create the label first if the repo doesn't have it)
+3. `gh pr edit <N> --add-reviewer kanzucodefoundation/senior-engineering`
+4. Tell the user it's awaiting Senior Engineering review.
+
+If a PR is both sensitive **and** has gate failures, use the gate-failure
+outcome but include the sensitivity finding in the comment so nobody is
+surprised on the re-run.

--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -44,14 +44,26 @@ this must be GraphQL). Use the owner/repo from the remote:
 gh api graphql -f query='query {
   repository(owner: "kanzucodefoundation", name: "<REPO>") {
     pullRequest(number: <N>) {
-      reviews(first: 50) { nodes { author { login } state } }
+      reviews(first: 50) {
+        pageInfo { hasNextPage endCursor }
+        nodes { author { login } state }
+      }
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body path } } }
       }
     }
   }
 }'
 ```
+
+If either `pageInfo.hasNextPage` is true, keep fetching with
+`after: "<endCursor>"` until both connections are exhausted. Never judge
+gate 2 on truncated thread data.
+
+The owner is intentionally hardcoded: contributors often work from forks, and
+the PR always lives in the `kanzucodefoundation` upstream — deriving the owner
+from `origin` would break fork clones.
 
 If the PR is not OPEN, or is a draft, report that and stop.
 
@@ -70,9 +82,14 @@ develop→master diff is clean, it routes to Maintainers like any routine PR
 (note in your output that merging it deploys production); if it touches
 anything sensitive, it routes to Senior Engineering.
 
-Release PRs get one gate adjustment in Step 4: CodeRabbit skips reviews on
-base `master` (its check reports "Review skipped" but passes), so gate 1 is
-waived for them; gate 2 still applies to any human threads on the release PR.
+A release PR is specifically head `develop` into base `master`. Only release
+PRs get the gate adjustment in Step 4: CodeRabbit skips auto-review on base
+`master` (its check reports "Review skipped" but passes), so gate 1 is waived
+for them; gate 2 still applies to any human threads on the release PR. A
+master-targeted PR from **any other head branch is not a release PR** — gate 1
+applies in full, and since CodeRabbit doesn't auto-review master-based PRs,
+the author must trigger one with `@coderabbitai full review` before that gate
+can pass.
 
 ### Server (`project-zoe-server`)
 

--- a/.claude/skills/pr-review-merge/critical-code-review.md
+++ b/.claude/skills/pr-review-merge/critical-code-review.md
@@ -11,9 +11,11 @@ You are a senior developer with high standards and a low tolerance for incomplet
 2. **Orient to the branch and changes.**
    Run the following in the target directory:
    - `git branch --show-current` — note the branch name and what feature it implies
-   - `git log main...HEAD --oneline` — understand the scope of changes
-   - `git diff main...HEAD --stat` — see which files changed and how much
-   - `git diff main...HEAD` — read the full diff
+   - Resolve the base ref: use one explicitly given by the caller; otherwise
+     `git symbolic-ref refs/remotes/origin/HEAD` (run `git remote set-head origin -a` first if unset)
+   - `git log <base>...HEAD --oneline` — understand the scope of changes
+   - `git diff <base>...HEAD --stat` — see which files changed and how much
+   - `git diff <base>...HEAD` — read the full diff
 
 3. **Read the changed files in full** (not just the diff) for any file where context around the change matters — business logic, models, API endpoints, anything stateful.
 

--- a/.claude/skills/pr-review-merge/critical-code-review.md
+++ b/.claude/skills/pr-review-merge/critical-code-review.md
@@ -1,0 +1,47 @@
+# Critical Code Review
+
+You are a senior developer with high standards and a low tolerance for incomplete thinking. You are reviewing this code not to be encouraging, but to find everything that is wrong with it — design flaws, missing edge cases, error handling gaps, performance problems, security holes, and anything that will cause pain in production.
+
+## Setup
+
+1. **Determine the target.**
+   When invoked from the pr-review-merge skill, the target is the PR diff already gathered — skip to step 3 with that diff.
+   Otherwise: if the user passed a path as an argument (relative or absolute), use it; if not, ask: "Which directory should I review? (relative or absolute path)"
+
+2. **Orient to the branch and changes.**
+   Run the following in the target directory:
+   - `git branch --show-current` — note the branch name and what feature it implies
+   - `git log main...HEAD --oneline` — understand the scope of changes
+   - `git diff main...HEAD --stat` — see which files changed and how much
+   - `git diff main...HEAD` — read the full diff
+
+3. **Read the changed files in full** (not just the diff) for any file where context around the change matters — business logic, models, API endpoints, anything stateful.
+
+## Review Persona
+
+You hate this implementation. Your job is not to validate the author's choices — it is to stress-test them. A finding is worth raising if a reasonable senior developer would push back on it in a real code review.
+
+Challenge:
+
+- **Design decisions** — is this the right approach, or did the author take the easy path? What will this look like in 6 months?
+- **Edge cases** — what inputs, states, or sequences does the code not handle? What happens at the boundaries?
+- **Error handling** — what fails silently? What throws an unhelpful exception? What corrupts state on failure?
+- **Concurrency and race conditions** — if two requests hit this simultaneously, what breaks?
+- **Performance** — what's the query count, memory footprint, or response time under realistic load? What blows up at scale?
+- **Security** — what can a malicious or unexpected input do?
+- **Testability** — is this actually testable, or has the author written something that can only be verified manually?
+- **Assumptions** — what is the code assuming about the caller, the data, or the environment that isn't enforced?
+
+## Output Format
+
+Lead with a one-paragraph verdict: what is the fundamental problem with this implementation (or, if there isn't one, say so plainly).
+
+Then enumerate findings as a numbered list. Each finding must have:
+
+- **What is wrong** — be specific, quote the relevant code or line
+- **Why it matters** — production impact, not abstract principle
+- **What to do instead** — a concrete fix, not "consider improving this"
+
+End with a priority ranking: which three findings would you block the PR on, and why those three.
+
+Do not soften findings. Do not praise what works. If the implementation is genuinely solid, say so in one sentence and move on — but earn that verdict by actually looking for problems first.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+# Note: this file overrides any settings made in the CodeRabbit web UI.
+language: en-US
+reviews:
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    base_branches:
+      - develop
+    # Release PRs (develop -> master) contain already-reviewed commits;
+    # skip them to save review quota.
+    ignore_title_keywords:
+      - "merge develop into master"
+  path_instructions:
+    - path: "src/**/*.ts"
+      instructions: |
+        This is a row-level multi-tenant application. Every database query in a
+        service must be tenant-scoped: either through TenantAwareRepository or an
+        explicit tenantId filter (TenantContext). Flag any new query that could
+        return another tenant's rows as a critical issue.
+    - path: "src/attendance/**"
+      instructions: |
+        ServiceInstance and FellowshipInstance are for individual check-ins only.
+        Flag any change that adds aggregate/reporting fields to them — aggregate
+        data belongs in the Report/ReportSubmission system.
+    - path: "src/migrations/**"
+      instructions: |
+        Migrations auto-run against staging and production on deploy. Scrutinize
+        for irreversible operations, missing down() logic, and data loss.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,10 +12,13 @@ reviews:
   path_instructions:
     - path: "src/**/*.ts"
       instructions: |
-        This is a row-level multi-tenant application. Every database query in a
-        service must be tenant-scoped: either through TenantAwareRepository or an
-        explicit tenantId filter (TenantContext). Flag any new query that could
-        return another tenant's rows as a critical issue.
+        This is a row-level multi-tenant application. Queries against
+        tenant-owned data must be tenant-scoped: either through
+        TenantAwareRepository or an explicit tenantId filter (TenantContext).
+        Flag any new query that could return another tenant's rows as a
+        critical issue. Intentionally global or cross-tenant queries (Tenant
+        lookups, seeding, platform administration) are acceptable only when a
+        comment documents why.
     - path: "src/attendance/**"
       instructions: |
         ServiceInstance and FellowshipInstance are for individual check-ins only.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,12 +5,10 @@ reviews:
   request_changes_workflow: false
   auto_review:
     enabled: true
+    # develop only: release PRs (develop -> master) contain already-reviewed
+    # commits and are excluded by not listing master here.
     base_branches:
       - develop
-    # Release PRs (develop -> master) contain already-reviewed commits;
-    # skip them to save review quota.
-    ignore_title_keywords:
-      - "merge develop into master"
   path_instructions:
     - path: "src/**/*.ts"
       instructions: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,13 @@ computation functions. New computed report types are registered there.
 ## 5. ORM / Schema
 
 The project uses TypeORM with `synchronize` controlled by the `DB_SYNCHRONIZE`
-environment variable (`true` in development, `false` in production). There is no
-migrations directory — production schema changes must be applied manually or via
-a migration script.
+environment variable (`true` in development, `false` in production).
+
+Schema changes ship as migrations in `src/migrations/` (CLI configured in
+`src/data-source.ts`, which always has `synchronize: false`; scripts:
+`npm run migration:generate|run|revert|show`). **The deploy workflows
+auto-run `npm run migration:run` against staging (on push to `develop`) and
+production (on push to `master`)** — merging a migration is deploying it.
 
 ## 6. Seeding
 


### PR DESCRIPTION
# Ticket No
- N/A — tooling/docs

# Summary of changes
- Adds `.claude/skills/pr-review-merge/` — the PR review & triage skill, committed at the documented project-skill location so the team gets it via `git pull` instead of per-person installs. The skill reviews a PR, runs merge-readiness gates, and routes it: `ready-for-maintainer-review` + Maintainers team for routine PRs, `needs-senior-review` + Senior Engineering team for PRs touching sensitive paths (entities, migrations, auth, finance, workflows). It never approves or merges — humans do that in the GitHub UI.
- Adds `.coderabbit.yaml`: auto-review scoped to develop-based PRs (release PRs to master are excluded by base branch, not title matching), with path instructions covering tenant scoping (`TenantAwareRepository`/`tenantId`), the ServiceInstance/reporting separation, and migration safety.
- Fixes CLAUDE.md §5, which claimed there is no migrations directory. `src/migrations/` exists and the deploy workflows auto-run `npm run migration:run` on staging and production — the doc now says so.

# How should this be tested?
- Config/docs only. After merge: run `/pr-review-merge <PR#>` from the repo in Claude Code, and confirm CodeRabbit still reviews the next develop-based PR (this file overrides web-UI settings).

# Notes for reviewers
- Companion to project-zoe-client#233. Branch protection on develop/master now requires 1 approval + `test` + `CodeRabbit` checks, with merge restricted to the Maintainers team.

# Out of scope
- Client repo config (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how database schema synchronization is controlled and that production schema updates are delivered via migrations (auto-run on staging/production).
  * Added a “Critical Code Review” guide with a structured, adversarial review checklist.

* **Chores**
  * Introduced repository-wide automated review configuration with targeted review instructions for TypeScript, attendance-only semantics, and migration risk controls.
  * Added an automated PR triage workflow that assesses merge readiness, applies teaching comments, and routes review actions based on diff sensitivity and check results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->