### PR TITLE
fix(coderabbit): sync pr-review-merge skill fixes from client#233 review

### DIFF
--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -25,7 +25,12 @@ Run `git remote get-url origin` in the current directory.
 - Anything else → stop and tell the user this skill only works inside the
   project-zoe-server or project-zoe-client repos.
 
-If no PR number/URL was given as an argument, ask which PR to review.
+**Normalize the PR reference to a bare number before using it in any
+command.** If given a URL, it must point at the detected repo under
+`kanzucodefoundation` — extract the number; if it points anywhere else, stop
+and say so. If the argument is neither a number nor such a URL, or no argument
+was given, ask which PR to review. Only the validated number is ever
+substituted into commands.
 
 ## Step 2 — Gather everything before judging anything
 
@@ -38,7 +43,8 @@ gh pr checks <N>
 ```
 
 And the review-thread state (the REST API does not expose thread resolution —
-this must be GraphQL). Use the owner/repo from the remote:
+this must be GraphQL). Substitute `<REPO>` with the repo name from Step 1; the
+owner is always `kanzucodefoundation` (see note below):
 
 ```bash
 gh api graphql -f query='query {
@@ -83,13 +89,13 @@ develop→master diff is clean, it routes to Maintainers like any routine PR
 anything sensitive, it routes to Senior Engineering.
 
 A release PR is specifically head `develop` into base `master`. Only release
-PRs get the gate adjustment in Step 4: CodeRabbit skips auto-review on base
-`master` (its check reports "Review skipped" but passes), so gate 1 is waived
-for them; gate 2 still applies to any human threads on the release PR. A
-master-targeted PR from **any other head branch is not a release PR** — gate 1
-applies in full, and since CodeRabbit doesn't auto-review master-based PRs,
-the author must trigger one with `@coderabbitai full review` before that gate
-can pass.
+PRs get the gate adjustment in Step 4: gate 1 is waived for them, whether or
+not CodeRabbit reviewed the release PR itself (its check may report "Review
+skipped" or post a real review — either way the check passes, and gate 2 still
+applies to any threads on the release PR). A master-targeted PR from **any
+other head branch is not a release PR** — gate 1 applies in full; if CodeRabbit
+hasn't reviewed it, the author must trigger one with `@coderabbitai full
+review` before that gate can pass.
 
 ### Server (`project-zoe-server`)
 

--- a/.claude/skills/pr-review-merge/critical-code-review.md
+++ b/.claude/skills/pr-review-merge/critical-code-review.md
@@ -44,6 +44,6 @@ Then enumerate findings as a numbered list. Each finding must have:
 - **Why it matters** — production impact, not abstract principle
 - **What to do instead** — a concrete fix, not "consider improving this"
 
-End with a priority ranking: which three findings would you block the PR on, and why those three.
+End with a priority ranking: up to three findings you would block the PR on, and why. If nothing rises to blocking, say "no blockers" plainly — do not invent findings to fill the ranking.
 
 Do not soften findings. Do not praise what works. If the implementation is genuinely solid, say so in one sentence and move on — but earn that verdict by actually looking for problems first.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,8 +5,10 @@ reviews:
   request_changes_workflow: false
   auto_review:
     enabled: true
-    # develop only: release PRs (develop -> master) contain already-reviewed
-    # commits and are excluded by not listing master here.
+    # CodeRabbit always auto-reviews PRs targeting the default branch (master);
+    # base_branches only ADDS branches — it cannot exclude master. So release
+    # PRs (develop -> master) may get a redundant auto-review; the
+    # pr-review-merge skill does not require it (gate waived for release PRs).
     base_branches:
       - develop
   path_instructions:


### PR DESCRIPTION
# Summary of changes
Syncs the skill/config fixes made on kanzucodefoundation/project-zoe-client#233 so the two repo copies stay identical:
- SKILL.md: PR argument normalized/validated to a bare number in the detected repo before any command (rejects cross-repo URLs); owner-vs-repo wording fixed; release-PR gate waiver no longer assumes CodeRabbit skips base-master reviews.
- critical-code-review.md: rank up to three blockers, "no blockers" allowed.
- .coderabbit.yaml: corrected comment — the default branch is always auto-reviewed; `base_branches` only extends the set.

# How should this be tested?
- Tooling/docs only; no runtime code. Run `/pr-review-merge <PR#>` after merge.

# Notes for reviewers
- If this merges into develop while release PR #252 is still open, #252 will simply carry these tooling files too — no runtime impact either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)