### PR TITLE
feat(users,groups): scope /api/users to a location group, include FOB leaders

### DIFF
--- a/src/groups/controllers/group.controller.spec.ts
+++ b/src/groups/controllers/group.controller.spec.ts
@@ -4,6 +4,7 @@ import { GroupPrivacy } from '../enums/groupPrivacy';
 import { GroupsService } from '../services/groups.service';
 import { GroupController } from './group.controller';
 import { UsersService } from '../../users/users.service';
+import ClientFriendlyException from '../../shared/exceptions/client-friendly.exception';
 
 describe('GroupController', () => {
   let controller: GroupController;
@@ -78,7 +79,10 @@ describe('GroupController', () => {
       };
     }),
     getContactLocationGroup: jest.fn(
-      async (contactId: number): Promise<{ id: number; name: string } | null> => {
+      async (
+        contactId: number,
+        user: any,
+      ): Promise<{ id: number; name: string } | null> => {
         return { id: 7, name: 'Downtown' };
       },
     ),
@@ -298,20 +302,34 @@ describe('GroupController', () => {
 
   describe('getContactLocationGroup (/contact-location/:contactId)', () => {
     it('returns the location group for a contact', async () => {
-      const result = await controller.getContactLocationGroup(12);
+      const rawRequest = { user: { id: 1 }, headers: {} };
+      const result = await controller.getContactLocationGroup(12, rawRequest);
 
       expect(mockGroupService.getContactLocationGroup).toHaveBeenCalledWith(
         12,
+        rawRequest.user,
       );
       expect(result).toEqual({ id: expect.any(Number), name: expect.any(String) });
     });
 
     it('returns null when the service finds no location group', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
       mockGroupService.getContactLocationGroup.mockResolvedValueOnce(null);
 
-      const result = await controller.getContactLocationGroup(13);
+      const result = await controller.getContactLocationGroup(13, rawRequest);
 
       expect(result).toBeNull();
+    });
+
+    it('propagates an access-denied error from the service', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+      mockGroupService.getContactLocationGroup.mockRejectedValueOnce(
+        new ClientFriendlyException('Access denied to this location group'),
+      );
+
+      await expect(
+        controller.getContactLocationGroup(14, rawRequest),
+      ).rejects.toThrow(ClientFriendlyException);
     });
   });
 });

--- a/src/groups/controllers/group.controller.spec.ts
+++ b/src/groups/controllers/group.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { GroupPrivacy } from '../enums/groupPrivacy';
 import { GroupsService } from '../services/groups.service';
 import { GroupController } from './group.controller';
@@ -46,6 +47,41 @@ describe('GroupController', () => {
         },
       };
     }),
