### PR TITLE
docs: document the PR review & merge workflow

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -32,6 +32,25 @@ feature branch → develop (staging) → master (production)
 
 6. Once the change is verified on staging, it is promoted to `master` via a separate PR, which triggers the production deploy.
 
+## PR review & merge
+
+Every PR passes through three layers before it can merge. `develop` and `master` are protected: direct pushes are blocked, one approving review is required (pushing new commits dismisses earlier approvals), the `test` and `CodeRabbit` checks must pass, and only the Maintainers team can merge.
+
+1. **CodeRabbit** reviews automatically when the PR is opened. Resolve every thread it raises — unresolved threads (even outdated ones) block the next step. If it reports "Review rate limited" (quota exhausted), trigger it later by commenting `@coderabbitai full review` on the PR.
+
+2. **Run `/pr-review-merge <PR number>`** from Claude Code inside this repo. This is the second, judgment-based review plus triage: it checks the gates (CodeRabbit reviewed, threads resolved, CI green, real PR description, no credential-shaped files, lockfile changes explained), reviews the diff, and routes the PR with a label and a team review request:
+
+   - `ready-for-maintainer-review` — nothing sensitive touched; any maintainer can approve and merge.
+   - `needs-senior-review` — the diff touches sensitive paths (entities, migrations, ORM config, auth/tenant code, group permissions, finance, deploy workflows); the Senior Engineering team must review first.
+
+   The full gate and sensitive-path list lives in [`.claude/skills/pr-review-merge/SKILL.md`](./.claude/skills/pr-review-merge/SKILL.md). The skill never approves or merges anything.
+
+3. **A maintainer approves and merges** in the GitHub UI (squash merge). The approval can come from anyone with write access — but not the PR author.
+
+To run the skill you need Claude Code started inside the repo (pull first — the skill ships in `.claude/skills/`), an authenticated `gh` CLI (`gh auth login`), and write access for the labelling step. If you work from a fork, run `gh repo set-default kanzucodefoundation/project-zoe-server` once so `gh` resolves PRs against the upstream repo.
+
+Releases (`develop` → `master`) follow the same process — the skill scans the full cumulative diff and routes it like any other PR. Merging to `master` deploys production, including migrations. If a hotfix ever lands on `master` directly, back-merge it into `develop` immediately, using a merge commit (not squash).
+
 ## Branch naming
 
 ```

--- a/contributing.md
+++ b/contributing.md
@@ -38,14 +38,14 @@ Every PR passes through three layers before it can merge. `develop` and `master`
 
 1. **CodeRabbit** reviews automatically when the PR is opened. Resolve every thread it raises — unresolved threads (even outdated ones) block the next step. If it reports "Review rate limited" (quota exhausted), trigger it later by commenting `@coderabbitai full review` on the PR.
 
-2. **Run `/pr-review-merge <PR number>`** from Claude Code inside this repo. This is the second, judgment-based review plus triage: it checks the gates (CodeRabbit reviewed, threads resolved, CI green, real PR description, no credential-shaped files, lockfile changes explained), reviews the diff, and routes the PR with a label and a team review request:
+2. **Run `/pr-review-merge <PR number>`** from Claude Code inside this repo. This is the second, judgment-based review plus triage: it checks the gates (CodeRabbit reviewed, threads resolved, CI green, real PR description, no credential-shaped files, lockfile changes explained), reviews the diff, and routes the PR with a label and a team review request. If any gate fails, the skill stops immediately, posts the failures, and applies no label or reviewer requests:
 
    - `ready-for-maintainer-review` — nothing sensitive touched; any maintainer can approve and merge.
    - `needs-senior-review` — the diff touches sensitive paths (entities, migrations, ORM config, auth/tenant code, group permissions, finance, deploy workflows); the Senior Engineering team must review first.
 
    The full gate and sensitive-path list lives in [`.claude/skills/pr-review-merge/SKILL.md`](./.claude/skills/pr-review-merge/SKILL.md). The skill never approves or merges anything.
 
-3. **A maintainer approves and merges** in the GitHub UI (squash merge). The approval can come from anyone with write access — but not the PR author.
+3. **A maintainer approves and merges** in the GitHub UI (squash merge). The approving reviewer must be a member of the Maintainers team — general write access is not sufficient, and the PR author cannot approve their own PR.
 
 To run the skill you need Claude Code started inside the repo (pull first — the skill ships in `.claude/skills/`), an authenticated `gh` CLI (`gh auth login`), and write access for the labelling step. If you work from a fork, run `gh repo set-default kanzucodefoundation/project-zoe-server` once so `gh` resolves PRs against the upstream repo.
 


### PR DESCRIPTION
# Summary of changes
Adds a **PR review & merge** section to `contributing.md` covering the workflow now in force: CodeRabbit first pass → `/pr-review-merge` second pass and triage (the two labels and which team reviews what) → maintainer approval and merge, plus the branch-protection rules, prerequisites for running the skill (Claude Code in the repo, authenticated `gh`, write access, fork setup), the `@coderabbitai full review` quota fallback, and release/back-merge conventions.

# How should this be tested?
- Docs only. Read it as a new contributor would.

# Notes for reviewers
- Companion client PR updates `CONTRIBUTING.md` with the same section adapted to client sensitive paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded pull request review and merge guidance with a three-step review and approval process.
  * Added instructions for handling automated review feedback and rate limits.
  * Documented sensitive-change routing, required approvals, and release workflow.
  * Clarified production deployment behavior and hotfix back-merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->