+    getGroupMembers: jest.fn((groupId, user, limit, offset) => {
+      return {
+        members: [
+          {
+            id: 1,
+            fullName: 'Member One',
+            role: 'Member',
+            joinedAt: new Date(),
+          },
+        ],
+        total: 1,
+        limit,
+        offset,
+      };
+    }),
+    getGroupSmsInfo: jest.fn((groupId, user) => {
+      return {
+        totalMembers: 3,
+        membersWithPhone: 2,
+        membersWithoutPhone: 1,
+      };
+    }),
+    sendGroupSms: jest.fn((groupId, message, user) => {
+      return {
+        success: true,
+        sentCount: 2,
+        totalMembers: 3,
+        skippedCount: 1,
+      };
+    }),
+    getContactLocationGroup: jest.fn(
+      async (contactId: number): Promise<{ id: number; name: string } | null> => {
+        return { id: 7, name: 'Downtown' };
+      },
+    ),
   };
 
   beforeEach(async () => {
@@ -137,6 +173,145 @@ describe('GroupController', () => {
         id: dto.parentId,
         name: expect.any(String),
       },
+    });
+  });
+
+  describe('getGroupMembers (/:id/members)', () => {
+    it('returns a page of members using default limit/offset', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+
+      const result = await controller.getGroupMembers(
+        5,
+        undefined,
+        undefined,
+        rawRequest,
+      );
+
+      expect(mockGroupService.getGroupMembers).toHaveBeenCalledWith(
+        5,
+        rawRequest.user,
+        50,
+        0,
+      );
+      expect(result).toEqual({
+        members: expect.any(Array),
+        total: expect.any(Number),
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    it('caps the limit at the configured maximum', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+
+      await controller.getGroupMembers(5, 500, 0, rawRequest);
+
+      expect(mockGroupService.getGroupMembers).toHaveBeenCalledWith(
+        5,
+        rawRequest.user,
+        100,
+        0,
+      );
+    });
+  });
+
+  describe('getGroupMembersByQuery (/member)', () => {
+    it('parses groupId/limit/skip query params and delegates to the service', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+
+      const result = await controller.getGroupMembersByQuery(
+        '9',
+        '10',
+        '0',
+        rawRequest,
+      );
+
+      expect(mockGroupService.getGroupMembers).toHaveBeenCalledWith(
+        9,
+        rawRequest.user,
+        10,
+        0,
+      );
+      expect(result).toEqual({
+        members: expect.any(Array),
+        total: expect.any(Number),
+        limit: 10,
+        offset: 0,
+      });
+    });
+
+    it('rejects a non-numeric groupId', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+
+      await expect(
+        controller.getGroupMembersByQuery('abc', '10', '0', rawRequest),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a groupId of zero', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+
+      await expect(
+        controller.getGroupMembersByQuery('0', '10', '0', rawRequest),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getGroupSmsInfo (/:id/sms-info)', () => {
+    it('returns member/phone counts for the group', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+
+      const result = await controller.getGroupSmsInfo(3, rawRequest);
+
+      expect(mockGroupService.getGroupSmsInfo).toHaveBeenCalledWith(
+        3,
+        rawRequest.user,
+      );
+      expect(result).toEqual({
+        totalMembers: expect.any(Number),
+        membersWithPhone: expect.any(Number),
+        membersWithoutPhone: expect.any(Number),
+      });
+    });
+  });
+
+  describe('sendGroupSms (/:groupId/send-sms)', () => {
+    it('forwards the message body to the service', async () => {
+      const rawRequest = { user: { id: 1 }, headers: {} };
+      const body = { message: 'Service starts at 9am' };
+
+      const result = await controller.sendGroupSms(3, body, rawRequest);
+
+      expect(mockGroupService.sendGroupSms).toHaveBeenCalledWith(
+        3,
+        body.message,
+        rawRequest.user,
+      );
+      expect(result).toEqual({
+        success: true,
+        sentCount: expect.any(Number),
+        totalMembers: expect.any(Number),
+        skippedCount: expect.any(Number),
+      });
+    });
+  });
+
+  describe('getContactLocationGroup (/contact-location/:contactId)', () => {
+    it('returns the location group for a contact', async () => {
+      const result = await controller.getContactLocationGroup(12);
+
+      expect(mockGroupService.getContactLocationGroup).toHaveBeenCalledWith(
+        12,
+      );
+      expect(result).toEqual({ id: expect.any(Number), name: expect.any(String) });
+    });
+
+    it('returns null when the service finds no location group', async () => {
+      mockGroupService.getContactLocationGroup.mockResolvedValueOnce(null);
+
+      const result = await controller.getContactLocationGroup(13);
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/groups/controllers/group.controller.ts
+++ b/src/groups/controllers/group.controller.ts
@@ -175,10 +175,12 @@ export class GroupController {
   ): Promise<void> {
     await this.service.remove(id, rawRequest.user);
   }
+
   @Get('contact-location/:contactId')
   async getContactLocationGroup(
     @Param('contactId', ParseIntPipe) contactId: number,
+    @Request() rawRequest: any,
   ): Promise<{ id: number; name: string } | null> {
-    return this.service.getContactLocationGroup(contactId);
+    return this.service.getContactLocationGroup(contactId, rawRequest.user);
   }
 }

--- a/src/groups/controllers/group.controller.ts
+++ b/src/groups/controllers/group.controller.ts
@@ -175,4 +175,10 @@ export class GroupController {
   ): Promise<void> {
     await this.service.remove(id, rawRequest.user);
   }
+  @Get('contact-location/:contactId')
+  async getContactLocationGroup(
+    @Param('contactId', ParseIntPipe) contactId: number,
+  ): Promise<{ id: number; name: string } | null> {
+    return this.service.getContactLocationGroup(contactId);
+  }
 }

--- a/src/groups/services/group.service.spec.ts
+++ b/src/groups/services/group.service.spec.ts
@@ -15,6 +15,13 @@ import GroupCategory from '../entities/groupCategory.entity';
 import Phone from '../../crm/entities/phone.entity';
 import { FellowshipSchedule } from '../../attendance/entities/fellowship-schedule.entity';
 
+let tenantAwareGroupRepoForTest: any;
+jest.mock('../../shared/repository/tenant-aware.repository', () => ({
+  TenantAwareRepository: jest
+    .fn()
+    .mockImplementation(() => tenantAwareGroupRepoForTest),
+}));
+
 describe('GroupsService', () => {
   let service: GroupsService;
   let mockRepositories: any;
@@ -23,6 +30,7 @@ describe('GroupsService', () => {
   let mockGoogleService: Partial<GoogleService>;
   let mockAfricasTalkingService: Partial<AfricasTalkingService>;
   let mockTenantContext: Partial<TenantContext>;
+  let mockTenantAwareGroupRepo: any;
 
   beforeEach(async () => {
     mockRepositories = {
@@ -84,6 +92,11 @@ describe('GroupsService', () => {
       requireTenant: jest.fn().mockReturnValue(1),
       tenantId: 1,
     } as any;
+
+    mockTenantAwareGroupRepo = {
+      findOne: jest.fn(),
+    };
+    tenantAwareGroupRepoForTest = mockTenantAwareGroupRepo;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -352,29 +365,58 @@ describe('GroupsService', () => {
   });
 
   describe('getContactLocationGroup', () => {
-    it('returns null when the contact has no location group', async () => {
+    const requestingUser = { id: 1 };
+
+    it('returns null when the contact has no location group, without checking permissions', async () => {
       mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
         null,
       );
 
-      const result = await service.getContactLocationGroup(5);
+      const result = await service.getContactLocationGroup(5, requestingUser);
 
       expect(result).toBeNull();
-      expect(mockRepositories.group.findOne).not.toHaveBeenCalled();
+      expect(
+        mockGroupsPermissionsService.hasPermissionForGroup,
+      ).not.toHaveBeenCalled();
+      expect(mockTenantAwareGroupRepo.findOne).not.toHaveBeenCalled();
     });
 
-    it('returns the id/name of the resolved location group', async () => {
+    it('throws when the requesting user lacks permission for the resolved location group', async () => {
       mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
         3,
       );
-      mockRepositories.group.findOne.mockResolvedValueOnce({
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        false,
+      );
+
+      await expect(
+        service.getContactLocationGroup(5, requestingUser),
+      ).rejects.toThrow(ClientFriendlyException);
+      expect(
+        mockGroupsPermissionsService.hasPermissionForGroup,
+      ).toHaveBeenCalledWith(requestingUser, 3);
+      expect(mockTenantAwareGroupRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns the id/name of the resolved location group when the user has access', async () => {
+      mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
+        3,
+      );
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      mockTenantAwareGroupRepo.findOne.mockResolvedValueOnce({
         id: 3,
         name: 'Downtown',
       });
 
-      const result = await service.getContactLocationGroup(5);
+      const result = await service.getContactLocationGroup(5, requestingUser);
 
       expect(result).toEqual({ id: 3, name: 'Downtown' });
+      expect(mockTenantAwareGroupRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 3 },
+        select: ['id', 'name'],
+      });
     });
   });
 

--- a/src/groups/services/group.service.spec.ts
+++ b/src/groups/services/group.service.spec.ts
@@ -1,0 +1,426 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import ClientFriendlyException from '../../shared/exceptions/client-friendly.exception';
+import { GroupsService } from './groups.service';
+import { GroupPermissionsService } from './group-permissions.service';
+import { GoogleService } from '../../vendor/google.service';
+import { AppLogger } from '../../utils/app-logger.service';
+import { TenantContext } from '../../shared/tenant/tenant-context';
+import { AfricasTalkingService } from '../../vendor/africas-talking.service';
+import Group from '../entities/group.entity';
+import GroupMembership from '../entities/groupMembership.entity';
+import GroupEvent from '../../events/entities/event.entity';
+import GroupCategory from '../entities/groupCategory.entity';
+import Phone from '../../crm/entities/phone.entity';
+import { FellowshipSchedule } from '../../attendance/entities/fellowship-schedule.entity';
+
+describe('GroupsService', () => {
+  let service: GroupsService;
+  let mockRepositories: any;
+  let mockDataSource: any;
+  let mockGroupsPermissionsService: any;
+  let mockGoogleService: Partial<GoogleService>;
+  let mockAfricasTalkingService: Partial<AfricasTalkingService>;
+  let mockTenantContext: Partial<TenantContext>;
+
+  beforeEach(async () => {
+    mockRepositories = {
+      group: {
+        find: jest.fn(),
+        findOne: jest.fn(),
+        count: jest.fn(),
+        createQueryBuilder: jest.fn(),
+      },
+      membership: {
+        find: jest.fn(),
+        count: jest.fn(),
+        createQueryBuilder: jest.fn(),
+      },
+      event: {
+        find: jest.fn(),
+      },
+      category: {
+        find: jest.fn(),
+        findOne: jest.fn(),
+      },
+      phone: {},
+      fellowshipSchedule: {
+        save: jest.fn(),
+        create: jest.fn((data) => data),
+      },
+    };
+
+    mockDataSource = {
+      getRepository: jest.fn((entity: any) => {
+        if (entity === Group) return mockRepositories.group;
+        if (entity === GroupMembership) return mockRepositories.membership;
+        if (entity === GroupEvent) return mockRepositories.event;
+        if (entity === GroupCategory) return mockRepositories.category;
+        if (entity === Phone) return mockRepositories.phone;
+        if (entity === FellowshipSchedule)
+          return mockRepositories.fellowshipSchedule;
+        return {};
+      }),
+      getTreeRepository: jest.fn(() => ({})),
+    };
+
+    mockGroupsPermissionsService = {
+      getAccessibleGroupIds: jest.fn(),
+      getUserGroupIds: jest.fn(),
+      getUserIsMemberLeaderGroupIds: jest.fn(),
+      assertPermissionForGroup: jest.fn(),
+      hasPermissionForGroup: jest.fn(),
+      getContactLocationGroupId: jest.fn(),
+      getDescendantGroupIds: jest.fn(),
+    };
+
+    mockGoogleService = { getPlaceDetails: jest.fn() };
+    mockAfricasTalkingService = {
+      normalizePhoneNumber: jest.fn((v: string) => v),
+      sendBulkSms: jest.fn(),
+    };
+    mockTenantContext = {
+      requireTenant: jest.fn().mockReturnValue(1),
+      tenantId: 1,
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GroupsService,
+        {
+          provide: getDataSourceToken(),
+          useValue: mockDataSource,
+        },
+        { provide: GroupPermissionsService, useValue: mockGroupsPermissionsService },
+        { provide: GoogleService, useValue: mockGoogleService },
+        {
+          provide: AppLogger,
+          useValue: {
+            createContextLogger: jest.fn(() => ({
+              business: jest.fn(),
+              security: jest.fn(),
+              error: jest.fn(),
+              startTracking: jest.fn(() => ({})),
+              endTracking: jest.fn(),
+            })),
+          },
+        },
+        { provide: TenantContext, useValue: mockTenantContext },
+        { provide: AfricasTalkingService, useValue: mockAfricasTalkingService },
+      ],
+    }).compile();
+
+    service = module.get<GroupsService>(GroupsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getGroupMembers', () => {
+    it('throws when the user lacks permission for the group', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        false,
+      );
+
+      await expect(
+        service.getGroupMembers(1, { id: 1 }),
+      ).rejects.toThrow(ClientFriendlyException);
+    });
+
+    it('returns paginated members mapped to a simple shape', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      const membershipQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          {
+            contact: {
+              id: 10,
+              person: { firstName: 'Ann', lastName: 'Otim' },
+              emails: [],
+            },
+            role: 'Member',
+            joinedAt: new Date('2024-01-01'),
+          },
+        ]),
+      };
+      mockRepositories.membership.createQueryBuilder.mockReturnValue(
+        membershipQb,
+      );
+      mockRepositories.membership.count.mockResolvedValue(1);
+
+      const result = await service.getGroupMembers(1, { id: 1 }, 20, 0);
+
+      expect(membershipQb.skip).toHaveBeenCalledWith(0);
+      expect(membershipQb.take).toHaveBeenCalledWith(20);
+      expect(result).toEqual({
+        members: [
+          {
+            id: 10,
+            fullName: 'Ann Otim',
+            role: 'Member',
+            joinedAt: new Date('2024-01-01'),
+          },
+        ],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      });
+    });
+
+    it('falls back to email when the contact has no person record', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      const membershipQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          {
+            contact: {
+              id: 11,
+              person: null,
+              emails: [{ value: 'noone@test.com' }],
+            },
+            role: 'Member',
+            joinedAt: new Date('2024-01-01'),
+          },
+        ]),
+      };
+      mockRepositories.membership.createQueryBuilder.mockReturnValue(
+        membershipQb,
+      );
+      mockRepositories.membership.count.mockResolvedValue(1);
+
+      const result = await service.getGroupMembers(1, { id: 1 });
+
+      expect(result.members[0].fullName).toBe('noone@test.com');
+    });
+  });
+
+  describe('getGroupSmsInfo', () => {
+    it('throws when the user lacks permission for the group', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        false,
+      );
+
+      await expect(
+        service.getGroupSmsInfo(1, { id: 1 }),
+      ).rejects.toThrow(ClientFriendlyException);
+    });
+
+    it('counts members with and without a phone number', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      mockRepositories.membership.find.mockResolvedValueOnce([
+        { contact: { phones: [{ value: '0700000000' }] } },
+        { contact: { phones: [] } },
+        { contact: { phones: undefined } },
+      ]);
+
+      const result = await service.getGroupSmsInfo(1, { id: 1 });
+
+      expect(result).toEqual({
+        totalMembers: 3,
+        membersWithPhone: 1,
+        membersWithoutPhone: 2,
+      });
+    });
+  });
+
+  describe('sendGroupSms', () => {
+    const user = { id: 1 };
+
+    it('throws NotFoundException when the group does not exist', async () => {
+      mockRepositories.group.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.sendGroupSms(1, 'hello', user),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws when the user lacks permission for the group', async () => {
+      mockRepositories.group.findOne.mockResolvedValueOnce({
+        id: 1,
+        name: 'Group A',
+      });
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        false,
+      );
+
+      await expect(
+        service.sendGroupSms(1, 'hello', user),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects an empty message', async () => {
+      mockRepositories.group.findOne.mockResolvedValueOnce({
+        id: 1,
+        name: 'Group A',
+      });
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+
+      await expect(
+        service.sendGroupSms(1, '   ', user),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a group with no active members', async () => {
+      mockRepositories.group.findOne.mockResolvedValueOnce({
+        id: 1,
+        name: 'Group A',
+      });
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      mockRepositories.membership.find.mockResolvedValueOnce([]);
+
+      await expect(
+        service.sendGroupSms(1, 'hello', user),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('skips members with no valid phone number and sends to the rest', async () => {
+      mockRepositories.group.findOne.mockResolvedValueOnce({
+        id: 1,
+        name: 'Group A',
+      });
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      mockRepositories.membership.find.mockResolvedValueOnce([
+        {
+          contactId: 1,
+          contact: { phones: [{ isPrimary: true, value: '0700000001' }] },
+        },
+        { contactId: 2, contact: { phones: [] } },
+      ]);
+      (mockAfricasTalkingService.normalizePhoneNumber as jest.Mock)
+        .mockReturnValueOnce('+256700000001');
+      (mockAfricasTalkingService.sendBulkSms as jest.Mock).mockResolvedValue({
+        success: true,
+        sentCount: 1,
+        failedCount: 0,
+      });
+
+      const result = await service.sendGroupSms(1, 'hello', user);
+
+      expect(mockAfricasTalkingService.sendBulkSms).toHaveBeenCalledWith(
+        ['+256700000001'],
+        'hello',
+      );
+      expect(result).toEqual({
+        success: true,
+        sentCount: 1,
+        totalMembers: 2,
+        skippedCount: 1,
+      });
+    });
+
+    it('throws when every phone number fails to normalize', async () => {
+      mockRepositories.group.findOne.mockResolvedValueOnce({
+        id: 1,
+        name: 'Group A',
+      });
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      mockRepositories.membership.find.mockResolvedValueOnce([
+        {
+          contactId: 1,
+          contact: { phones: [{ isPrimary: true, value: 'bad-number' }] },
+        },
+      ]);
+      (mockAfricasTalkingService.normalizePhoneNumber as jest.Mock)
+        .mockReturnValueOnce(null);
+
+      await expect(
+        service.sendGroupSms(1, 'hello', user),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getContactLocationGroup', () => {
+    it('returns null when the contact has no location group', async () => {
+      mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
+        null,
+      );
+
+      const result = await service.getContactLocationGroup(5);
+
+      expect(result).toBeNull();
+      expect(mockRepositories.group.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns the id/name of the resolved location group', async () => {
+      mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
+        3,
+      );
+      mockRepositories.group.findOne.mockResolvedValueOnce({
+        id: 3,
+        name: 'Downtown',
+      });
+
+      const result = await service.getContactLocationGroup(5);
+
+      expect(result).toEqual({ id: 3, name: 'Downtown' });
+    });
+  });
+
+  describe('findAll — sameLocation scoping', () => {
+    it("scopes purpose-filtered groups to the requesting user's own location", async () => {
+      mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
+        2,
+      );
+      mockGroupsPermissionsService.getDescendantGroupIds.mockResolvedValueOnce(
+        [20, 21],
+      );
+      const purposeQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockRepositories.group.createQueryBuilder.mockReturnValue(purposeQb);
+
+      await service.findAll(
+        { purpose: 'Fellowship', sameLocation: true } as any,
+        { contactId: 7 },
+      );
+
+      expect(
+        mockGroupsPermissionsService.getContactLocationGroupId,
+      ).toHaveBeenCalledWith(7);
+      expect(purposeQb.andWhere).toHaveBeenCalledWith(
+        'group.id IN (:...accessibleGroupIds)',
+        { accessibleGroupIds: [2, 20, 21] },
+      );
+    });
+
+    it('returns an empty array when the requesting user has no location group', async () => {
+      mockGroupsPermissionsService.getContactLocationGroupId.mockResolvedValueOnce(
+        null,
+      );
+
+      const result = await service.findAll(
+        { purpose: 'Fellowship', sameLocation: true } as any,
+        { contactId: 7 },
+      );
+
+      expect(result).toEqual([]);
+      expect(mockRepositories.group.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -40,6 +40,7 @@ import {
 } from '@nestjs/common';
 import { Tenant } from 'src/tenants/entities/tenant.entity';
 import { FellowshipSchedule } from '../../attendance/entities/fellowship-schedule.entity';
+import { TenantAwareRepository } from '../../shared/repository/tenant-aware.repository';
 
 @Injectable()
 export class GroupsService {
@@ -50,6 +51,7 @@ export class GroupsService {
   private readonly groupCategoryRepository: Repository<GroupCategory>;
   private readonly phoneRepository: Repository<Phone>;
   private readonly fellowshipScheduleRepository: Repository<FellowshipSchedule>;
+  private readonly tenantAwareGroupRepository: TenantAwareRepository<Group>;
   private readonly logger: ContextLogger;
 
   constructor(
@@ -68,6 +70,11 @@ export class GroupsService {
     this.phoneRepository = dataSource.getRepository(Phone);
     this.fellowshipScheduleRepository =
       dataSource.getRepository(FellowshipSchedule);
+    this.tenantAwareGroupRepository = new TenantAwareRepository(
+      Group,
+      dataSource.manager,
+      tenantContext,
+    );
     this.logger = this.appLogger.createContextLogger('GroupsService');
   }
 
@@ -1194,18 +1201,29 @@ export class GroupsService {
       skippedCount: skippedCount + result.failedCount,
     };
   }
+
   async getContactLocationGroup(
     contactId: number,
+    user: any,
   ): Promise<{ id: number; name: string } | null> {
     const groupId =
       await this.groupsPermissionsService.getContactLocationGroupId(contactId);
     if (groupId === null) {
       return null;
     }
-    const tenantId = this.tenantContext.requireTenant();
-    const group = await this.repository.findOne({
-      where: { id: groupId, tenant: { id: tenantId } },
+    const hasAccess = await this.groupsPermissionsService.hasPermissionForGroup(
+      user,
+      groupId,
+    );
+    if (!hasAccess) {
+      throw new ClientFriendlyException(
+        'Access denied to this location group',
+      );
+    }
+    const group = await this.tenantAwareGroupRepository.findOne({
+      where: { id: groupId },
       select: ['id', 'name'],
-    });    return group ? { id: group.id, name: group.name } : null;
+    });
+    return group ? { id: group.id, name: group.name } : null;
   }
 }

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -1194,4 +1194,18 @@ export class GroupsService {
       skippedCount: skippedCount + result.failedCount,
     };
   }
+  async getContactLocationGroup(
+    contactId: number,
+  ): Promise<{ id: number; name: string } | null> {
+    const groupId =
+      await this.groupsPermissionsService.getContactLocationGroupId(contactId);
+    if (groupId === null) {
+      return null;
+    }
+    const tenantId = this.tenantContext.requireTenant();
+    const group = await this.repository.findOne({
+      where: { id: groupId, tenant: { id: tenantId } },
+      select: ['id', 'name'],
+    });    return group ? { id: group.id, name: group.name } : null;
+  }
 }

--- a/src/groups/services/groups.service.ts
+++ b/src/groups/services/groups.service.ts
@@ -40,7 +40,7 @@ import {
 } from '@nestjs/common';
 import { Tenant } from 'src/tenants/entities/tenant.entity';
 import { FellowshipSchedule } from '../../attendance/entities/fellowship-schedule.entity';
-import { TenantAwareRepository } from '../../shared/repository/tenant-aware.repository';
+import { GroupRepository } from '../../shared/repository/group.repository';
 
 @Injectable()
 export class GroupsService {
@@ -51,7 +51,9 @@ export class GroupsService {
   private readonly groupCategoryRepository: Repository<GroupCategory>;
   private readonly phoneRepository: Repository<Phone>;
   private readonly fellowshipScheduleRepository: Repository<FellowshipSchedule>;
-  private readonly tenantAwareGroupRepository: TenantAwareRepository<Group>;
+  // Tenant-scoped lookups (e.g. getContactLocationGroup) go through this
+  // instead of hand-rolling `tenant: { id: tenantId }` at each call site.
+  private readonly tenantAwareGroupRepository: GroupRepository;
   private readonly logger: ContextLogger;
 
   constructor(
@@ -70,8 +72,7 @@ export class GroupsService {
     this.phoneRepository = dataSource.getRepository(Phone);
     this.fellowshipScheduleRepository =
       dataSource.getRepository(FellowshipSchedule);
-    this.tenantAwareGroupRepository = new TenantAwareRepository(
-      Group,
+    this.tenantAwareGroupRepository = new GroupRepository(
       dataSource.manager,
       tenantContext,
     );
@@ -1202,6 +1203,11 @@ export class GroupsService {
     };
   }
 
+  /**
+   * Resolves the location group for a contact. Requires the caller to have
+   * permission for that location group — without this check, any
+   * authenticated tenant user could resolve another contact's location.
+   */
   async getContactLocationGroup(
     contactId: number,
     user: any,
@@ -1211,6 +1217,7 @@ export class GroupsService {
     if (groupId === null) {
       return null;
     }
+
     const hasAccess = await this.groupsPermissionsService.hasPermissionForGroup(
       user,
       groupId,
@@ -1220,6 +1227,7 @@ export class GroupsService {
         'Access denied to this location group',
       );
     }
+
     const group = await this.tenantAwareGroupRepository.findOne({
       where: { id: groupId },
       select: ['id', 'name'],

--- a/src/seed/seed.service.ts
+++ b/src/seed/seed.service.ts
@@ -56,6 +56,7 @@ export class SeedService {
       jwtHelperservice,
       groupMembershipService,
       mockTenantContext,
+      groupsPermissionsService,
     );
 
     this.groupsService = new GroupsService(

--- a/src/shared/repository/group.repository.ts
+++ b/src/shared/repository/group.repository.ts
@@ -1,0 +1,15 @@
+import { EntityManager } from 'typeorm';
+import { TenantAwareRepository } from './tenant-aware.repository';
+import { TenantContext } from '../tenant/tenant-context';
+import Group from '../../groups/entities/group.entity';
+
+/**
+ * Tenant-scoped repository for Group. Centralizes the
+ * `new TenantAwareRepository(Group, ...)` construction that was previously
+ * duplicated inline in GroupsService and UsersService.
+ */
+export class GroupRepository extends TenantAwareRepository<Group> {
+  constructor(manager: EntityManager, tenantContext: TenantContext) {
+    super(Group, manager, tenantContext);
+  }
+}

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -72,6 +72,7 @@ describe('TasksService — location-based visibility scoping', () => {
     });
     membershipQb = createChainableQb({
       getCount: jest.fn().mockResolvedValue(0),
+      getMany: jest.fn().mockResolvedValue([]),
     });
     commentQb = createChainableQb({
       getRawMany: jest.fn().mockResolvedValue([]),

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -292,9 +292,15 @@ export class TasksService {
 
   async findOne(taskId: number, user: any): Promise<Task> {
     const tenantId = this.tenantContext.requireTenant();
-    const task = await this.findTaskWithRelations(taskId, tenantId);
+    const task = await this.taskRepository.findOne({
+      where: { id: taskId, tenant: { id: tenantId } },
+      relations: ['contact'],
+    });
+    if (!task) {
+      throw new NotFoundException(`Task ${taskId} not found`);
+    }
     await this.assertContactLocationAccess(task.contact.id, user);
-    return task;
+    return this.findTaskWithRelations(taskId, tenantId);
   }
 
   async update(
@@ -518,7 +524,7 @@ export class TasksService {
   private async findTaskWithRelations(
     taskId: number,
     tenantId: number,
-  ): Promise<Task> {
+  ): Promise<TaskWithLocationGroup> {
     const task = await this.taskRepository.findOne({
       where: { id: taskId, tenant: { id: tenantId } },
       relations: [...TASK_DETAIL_RELATIONS],
@@ -528,9 +534,14 @@ export class TasksService {
       throw new NotFoundException(`Task ${taskId} not found`);
     }
 
-    this.sanitizeTaskUsers(task);
-    this.attachContactAddress(task);
-    return task;
+    const [taskWithLocationGroup] = await this.attachLocationGroups(
+      [task],
+      tenantId,
+    );
+
+    this.sanitizeTaskUsers(taskWithLocationGroup);
+    this.attachContactAddress(taskWithLocationGroup);
+    return taskWithLocationGroup;
   }
 
   private sanitizeTaskUsers(task: Task): void {

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -290,7 +290,7 @@ export class TasksService {
     return tasksWithLocationGroups;
   }
 
-  async findOne(taskId: number, user: any): Promise<Task> {
+  async findOne(taskId: number, user: any): Promise<TaskWithLocationGroup> {
     const tenantId = this.tenantContext.requireTenant();
     const task = await this.taskRepository.findOne({
       where: { id: taskId, tenant: { id: tenantId } },

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -29,7 +29,7 @@ describe('Users Controller', () => {
         isActive: false,
       };
     }),
-    findUsersInGroup: jest.fn((groupId) => {
+    findUsersInGroup: jest.fn((groupId, user) => {
       return [
         {
           id: 1,
@@ -110,10 +110,14 @@ describe('Users Controller', () => {
 
   it('should list the users belonging to a location group', async () => {
     const groupId = 42;
+    const rawRequest = { user: { id: 1 }, headers: {} };
 
-    const result = await controller.findByLocationGroup(groupId);
+    const result = await controller.findByLocationGroup(groupId, rawRequest);
 
-    expect(mockUsersService.findUsersInGroup).toHaveBeenCalledWith(groupId);
+    expect(mockUsersService.findUsersInGroup).toHaveBeenCalledWith(
+      groupId,
+      rawRequest.user,
+    );
     expect(result).toHaveLength(1);
     result.forEach((it) => {
       expect(it).toMatchObject({

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -29,6 +29,23 @@ describe('Users Controller', () => {
         isActive: false,
       };
     }),
+    findUsersInGroup: jest.fn((groupId) => {
+      return [
+        {
+          id: 1,
+          username: 'memberone@test.com',
+          fullName: 'Member One',
+          contactId: 1,
+          contact: {
+            id: 1,
+            name: 'Member One',
+          },
+          avatar: null,
+          roles: ['USER_VIEW'],
+          isActive: true,
+        },
+      ];
+    }),
   };
 
   beforeEach(async () => {
@@ -88,6 +105,25 @@ describe('Users Controller', () => {
     });
     result.roles.forEach((it) => {
       expect(it).toEqual(expect.any(String));
+    });
+  });
+
+  it('should list the users belonging to a location group', async () => {
+    const groupId = 42;
+
+    const result = await controller.findByLocationGroup(groupId);
+
+    expect(mockUsersService.findUsersInGroup).toHaveBeenCalledWith(groupId);
+    expect(result).toHaveLength(1);
+    result.forEach((it) => {
+      expect(it).toMatchObject({
+        id: expect.any(Number),
+        username: expect.any(String),
+        fullName: expect.any(String),
+        contactId: expect.any(Number),
+        roles: expect.any(Array),
+        isActive: expect.any(Boolean),
+      });
     });
   });
 });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,6 +11,7 @@ import {
   Query,
   UseGuards,
   UseInterceptors,
+  Request,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import SearchDto from '../shared/dto/search.dto';
@@ -36,8 +37,9 @@ export class UsersController {
   @Get('by-location/:groupId')
   async findByLocationGroup(
     @Param('groupId', ParseIntPipe) groupId: number,
+    @Request() rawRequest: any,
   ): Promise<UserListDto[]> {
-    return this.service.findUsersInGroup(groupId);
+    return this.service.findUsersInGroup(groupId, rawRequest.user);
   }
 
   @Post()

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -33,6 +33,12 @@ export class UsersController {
   async findAll(@Query() req: SearchDto): Promise<UserListDto[]> {
     return this.service.findAll(req);
   }
+  @Get('by-location/:groupId')
+  async findByLocationGroup(
+    @Param('groupId', ParseIntPipe) groupId: number,
+  ): Promise<UserListDto[]> {
+    return this.service.findUsersInGroup(groupId);
+  }
 
   @Post()
   async create(@Body() data: CreateUserDto): Promise<UserListDto> {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -5,11 +5,14 @@ import { ContactsService } from '../crm/contacts.service';
 import { JwtHelperService } from '../auth/jwt-helpers.service';
 import { GroupsMembershipService } from '../groups/services/group-membership.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
-import { Connection, Repository } from 'typeorm';
+import { Connection } from 'typeorm';
 import Email from '../crm/entities/email.entity';
 import Roles from './entities/roles.entity';
 import UserRoles from './entities/userRoles.entity';
 import Person from '../crm/entities/person.entity';
+import Group from '../groups/entities/group.entity';
+import GroupMembership from '../groups/entities/groupMembership.entity';
+import { GroupRole } from '../groups/enums/groupRole';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -28,6 +31,11 @@ describe('UsersService', () => {
         create: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
+        // Used by findUsersInGroup() to reach Group / GroupMembership
+        // repositories via `this.repository.manager.getRepository(...)`
+        manager: {
+          getRepository: jest.fn(),
+        },
       },
       email: {
         find: jest.fn(),
@@ -128,5 +136,158 @@ describe('UsersService', () => {
     const result = await service.create(mockUser);
     expect(result).toBeDefined();
     expect(mockRepositories.user.save).toHaveBeenCalled();
+  });
+
+  describe('findUsersInGroup', () => {
+    let mockGroupRepo: any;
+    let mockMembershipRepo: any;
+    let mockMembershipQb: any;
+
+    beforeEach(() => {
+      mockMembershipQb = {
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getMany: jest.fn(),
+      };
+
+      mockGroupRepo = {
+        findOne: jest.fn(),
+      };
+
+      mockMembershipRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue(mockMembershipQb),
+      };
+
+      mockRepositories.user.manager.getRepository.mockImplementation(
+        (entity: any) => {
+          if (entity === Group) return mockGroupRepo;
+          if (entity === GroupMembership) return mockMembershipRepo;
+          return null;
+        },
+      );
+    });
+
+    it('scopes to a single group when no FOB ancestor exists', async () => {
+      mockGroupRepo.findOne.mockResolvedValueOnce({
+        id: 5,
+        parentId: null,
+        category: { name: 'Location' },
+      });
+      mockMembershipQb.getMany.mockResolvedValueOnce([
+        { contactId: 1 },
+        { contactId: 2 },
+      ]);
+      mockRepositories.user.find.mockResolvedValueOnce([
+        {
+          id: 1,
+          contactId: 1,
+          userRoles: [],
+          contact: { person: { firstName: 'A', lastName: 'B' } },
+        },
+        {
+          id: 2,
+          contactId: 2,
+          userRoles: [],
+          contact: { person: { firstName: 'C', lastName: 'D' } },
+        },
+      ]);
+
+      const result = await service.findUsersInGroup(5);
+
+      expect(mockMembershipQb.andWhere).toHaveBeenCalledWith(
+        'membership.groupId = :groupId',
+        expect.objectContaining({ groupId: 5 }),
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('also includes FOB leaders when an ancestor FOB group is found', async () => {
+      mockGroupRepo.findOne
+        .mockResolvedValueOnce({
+          id: 5,
+          parentId: 4,
+          category: { name: 'Location' },
+        })
+        .mockResolvedValueOnce({
+          id: 4,
+          parentId: null,
+          category: { name: 'FOB' },
+        });
+      mockMembershipQb.getMany.mockResolvedValueOnce([{ contactId: 3 }]);
+      mockRepositories.user.find.mockResolvedValueOnce([
+        {
+          id: 3,
+          contactId: 3,
+          userRoles: [],
+          contact: { person: { firstName: 'E', lastName: 'F' } },
+        },
+      ]);
+
+      const result = await service.findUsersInGroup(5);
+
+      expect(mockMembershipQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('membership.groupId = :fobGroupId'),
+        expect.objectContaining({
+          groupId: 5,
+          fobGroupId: 4,
+          leaderRole: GroupRole.Leader,
+        }),
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('stops walking up the tree if a parent group is missing', async () => {
+      mockGroupRepo.findOne.mockResolvedValueOnce(undefined);
+      mockMembershipQb.getMany.mockResolvedValueOnce([]);
+
+      await service.findUsersInGroup(99);
+
+      // Only the initial lookup should have run; the while loop breaks
+      // as soon as `group` comes back falsy.
+      expect(mockGroupRepo.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty array without querying users when the group has no members', async () => {
+      mockGroupRepo.findOne.mockResolvedValueOnce({
+        id: 9,
+        parentId: null,
+        category: { name: 'Location' },
+      });
+      mockMembershipQb.getMany.mockResolvedValueOnce([]);
+
+      const result = await service.findUsersInGroup(9);
+
+      expect(result).toEqual([]);
+      expect(mockRepositories.user.find).not.toHaveBeenCalled();
+    });
+
+    it('de-duplicates repeated contact ids from the membership rows', async () => {
+      mockGroupRepo.findOne.mockResolvedValueOnce({
+        id: 5,
+        parentId: null,
+        category: { name: 'Location' },
+      });
+      mockMembershipQb.getMany.mockResolvedValueOnce([
+        { contactId: 1 },
+        { contactId: 1 },
+      ]);
+      mockRepositories.user.find.mockResolvedValueOnce([
+        {
+          id: 1,
+          contactId: 1,
+          userRoles: [],
+          contact: { person: { firstName: 'A', lastName: 'B' } },
+        },
+      ]);
+
+      const result = await service.findUsersInGroup(5);
+
+      // Only one user should be requested/returned even though the same
+      // contactId appeared twice in the membership rows.
+      expect(mockRepositories.user.find).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+    });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 import { ContactsService } from '../crm/contacts.service';
 import { JwtHelperService } from '../auth/jwt-helpers.service';
 import { GroupsMembershipService } from '../groups/services/group-membership.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
+import { GroupPermissionsService } from '../groups/services/group-permissions.service';
 import { Connection } from 'typeorm';
 import Email from '../crm/entities/email.entity';
 import Roles from './entities/roles.entity';
@@ -14,14 +16,41 @@ import Group from '../groups/entities/group.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
 import { GroupRole } from '../groups/enums/groupRole';
 
+// TenantAwareRepository requires a real TypeORM EntityManager; intercept its
+// constructor so the test can supply mockGroupRepo without a live connection
+// (mirrors the approach used in tasks.service.spec.ts).
+let groupRepoForTest: any;
+jest.mock('../shared/repository/tenant-aware.repository', () => ({
+  TenantAwareRepository: jest.fn().mockImplementation(() => groupRepoForTest),
+}));
+
 describe('UsersService', () => {
   let service: UsersService;
   let mockConnection: Partial<Connection>;
   let mockContactsService: Partial<ContactsService>;
   let mockJwtHelperService: Partial<JwtHelperService>;
+  let mockGroupsPermissionsService: { hasPermissionForGroup: jest.Mock };
   let mockRepositories: any;
+  let mockGroupRepo: any;
+  let mockMembershipQb: any;
 
   beforeEach(async () => {
+    mockMembershipQb = {
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+
+    // groupRepository is a TenantAwareRepository<Group> constructed once in
+    // the UsersService constructor (see the jest.mock interception above),
+    // so findNearestFobAncestor's lookups land on this mock's `findOne`.
+    mockGroupRepo = {
+      findOne: jest.fn(),
+    };
+    groupRepoForTest = mockGroupRepo;
+
     // Create mock repositories
     mockRepositories = {
       user: {
@@ -31,11 +60,6 @@ describe('UsersService', () => {
         create: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
-        // Used by findUsersInGroup() to reach Group / GroupMembership
-        // repositories via `this.repository.manager.getRepository(...)`
-        manager: {
-          getRepository: jest.fn(),
-        },
       },
       email: {
         find: jest.fn(),
@@ -51,6 +75,11 @@ describe('UsersService', () => {
       person: {
         find: jest.fn(),
       },
+      // membershipRepository is a plain Repository<GroupMembership>
+      // constructed via connection.getRepository(GroupMembership).
+      membership: {
+        createQueryBuilder: jest.fn().mockReturnValue(mockMembershipQb),
+      },
     };
 
     // Create mock connection
@@ -61,8 +90,10 @@ describe('UsersService', () => {
         if (entity === Roles) return mockRepositories.roles;
         if (entity === UserRoles) return mockRepositories.userRoles;
         if (entity === Person) return mockRepositories.person;
+        if (entity === GroupMembership) return mockRepositories.membership;
         return mockRepositories.user;
       }),
+      manager: {} as any,
     };
 
     // Create mock services
@@ -75,6 +106,10 @@ describe('UsersService', () => {
     mockJwtHelperService = {
       generateToken: jest.fn(),
       decodeToken: jest.fn(),
+    };
+
+    mockGroupsPermissionsService = {
+      hasPermissionForGroup: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -100,6 +135,10 @@ describe('UsersService', () => {
           provide: TenantContext,
           useValue: { requireTenant: jest.fn().mockReturnValue(1) },
         },
+        {
+          provide: GroupPermissionsService,
+          useValue: mockGroupsPermissionsService,
+        },
       ],
     }).compile();
 
@@ -116,6 +155,7 @@ describe('UsersService', () => {
     expect(mockConnection.getRepository).toHaveBeenCalledWith(Roles);
     expect(mockConnection.getRepository).toHaveBeenCalledWith(UserRoles);
     expect(mockConnection.getRepository).toHaveBeenCalledWith(Person);
+    expect(mockConnection.getRepository).toHaveBeenCalledWith(GroupMembership);
   });
 
   it('should create new user', async () => {
@@ -139,37 +179,23 @@ describe('UsersService', () => {
   });
 
   describe('findUsersInGroup', () => {
-    let mockGroupRepo: any;
-    let mockMembershipRepo: any;
-    let mockMembershipQb: any;
+    const requestingUser = { id: 1 };
 
-    beforeEach(() => {
-      mockMembershipQb = {
-        innerJoin: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        getMany: jest.fn(),
-      };
-
-      mockGroupRepo = {
-        findOne: jest.fn(),
-      };
-
-      mockMembershipRepo = {
-        createQueryBuilder: jest.fn().mockReturnValue(mockMembershipQb),
-      };
-
-      mockRepositories.user.manager.getRepository.mockImplementation(
-        (entity: any) => {
-          if (entity === Group) return mockGroupRepo;
-          if (entity === GroupMembership) return mockMembershipRepo;
-          return null;
-        },
+    it('throws ForbiddenException and never queries memberships when the user lacks permission', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        false,
       );
+
+      await expect(
+        service.findUsersInGroup(5, requestingUser),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockRepositories.membership.createQueryBuilder).not.toHaveBeenCalled();
     });
 
     it('scopes to a single group when no FOB ancestor exists', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
       mockGroupRepo.findOne.mockResolvedValueOnce({
         id: 5,
         parentId: null,
@@ -194,16 +220,19 @@ describe('UsersService', () => {
         },
       ]);
 
-      const result = await service.findUsersInGroup(5);
+      const result = await service.findUsersInGroup(5, requestingUser);
 
       expect(mockMembershipQb.andWhere).toHaveBeenCalledWith(
         'membership.groupId = :groupId',
-        expect.objectContaining({ groupId: 5 }),
+        expect.objectContaining({ groupId: 5, fobGroupId: undefined }),
       );
       expect(result).toHaveLength(2);
     });
 
-    it('also includes FOB leaders when an ancestor FOB group is found', async () => {
+    it('also includes FOB leaders when an ancestor FOB group is found by walking up parentId', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
       mockGroupRepo.findOne
         .mockResolvedValueOnce({
           id: 5,
@@ -225,8 +254,9 @@ describe('UsersService', () => {
         },
       ]);
 
-      const result = await service.findUsersInGroup(5);
+      const result = await service.findUsersInGroup(5, requestingUser);
 
+      expect(mockGroupRepo.findOne).toHaveBeenCalledTimes(2);
       expect(mockMembershipQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('membership.groupId = :fobGroupId'),
         expect.objectContaining({
@@ -239,17 +269,50 @@ describe('UsersService', () => {
     });
 
     it('stops walking up the tree if a parent group is missing', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
       mockGroupRepo.findOne.mockResolvedValueOnce(undefined);
       mockMembershipQb.getMany.mockResolvedValueOnce([]);
 
-      await service.findUsersInGroup(99);
+      await service.findUsersInGroup(99, requestingUser);
 
-      // Only the initial lookup should have run; the while loop breaks
-      // as soon as `group` comes back falsy.
+      // Only the initial lookup should have run; the walk stops as soon as
+      // the group comes back falsy.
       expect(mockGroupRepo.findOne).toHaveBeenCalledTimes(1);
     });
 
+    it('does not loop forever if the parent chain cycles back on itself', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
+      // 5 -> 6 -> 5 ... a corrupt/cyclic parentId chain should not hang.
+      mockGroupRepo.findOne
+        .mockResolvedValueOnce({
+          id: 5,
+          parentId: 6,
+          category: { name: 'Location' },
+        })
+        .mockResolvedValueOnce({
+          id: 6,
+          parentId: 5,
+          category: { name: 'Location' },
+        });
+      mockMembershipQb.getMany.mockResolvedValueOnce([]);
+
+      await service.findUsersInGroup(5, requestingUser);
+
+      expect(mockGroupRepo.findOne).toHaveBeenCalledTimes(2);
+      expect(mockMembershipQb.andWhere).toHaveBeenCalledWith(
+        'membership.groupId = :groupId',
+        expect.objectContaining({ fobGroupId: undefined }),
+      );
+    });
+
     it('returns an empty array without querying users when the group has no members', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
       mockGroupRepo.findOne.mockResolvedValueOnce({
         id: 9,
         parentId: null,
@@ -257,13 +320,16 @@ describe('UsersService', () => {
       });
       mockMembershipQb.getMany.mockResolvedValueOnce([]);
 
-      const result = await service.findUsersInGroup(9);
+      const result = await service.findUsersInGroup(9, requestingUser);
 
       expect(result).toEqual([]);
       expect(mockRepositories.user.find).not.toHaveBeenCalled();
     });
 
     it('de-duplicates repeated contact ids from the membership rows', async () => {
+      mockGroupsPermissionsService.hasPermissionForGroup.mockResolvedValueOnce(
+        true,
+      );
       mockGroupRepo.findOne.mockResolvedValueOnce({
         id: 5,
         parentId: null,
@@ -282,7 +348,7 @@ describe('UsersService', () => {
         },
       ]);
 
-      const result = await service.findUsersInGroup(5);
+      const result = await service.findUsersInGroup(5, requestingUser);
 
       // Only one user should be requested/returned even though the same
       // contactId appeared twice in the membership rows.

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -23,6 +23,8 @@ import { GroupsMembershipService } from '../groups/services/group-membership.ser
 import { GroupRole } from '../groups/enums/groupRole';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { Tenant } from '../tenants/entities/tenant.entity';
+import GroupMembership from '../groups/entities/groupMembership.entity';
+import Group from '../groups/entities/group.entity';
 
 @Injectable()
 export class UsersService {
@@ -367,6 +369,56 @@ export class UsersService {
 
   async remove(id: number): Promise<void> {
     await this.repository.delete(id);
+  }
+  async findUsersInGroup(groupId: number): Promise<UserListDto[]> {
+    const tenantId = this.tenantContext.requireTenant();
+    
+    const groupRepository = this.repository.manager.getRepository(Group);
+    const membershipRepository = this.repository.manager.getRepository(GroupMembership);
+
+    let fobGroupId: number | null = null;
+    let currentId: number | null = groupId;
+    const visited = new Set<number>();
+    
+    while (currentId !== null && !visited.has(currentId)) {
+      visited.add(currentId);
+      const group = await groupRepository.findOne({
+        where: { 
+          id: currentId,
+          tenant: { id: tenantId }
+        },
+        relations: { category: true },
+      });
+      if (!group) break;
+      if (group.category?.name === 'FOB') {
+        fobGroupId = group.id;
+        break;
+      }
+      currentId = group.parentId ?? null;
+    }
+
+    const memberships = await membershipRepository
+      .createQueryBuilder('membership')
+      .innerJoin('membership.group', 'group')
+      .where('group.tenantId = :tenantId', { tenantId })
+      .andWhere('membership.isActive = true')
+      .andWhere(
+        fobGroupId
+          ? '(membership.groupId = :groupId OR (membership.groupId = :fobGroupId AND membership.role = :leaderRole))'
+          : 'membership.groupId = :groupId',
+        { groupId, fobGroupId, leaderRole: GroupRole.Leader },
+      )
+      .select(['membership.contactId'])
+      .getMany();
+      
+    const contactIds = [...new Set(memberships.map((m) => m.contactId))];
+    if (contactIds.length === 0) return [];
+    
+    const data = await this.repository.find({
+      relations: ['contact', 'contact.person', 'userRoles', 'userRoles.roles'],
+      where: { contactId: In(contactIds), tenant: { id: tenantId } },
+    });
+    return data.map((it) => this.toListModel(it));
   }
 
   async findByName(username: string): Promise<User | undefined> {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -30,9 +30,8 @@ import { GroupRole } from '../groups/enums/groupRole';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { Tenant } from '../tenants/entities/tenant.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
-import Group from '../groups/entities/group.entity';
 import { GroupPermissionsService } from '../groups/services/group-permissions.service';
-import { TenantAwareRepository } from '../shared/repository/tenant-aware.repository';
+import { GroupRepository } from '../shared/repository/group.repository';
 
 @Injectable()
 export class UsersService {
@@ -43,7 +42,7 @@ export class UsersService {
   private readonly personRepository: Repository<Person>;
   // Tenant-scoped: findNearestFobAncestor relies on this auto-applying the
   // tenant filter instead of every call site re-supplying `tenant: { id }`.
-  private readonly groupRepository: TenantAwareRepository<Group>;
+  private readonly groupRepository: GroupRepository;
   // GroupMembership has no direct tenant column (it's scoped via its
   // `group` relation), so this stays a plain repository with an explicit
   // `group.tenantId` join filter, matching TasksService's convention.
@@ -62,11 +61,7 @@ export class UsersService {
     this.rolesRepository = connection.getRepository(Roles);
     this.userRolesRepository = connection.getRepository(UserRoles);
     this.personRepository = connection.getRepository(Person);
-    this.groupRepository = new TenantAwareRepository(
-      Group,
-      connection.manager,
-      tenantContext,
-    );
+    this.groupRepository = new GroupRepository(connection.manager, tenantContext);
     this.membershipRepository = connection.getRepository(GroupMembership);
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,10 @@
-import { HttpException, Injectable, Inject, Logger } from '@nestjs/common';
+import {
+  HttpException,
+  Injectable,
+  Inject,
+  Logger,
+  ForbiddenException,
+} from '@nestjs/common';
 import { In, Repository, Connection, ILike } from 'typeorm';
 import { User } from './entities/user.entity';
 import Email from 'src/crm/entities/email.entity';
@@ -25,6 +31,8 @@ import { TenantContext } from '../shared/tenant/tenant-context';
 import { Tenant } from '../tenants/entities/tenant.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
 import Group from '../groups/entities/group.entity';
+import { GroupPermissionsService } from '../groups/services/group-permissions.service';
+import { TenantAwareRepository } from '../shared/repository/tenant-aware.repository';
 
 @Injectable()
 export class UsersService {
@@ -33,18 +41,33 @@ export class UsersService {
   private readonly rolesRepository: Repository<Roles>;
   private readonly userRolesRepository: Repository<UserRoles>;
   private readonly personRepository: Repository<Person>;
+  // Tenant-scoped: findNearestFobAncestor relies on this auto-applying the
+  // tenant filter instead of every call site re-supplying `tenant: { id }`.
+  private readonly groupRepository: TenantAwareRepository<Group>;
+  // GroupMembership has no direct tenant column (it's scoped via its
+  // `group` relation), so this stays a plain repository with an explicit
+  // `group.tenantId` join filter, matching TasksService's convention.
+  private readonly membershipRepository: Repository<GroupMembership>;
+
   constructor(
     @Inject('CONNECTION') connection: Connection,
     private readonly contactsService: ContactsService,
     private readonly jwtHelperService: JwtHelperService,
     private readonly groupsMembershipService: GroupsMembershipService,
     private readonly tenantContext: TenantContext,
+    private readonly groupsPermissionsService: GroupPermissionsService,
   ) {
     this.repository = connection.getRepository(User);
     this.emailRepository = connection.getRepository(Email);
     this.rolesRepository = connection.getRepository(Roles);
     this.userRolesRepository = connection.getRepository(UserRoles);
     this.personRepository = connection.getRepository(Person);
+    this.groupRepository = new TenantAwareRepository(
+      Group,
+      connection.manager,
+      tenantContext,
+    );
+    this.membershipRepository = connection.getRepository(GroupMembership);
   }
 
   async findAll(req: UserSearchDto): Promise<UserListDto[]> {
@@ -370,55 +393,91 @@ export class UsersService {
   async remove(id: number): Promise<void> {
     await this.repository.delete(id);
   }
-  async findUsersInGroup(groupId: number): Promise<UserListDto[]> {
-    const tenantId = this.tenantContext.requireTenant();
-    
-    const groupRepository = this.repository.manager.getRepository(Group);
-    const membershipRepository = this.repository.manager.getRepository(GroupMembership);
 
-    let fobGroupId: number | null = null;
-    let currentId: number | null = groupId;
-    const visited = new Set<number>();
-    
-    while (currentId !== null && !visited.has(currentId)) {
-      visited.add(currentId);
-      const group = await groupRepository.findOne({
-        where: { 
-          id: currentId,
-          tenant: { id: tenantId }
-        },
-        relations: { category: true },
-      });
-      if (!group) break;
-      if (group.category?.name === 'FOB') {
-        fobGroupId = group.id;
-        break;
-      }
-      currentId = group.parentId ?? null;
+  /**
+   * Lists the users belonging to a group (plus, if the group sits beneath a
+   * FOB, that FOB's leaders). Requires the caller to have permission for the
+   * target group — this returns member usernames/emails/roles, so it must
+   * not be reachable by an arbitrary authenticated tenant user.
+   */
+  async findUsersInGroup(groupId: number, user: any): Promise<UserListDto[]> {
+    const hasAccess = await this.groupsPermissionsService.hasPermissionForGroup(
+      user,
+      groupId,
+    );
+    if (!hasAccess) {
+      throw new ForbiddenException('Access denied to this group');
     }
 
-    const memberships = await membershipRepository
+    const tenantId = this.tenantContext.requireTenant();
+    const fobGroup = await this.findNearestFobAncestor(groupId);
+
+    const memberships = await this.membershipRepository
       .createQueryBuilder('membership')
       .innerJoin('membership.group', 'group')
       .where('group.tenantId = :tenantId', { tenantId })
       .andWhere('membership.isActive = true')
       .andWhere(
-        fobGroupId
+        fobGroup
           ? '(membership.groupId = :groupId OR (membership.groupId = :fobGroupId AND membership.role = :leaderRole))'
           : 'membership.groupId = :groupId',
-        { groupId, fobGroupId, leaderRole: GroupRole.Leader },
+        { groupId, fobGroupId: fobGroup?.id, leaderRole: GroupRole.Leader },
       )
       .select(['membership.contactId'])
       .getMany();
-      
+
     const contactIds = [...new Set(memberships.map((m) => m.contactId))];
     if (contactIds.length === 0) return [];
-    
+
     const data = await this.repository.find({
       relations: ['contact', 'contact.person', 'userRoles', 'userRoles.roles'],
       where: { contactId: In(contactIds), tenant: { id: tenantId } },
     });
     return data.map((it) => this.toListModel(it));
+  }
+
+  /**
+   * Finds the nearest ancestor group whose category is FOB, walking up
+   * parentId one level at a time.
+   *
+   * Deliberately NOT using TreeRepository.findAncestors()/a closure-table
+   * join here: that call builds its join from the entity's schema-qualified
+   * table path, and when the schema is explicitly "public" TypeORM
+   * misparses "public.<table>" as an alias.relation reference and throws
+   * `"public" alias was not found` (a real TypeORM bug we hit in
+   * production). The per-level walk is a few extra round trips on what are
+   * normally shallow hierarchies, but it never touches that code path.
+   */
+  private async findNearestFobAncestor(
+    startGroupId: number,
+  ): Promise<{ id: number; name: string } | null> {
+    let currentId: number | null = startGroupId;
+    const visited = new Set<number>();
+
+    while (currentId !== null && !visited.has(currentId)) {
+      visited.add(currentId);
+
+      // groupRepository is tenant-aware, so this is implicitly scoped to
+      // the current tenant without repeating `tenant: { id: tenantId }`
+      // at this call site.
+      const group = await this.groupRepository.findOne({
+        where: { id: currentId },
+        relations: { category: true },
+      });
+
+      if (!group) return null;
+      // 'FOB' is a STRUCTURE-purpose category *name*, not a fixed system
+      // constant like GroupCategoryPurpose — structure category names
+      // (FOB, Region, Zone, Department, ...) are admin-configured per
+      // tenant, so there's no enum member to reference here.
+      if (group.category?.name === 'FOB') {
+        return { id: group.id, name: group.name };
+      }
+
+      currentId = group.parentId ?? null;
+    }
+
+    return null;
   }
 
   async findByName(username: string): Promise<User | undefined> {


### PR DESCRIPTION
## Summary of changes
- `UsersService.findUsersInGroup(groupId)` — resolves the group's   active members, walks up to find the nearest ancestor group whose   category name is `FOB` (if any), and returns the union of that  group's members plus the FOB's active Leaders, in one membership  query using an OR condition (not two separate queries/endpoints).
- `UsersController` — new `GET /api/users/by-location/:groupId`.
- `GroupsService.getContactLocationGroup(contactId)` — thin wrapper  around the existing `GroupPermissionsService.getContactLocationGroupId`,  returning `{ id, name }` or `null`.
- `GroupController` — new `GET /api/groups/contact-location/:contactId`.
- `TasksService.findTaskWithRelations` — now calls the existing  `attachLocationGroups` helper (previously only called from  `findAll`/`findAllForContact`), so single-task fetches also carry  `locationGroup`. This was the root cause of the `/by-location/undefined`  400s seen during testing.

## How should this be tested
1. Seed/confirm a hierarchy: FOB → ... → Location, with a   `GroupMembership` of role `Leader` on the FOB group for some user's   contact, and separate members directly on the Location group.
2. `GET /api/groups/contact-location/:contactId` for a contact in that   location → expect `{ id, name }` of the location group.
3. `GET /api/users/by-location/:locationGroupId` → expect both the   direct location members and the FOB's Leader(s), no duplicates,   in one response.
4. Contact/location with no FOB ancestor → same endpoint returns only   direct location members, unchanged from pre-FOB behavior.
5. `GET /api/tasks/:id` (single task fetch), and the task update /   reassign / status-update / create flows → confirm each response   now includes `task.locationGroup` populated, not just the list   endpoints.
6. Regression: confirm `findAll` and `findAllForContact` responses are   unaffected (they already called `attachLocationGroups`, untouched   here).

## Note for reviewers
- The FOB match is a literal string check on `group.category.name ===  'FOB'`. Please confirm this matches your actual seed/category data —   if the category is named differently, this needs a one-line update.
- The ancestor walk is a sequential loop of `findOne` calls (bounded by  tree depth, with cycle protection via a `visited` set). Fine for  current hierarchy depths; flagged as a candidate for a single  recursive query if this becomes a hot path.
- `findTaskWithRelations` change affects `findOne`, `create`, `update`,  `updateStatus`, and `reassign` simultaneously since they all share  this helper — worth a broader regression pass on those flows, not  just the assignment-related ones.

## Out of scope
- No new authorization checks — the location/FOB-scoped user list is  returned regardless of whether the requesting user has access to  that location/FOB. If that's a concern, it's a separate follow-up.
- No changes to `GroupPermissionsService.getContactLocationGroupId`  itself, reused as-is.
- No migration or seed-data changes for FOB categories or leader  memberships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location-group lookup for contacts.
  * Added an endpoint to list users in a location group, including relevant leaders.
  * Enhanced task details with location-group information and contact address data.
* **Improvements**
  * Improved location-based access checks for tasks and group information.
  * Added stronger validation for group members, permissions, pagination, and SMS operations.
  * Improved handling of missing or restricted location groups.
* **Tests**
  * Expanded coverage for groups, users, tasks, permissions, pagination, and SMS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->