### PR TITLE
(feat): mca  weekly attendance summary

### DIFF
--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -122,6 +122,18 @@ export class ReportsController {
     });
   }
 
+  @Get('mca/weekly-summary')
+  async getWeeklyMcaSummary(@Request() request): Promise<any> {
+    this.logger.apiLog('log', 'Get weekly MCA summary request received', {
+      operation: 'getWeeklyMcaSummary',
+      resource: 'reports',
+      metadata: {
+        userId: request.user?.id,
+      },
+    });
+    return await this.reportService.getWeeklyMcaSummary(request.user);
+  }
+  
   @Get('submissions/:id')
   async getSubmissionDetails(
     @Param('id', ParseIntPipe) id: number,

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Header,
   Post,
   Patch,
   Put,
@@ -123,6 +124,7 @@ export class ReportsController {
   }
 
   @Get('mca/weekly-summary')
+  @Header('Cache-Control', 'no-store')
   async getWeeklyMcaSummary(@Request() request): Promise<any> {
     this.logger.apiLog('log', 'Get weekly MCA summary request received', {
       operation: 'getWeeklyMcaSummary',

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -624,67 +624,67 @@ describe('ReportsService', () => {
     });
   });
   describe('Report Submission Notifications (dispatch)', () => {
-  const baseReportWithGroup = {
-    id: 1,
-    name: 'Weekly Report',
-    status: ReportStatus.ACTIVE,
-    groupFieldName: 'groupId', // needed so selectedGroupId resolves from data.groupId
-    targetGroupCategory: undefined,
-    fields: [],
-  } as unknown as Report;
+    const baseReportWithGroup = {
+      id: 1,
+      name: 'Weekly Report',
+      status: ReportStatus.ACTIVE,
+      groupFieldName: 'groupId', // needed so selectedGroupId resolves from data.groupId
+      targetGroupCategory: undefined,
+      fields: [],
+    } as unknown as Report;
 
-  const mockTargetGroup = { id: 10, name: 'MC Nairobi', parentId: undefined } as Group;
+    const mockTargetGroup = { id: 10, name: 'MC Nairobi', parentId: undefined } as Group;
 
-  const reportId = 1;
-  const submittingUser = { id: 7, contactId: 3 } as any;
+    const reportId = 1;
+    const submittingUser = { id: 7, contactId: 3 } as any;
 
-  beforeEach(() => {
-    (mockNotificationsService.create as jest.Mock).mockClear();
+    beforeEach(() => {
+      (mockNotificationsService.create as jest.Mock).mockClear();
 
-    mockRepositories.report.findOne.mockResolvedValue(baseReportWithGroup);
-    mockRepositories.user.findOne.mockResolvedValue({ id: 7, contactId: 3, username: 'shepherd@example.com' });
-    mockRepositories.groupMembership.findOne.mockResolvedValue({ group: { id: 10, category: undefined } });
-    mockGroupPermissionsService.hasPermissionForGroup = jest.fn().mockResolvedValue(true);
-    mockRepositories.groupTree.findOne.mockResolvedValue(mockTargetGroup);
-    mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
-    mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
-      Promise.resolve({ id: 99, ...sub }),
-    );
-    mockRepositories.reportField.find.mockResolvedValue([{ name: 'groupId' }]);
+      mockRepositories.report.findOne.mockResolvedValue(baseReportWithGroup);
+      mockRepositories.user.findOne.mockResolvedValue({ id: 7, contactId: 3, username: 'shepherd@example.com' });
+      mockRepositories.groupMembership.findOne.mockResolvedValue({ group: { id: 10, category: undefined } });
+      mockGroupPermissionsService.hasPermissionForGroup = jest.fn().mockResolvedValue(true);
+      mockRepositories.groupTree.findOne.mockResolvedValue(mockTargetGroup);
+      mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+      mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
+        Promise.resolve({ id: 99, ...sub }),
+      );
+      mockRepositories.reportField.find.mockResolvedValue([{ name: 'groupId' }]);
 
-    jest
-      .spyOn(service as any, 'resolveReportSubmissionRecipients')
-      .mockResolvedValue([10, 11]);
+      jest
+        .spyOn(service as any, 'resolveReportSubmissionRecipients')
+        .mockResolvedValue([10, 11]);
+    });
+
+    it('dispatches a notification per resolved recipient and tolerates individual failures', async () => {
+      await service.submitReport(reportId, { data: { groupId: '10' } }, submittingUser);
+
+      expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
+      expect(mockNotificationsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 10, type: 'report_submitted' }),
+      );
+      expect(mockNotificationsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 11, type: 'report_submitted' }),
+      );
+    });
+
+    it('still resolves the submission when one notification dispatch fails', async () => {
+      (mockNotificationsService.create as jest.Mock).mockImplementation(
+        ({ userId }: any) =>
+          userId === 10
+            ? Promise.reject(new Error('Realtime push failed'))
+            : Promise.resolve({}),
+      );
+      const result = await service.submitReport(
+        reportId,
+        { data: { groupId: '10' } },
+        submittingUser,
+      );
+      expect(result).toBeDefined();
+      expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
+    });
   });
-
-  it('dispatches a notification per resolved recipient and tolerates individual failures', async () => {
-    await service.submitReport(reportId, { data: { groupId: '10' } }, submittingUser);
-
-    expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
-    expect(mockNotificationsService.create).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 10, type: 'report_submitted' }),
-    );
-    expect(mockNotificationsService.create).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 11, type: 'report_submitted' }),
-    );
-  });
-
-  it('still resolves the submission when one notification dispatch fails', async () => {
-    (mockNotificationsService.create as jest.Mock).mockImplementation(
-      ({ userId }: any) =>
-        userId === 10
-          ? Promise.reject(new Error('Realtime push failed'))
-          : Promise.resolve({}),
-    );
-    const result = await service.submitReport(
-      reportId,
-      { data: { groupId: '10' } },
-      submittingUser,
-    );
-    expect(result).toBeDefined();
-    expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
-  });
-});
   describe('getWeeklyMcaSummary', () => {
     const mockUser = { id: 7, contactId: 3 } as any;
     const makeQueryBuilder = (
@@ -703,8 +703,8 @@ describe('ReportsService', () => {
       return qb;
     };
 
-    it('returns reportFound: false when no MCA-labelled field exists for the tenant', async () => {
-      const fieldQb = makeQueryBuilder([]);
+    it('returns reportFound: false when no MCA field exists for the tenant', async () => {
+      const fieldQb = makeQueryBuilder(null, 'getOne');
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(fieldQb);
 
       const result = await service.getWeeklyMcaSummary(mockUser);
@@ -712,7 +712,7 @@ describe('ReportsService', () => {
       expect(result.reportFound).toBe(false);
       expect(result.total).toBe(0);
       expect(result.breakdown).toEqual([]);
-       // The field lookup must be scoped to the current tenant.
+      // The field lookup must be scoped to the current tenant.
       const tenantScoped = [
         ...fieldQb.where.mock.calls,
         ...fieldQb.andWhere.mock.calls,
@@ -722,9 +722,26 @@ describe('ReportsService', () => {
       expect(mockRepositories.groupMembership.find).not.toHaveBeenCalled();
     });
 
+    it('scopes the field lookup to the MC Attendance Report by name, not just the field label', async () => {
+      const fieldQb = makeQueryBuilder(null, 'getOne');
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(fieldQb);
+
+      await service.getWeeklyMcaSummary(mockUser);
+
+      const reportNameScoped = [
+        ...fieldQb.where.mock.calls,
+        ...fieldQb.andWhere.mock.calls,
+      ].some(
+        ([sql, params]) =>
+          sql.includes('report.name') &&
+          params?.reportName === 'MC Attendance Report',
+      );
+      expect(reportNameScoped).toBe(true);
+    });
+
     it('returns zero total when the MCA field exists but user manages no groups', async () => {
-      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
-      const fieldQb = makeQueryBuilder([field]);
+      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      const fieldQb = makeQueryBuilder(field, 'getOne');
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(fieldQb);
       mockRepositories.groupMembership.find.mockResolvedValue([]);
       mockGroupTreeService.getGroupAndAllChildren = jest
@@ -737,14 +754,15 @@ describe('ReportsService', () => {
       expect(result.total).toBe(0);
       expect(result.breakdown).toEqual([]);
       // Should short-circuit before ever querying submissions.
-      expect(mockRepositories.reportSubmission.createQueryBuilder).not.toHaveBeenCalled();
+      expect(
+        mockRepositories.reportSubmission.createQueryBuilder,
+      ).not.toHaveBeenCalled();
     });
 
-    it('matches both known MCA field labels and sums across groups the user manages', async () => {
-      const fieldA = { id: 1, label: 'MC Attendance', report: { id: 100 } };
-      const fieldB = { id: 2, label: 'How many attended MC?', report: { id: 200 } };
+    it('sums attendance across groups the user manages for the single MCA field', async () => {
+      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
-        makeQueryBuilder([fieldA, fieldB]),
+        makeQueryBuilder(field, 'getOne'),
       );
 
       mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
@@ -759,11 +777,12 @@ describe('ReportsService', () => {
         },
         {
           group: { id: 11, name: 'MC Kampala' },
-          submissionData: [{ reportField: { id: 2 }, fieldValue: '20' }],
+          submissionData: [{ reportField: { id: 1 }, fieldValue: '20' }],
         },
       ];
+      const submissionQb = makeQueryBuilder(submissions);
       mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
-        makeQueryBuilder(submissions),
+        submissionQb,
       );
 
       const result = await service.getWeeklyMcaSummary(mockUser);
@@ -776,12 +795,30 @@ describe('ReportsService', () => {
           { groupId: 11, groupName: 'MC Kampala', total: 20 },
         ]),
       );
+
+      // Submission query must be scoped to the single resolved report,
+      // the user's manageable groups, and this week's reportingPeriod.
+      const andWhereCalls = submissionQb.andWhere.mock.calls;
+      expect(
+        andWhereCalls.some(
+          ([sql, params]) =>
+            sql.includes('group.id') &&
+            Array.isArray(params?.groupIds) &&
+            params.groupIds.includes(10) &&
+            params.groupIds.includes(11),
+        ),
+      ).toBe(true);
+      expect(
+        andWhereCalls.some(([sql, params]) =>
+          sql.includes('reportingPeriod') && typeof params?.reportingPeriod === 'string',
+        ),
+      ).toBe(true);
     });
 
     it('aggregates multiple submissions for the same group into a single breakdown entry (roll-up scenario)', async () => {
-      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
-        makeQueryBuilder([field]),
+        makeQueryBuilder(field, 'getOne'),
       );
       // A zonal-level leader managing several MCs that all report into the same group.
       mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 1 }]);
@@ -812,9 +849,9 @@ describe('ReportsService', () => {
     });
 
     it('skips non-numeric field values without throwing or affecting the total', async () => {
-      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
-        makeQueryBuilder([field]),
+        makeQueryBuilder(field, 'getOne'),
       );
       mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
       mockGroupTreeService.getGroupAndAllChildren = jest
@@ -833,10 +870,11 @@ describe('ReportsService', () => {
       expect(result.total).toBe(0);
       expect(result.breakdown).toEqual([]);
     });
-    it('ignores submissionData rows whose reportField id is not one of the resolved MCA fields', async () => {
-      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+
+    it('rejects values with a numeric prefix followed by trailing text (e.g. "15 attendees")', async () => {
+      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
-        makeQueryBuilder([field]),
+        makeQueryBuilder(field, 'getOne'),
       );
       mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
       mockGroupTreeService.getGroupAndAllChildren = jest
@@ -845,17 +883,15 @@ describe('ReportsService', () => {
       const submissions = [
         {
           group: { id: 10, name: 'MC Nairobi' },
-          submissionData: [
-            { reportField: { id: 1 }, fieldValue: '8' },
-            { reportField: { id: 99 }, fieldValue: '1000' },
-          ],
+          submissionData: [{ reportField: { id: 1 }, fieldValue: '15 attendees' }],
         },
       ];
       mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(submissions),
       );
       const result = await service.getWeeklyMcaSummary(mockUser);
-      expect(result.total).toBe(8);
+      expect(result.total).toBe(0);
+      expect(result.breakdown).toEqual([]);
     });
   });
 });

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -53,6 +53,7 @@ describe('ReportsService', () => {
         findOne: jest.fn(),
         save: jest.fn(),
         create: jest.fn(),
+        createQueryBuilder: jest.fn(), 
       },
       reportSubmissionData: {
         find: jest.fn(),
@@ -64,6 +65,7 @@ describe('ReportsService', () => {
       reportField: {
         save: jest.fn(),
         find: jest.fn(),
+        createQueryBuilder: jest.fn(), 
       },
       groupMembership: {
         find: jest.fn(),
@@ -622,58 +624,238 @@ describe('ReportsService', () => {
     });
   });
   describe('Report Submission Notifications (dispatch)', () => {
-    const baseReportWithGroup = {
-      id: 1,
-      name: 'Weekly Report',
-      status: ReportStatus.ACTIVE,
-      groupFieldName: 'groupId', // needed so selectedGroupId resolves from data.groupId
-      targetGroupCategory: undefined,
-      fields: [],
-    } as unknown as Report;
+  const baseReportWithGroup = {
+    id: 1,
+    name: 'Weekly Report',
+    status: ReportStatus.ACTIVE,
+    groupFieldName: 'groupId', // needed so selectedGroupId resolves from data.groupId
+    targetGroupCategory: undefined,
+    fields: [],
+  } as unknown as Report;
 
-    const mockTargetGroup = { id: 10, name: 'MC Nairobi', parentId: undefined } as Group;
+  const mockTargetGroup = { id: 10, name: 'MC Nairobi', parentId: undefined } as Group;
 
-    it('dispatches a notification per resolved recipient and tolerates individual failures', async () => {
-      (mockNotificationsService.create as jest.Mock).mockClear();
+  const reportId = 1;
+  const submittingUser = { id: 7, contactId: 3 } as any;
 
-      const reportId = 1;
-      const submittingUser = { id: 7, contactId: 3 } as any;
+  beforeEach(() => {
+    (mockNotificationsService.create as jest.Mock).mockClear();
 
-      mockRepositories.report.findOne.mockResolvedValue(baseReportWithGroup);
-      mockRepositories.user.findOne.mockResolvedValue({ id: 7, contactId: 3, username: 'shepherd@example.com' });
-      mockRepositories.groupMembership.findOne.mockResolvedValue({ group: { id: 10, category: undefined } });
-      mockGroupPermissionsService.hasPermissionForGroup = jest.fn().mockResolvedValue(true);
-      mockRepositories.groupTree.findOne.mockResolvedValue(mockTargetGroup);
-      mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
-      mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
-        Promise.resolve({ id: 99, ...sub }),
+    mockRepositories.report.findOne.mockResolvedValue(baseReportWithGroup);
+    mockRepositories.user.findOne.mockResolvedValue({ id: 7, contactId: 3, username: 'shepherd@example.com' });
+    mockRepositories.groupMembership.findOne.mockResolvedValue({ group: { id: 10, category: undefined } });
+    mockGroupPermissionsService.hasPermissionForGroup = jest.fn().mockResolvedValue(true);
+    mockRepositories.groupTree.findOne.mockResolvedValue(mockTargetGroup);
+    mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+    mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
+      Promise.resolve({ id: 99, ...sub }),
+    );
+    mockRepositories.reportField.find.mockResolvedValue([{ name: 'groupId' }]);
+
+    jest
+      .spyOn(service as any, 'resolveReportSubmissionRecipients')
+      .mockResolvedValue([10, 11]);
+  });
+
+  it('dispatches a notification per resolved recipient and tolerates individual failures', async () => {
+    await service.submitReport(reportId, { data: { groupId: '10' } }, submittingUser);
+
+    expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
+    expect(mockNotificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 10, type: 'report_submitted' }),
+    );
+    expect(mockNotificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 11, type: 'report_submitted' }),
+    );
+  });
+
+  it('still resolves the submission when one notification dispatch fails', async () => {
+    (mockNotificationsService.create as jest.Mock).mockImplementation(
+      ({ userId }: any) =>
+        userId === 10
+          ? Promise.reject(new Error('Realtime push failed'))
+          : Promise.resolve({}),
+    );
+    const result = await service.submitReport(
+      reportId,
+      { data: { groupId: '10' } },
+      submittingUser,
+    );
+    expect(result).toBeDefined();
+    expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
+  });
+});
+  describe('getWeeklyMcaSummary', () => {
+    const mockUser = { id: 7, contactId: 3 } as any;
+    const makeQueryBuilder = (
+      result: any,
+      terminator: 'getOne' | 'getMany' = 'getMany',
+    ) => {
+      const qb: any = {
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn(),
+        getMany: jest.fn(),
+      };
+      qb[terminator].mockResolvedValue(result);
+      return qb;
+    };
+
+    it('returns reportFound: false when no MCA-labelled field exists for the tenant', async () => {
+      const fieldQb = makeQueryBuilder([]);
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(fieldQb);
+
+      const result = await service.getWeeklyMcaSummary(mockUser);
+
+      expect(result.reportFound).toBe(false);
+      expect(result.total).toBe(0);
+      expect(result.breakdown).toEqual([]);
+       // The field lookup must be scoped to the current tenant.
+      const tenantScoped = [
+        ...fieldQb.where.mock.calls,
+        ...fieldQb.andWhere.mock.calls,
+      ].some(([, params]) => params?.tenantId === mockTenantContext.tenantId);
+      expect(tenantScoped).toBe(true);
+      // Should short-circuit before ever resolving manageable groups.
+      expect(mockRepositories.groupMembership.find).not.toHaveBeenCalled();
+    });
+
+    it('returns zero total when the MCA field exists but user manages no groups', async () => {
+      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      const fieldQb = makeQueryBuilder([field]);
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(fieldQb);
+      mockRepositories.groupMembership.find.mockResolvedValue([]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([]);
+
+      const result = await service.getWeeklyMcaSummary(mockUser);
+
+      expect(result.reportFound).toBe(true);
+      expect(result.total).toBe(0);
+      expect(result.breakdown).toEqual([]);
+      // Should short-circuit before ever querying submissions.
+      expect(mockRepositories.reportSubmission.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('matches both known MCA field labels and sums across groups the user manages', async () => {
+      const fieldA = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      const fieldB = { id: 2, label: 'How many attended MC?', report: { id: 200 } };
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([fieldA, fieldB]),
       );
-      mockRepositories.reportField.find.mockResolvedValue([{ name: 'groupId' }]);
 
-      jest
-        .spyOn(service as any, 'resolveReportSubmissionRecipients')
+      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
         .mockResolvedValue([10, 11]);
 
-      await service.submitReport(reportId, { data: { groupId: '10' } }, submittingUser);
-
-      expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
-      expect(mockNotificationsService.create).toHaveBeenCalledWith(
-        expect.objectContaining({ userId: 10, type: 'report_submitted' }),
+      const submissions = [
+        {
+          group: { id: 10, name: 'MC Nairobi' },
+          submissionData: [{ reportField: { id: 1 }, fieldValue: '15' }],
+        },
+        {
+          group: { id: 11, name: 'MC Kampala' },
+          submissionData: [{ reportField: { id: 2 }, fieldValue: '20' }],
+        },
+      ];
+      mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(submissions),
       );
-      expect(mockNotificationsService.create).toHaveBeenCalledWith(
-        expect.objectContaining({ userId: 11, type: 'report_submitted' }),
+
+      const result = await service.getWeeklyMcaSummary(mockUser);
+
+      expect(result.reportFound).toBe(true);
+      expect(result.total).toBe(35);
+      expect(result.breakdown).toEqual(
+        expect.arrayContaining([
+          { groupId: 10, groupName: 'MC Nairobi', total: 15 },
+          { groupId: 11, groupName: 'MC Kampala', total: 20 },
+        ]),
+      );
+    });
+
+    it('aggregates multiple submissions for the same group into a single breakdown entry (roll-up scenario)', async () => {
+      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([field]),
+      );
+      // A zonal-level leader managing several MCs that all report into the same group.
+      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 1 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10, 11, 12]);
+
+      const submissions = [
+        {
+          group: { id: 10, name: 'MC Nairobi' },
+          submissionData: [{ reportField: { id: 1 }, fieldValue: '10' }],
+        },
+        {
+          group: { id: 10, name: 'MC Nairobi' },
+          submissionData: [{ reportField: { id: 1 }, fieldValue: '5' }],
+        },
+      ];
+      mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(submissions),
       );
 
-      (mockNotificationsService.create as jest.Mock).mockClear();
-      (mockNotificationsService.create as jest.Mock).mockRejectedValueOnce(
-        new Error('Realtime push failed'),
+      const result = await service.getWeeklyMcaSummary(mockUser);
+
+      expect(result.total).toBe(15);
+      expect(result.breakdown).toEqual([
+        { groupId: 10, groupName: 'MC Nairobi', total: 15 },
+      ]);
+    });
+
+    it('skips non-numeric field values without throwing or affecting the total', async () => {
+      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([field]),
       );
-      (mockNotificationsService.create as jest.Mock).mockResolvedValueOnce(undefined);
-
-      const result = await service.submitReport(reportId, { data: { groupId: '10' } }, submittingUser);
-
-      expect(result).toBeDefined();
-      expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
+      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+      const submissions = [
+        {
+          group: { id: 10, name: 'MC Nairobi' },
+          submissionData: [{ reportField: { id: 1 }, fieldValue: 'N/A' }],
+        },
+      ];
+      mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(submissions),
+      );
+      const result = await service.getWeeklyMcaSummary(mockUser);
+      expect(result.total).toBe(0);
+      expect(result.breakdown).toEqual([]);
+    });
+    it('ignores submissionData rows whose reportField id is not one of the resolved MCA fields', async () => {
+      const field = { id: 1, label: 'MC Attendance', report: { id: 100 } };
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([field]),
+      );
+      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+      const submissions = [
+        {
+          group: { id: 10, name: 'MC Nairobi' },
+          submissionData: [
+            { reportField: { id: 1 }, fieldValue: '8' },
+            { reportField: { id: 99 }, fieldValue: '1000' },
+          ],
+        },
+      ];
+      mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(submissions),
+      );
+      const result = await service.getWeeklyMcaSummary(mockUser);
+      expect(result.total).toBe(8);
     });
   });
 });

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -56,7 +56,8 @@ export class ReportsService {
   private readonly treeRepository: TreeRepository<Group>;
   private readonly contactRepository: Repository<Contact>;
   private readonly logger: ContextLogger;
-  private static readonly MCA_FIELD_LABELS = ['MC Attendance', 'How many attended MC?'];
+  private static readonly MCA_REPORT_NAME = 'MC Attendance Report';
+  private static readonly MCA_FIELD_LABEL = 'How many attended MC?';
 
   constructor(
     @Inject('CONNECTION') connection: Connection,
@@ -1680,8 +1681,6 @@ export class ReportsService {
   }> {
     const tenantId = this.tenantContext.requireTenant();
     const weekStart = this.getStartOfWeek(new Date());
-    const weekEndExclusive = new Date(weekStart);
-    weekEndExclusive.setDate(weekEndExclusive.getDate() + 7);
     const weekEnd = new Date(weekStart);
     weekEnd.setDate(weekEnd.getDate() + 6);
 
@@ -1692,23 +1691,30 @@ export class ReportsService {
       weekEnd: weekEnd.toISOString().slice(0, 10),
     };
 
-    const attendanceFields = await this.reportFieldRepository
+    const attendanceField = await this.reportFieldRepository
       .createQueryBuilder('field')
       .innerJoinAndSelect('field.report', 'report')
-      .where('LOWER(field.label) IN (:...labels)', {
-        labels: ReportsService.MCA_FIELD_LABELS.map((l) => l.toLowerCase()),
+      .where('LOWER(field.label) = LOWER(:label)', {
+        label: ReportsService.MCA_FIELD_LABEL,
+      })
+      .andWhere('LOWER(report.name) = LOWER(:reportName)', {
+        reportName: ReportsService.MCA_REPORT_NAME,
       })
       .andWhere('report.status = :status', { status: ReportStatus.ACTIVE })
       .andWhere('report.tenant = :tenantId', { tenantId })
-      .getMany();
+      .getOne();
 
-    if (attendanceFields.length === 0) {
+    if (!attendanceField) {
       this.logger.business(
         'warn',
-        'No MCA fields found for tenant; skipping weekly summary',
+        'MCA field not found for tenant; skipping weekly summary',
         {
           operation: 'getWeeklyMcaSummary',
-          metadata: { tenantId, labelsSearched: ReportsService.MCA_FIELD_LABELS },
+          metadata: {
+            tenantId,
+            reportName: ReportsService.MCA_REPORT_NAME,
+            fieldLabel: ReportsService.MCA_FIELD_LABEL,
+          },
         },
       );
       return { ...emptyResult, reportFound: false };
@@ -1719,16 +1725,19 @@ export class ReportsService {
       return { ...emptyResult, reportFound: true };
     }
 
-    const fieldIds = attendanceFields.map((f) => f.id);
-    const fieldIdSet = new Set(fieldIds);
-    const reportIds = Array.from(new Set(attendanceFields.map((f) => f.report.id)));
+    const fieldId = attendanceField.id;
+    const reportId = attendanceField.report.id;
 
     const submissions = await this.reportSubmissionRepository
       .createQueryBuilder('submission')
       .innerJoinAndSelect('submission.group', 'group')
-      .innerJoinAndSelect('submission.submissionData', 'submissionData')
-      .leftJoinAndSelect('submissionData.reportField', 'reportField')
-      .where('submission.report IN (:...reportIds)', { reportIds })
+      .innerJoinAndSelect(
+        'submission.submissionData',
+        'submissionData',
+        'submissionData.reportField = :fieldId',
+        { fieldId },
+      )
+      .where('submission.report = :reportId', { reportId })
       .andWhere('group.id IN (:...groupIds)', { groupIds })
       .andWhere('submission.reportingPeriod = :reportingPeriod', {
         reportingPeriod: emptyResult.weekStart,
@@ -1740,8 +1749,6 @@ export class ReportsService {
 
     for (const submission of submissions) {
       for (const sd of submission.submissionData) {
-        const fieldId = sd.reportField.id;
-        if (!fieldIdSet.has(fieldId)) continue;
         const raw = sd.fieldValue;
         const text = String(raw).trim();
         const num = typeof raw === 'number' ? raw : Number(text);

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -56,6 +56,7 @@ export class ReportsService {
   private readonly treeRepository: TreeRepository<Group>;
   private readonly contactRepository: Repository<Contact>;
   private readonly logger: ContextLogger;
+  private static readonly MCA_FIELD_LABELS = ['MC Attendance', 'How many attended MC?'];
 
   constructor(
     @Inject('CONNECTION') connection: Connection,
@@ -1668,5 +1669,104 @@ export class ReportsService {
       });
       return [];
     }
+  }
+  
+  async getWeeklyMcaSummary(user: UserDto): Promise<{
+    total: number;
+    breakdown: { groupId: number; groupName: string; total: number }[];
+    weekStart: string;
+    weekEnd: string;
+    reportFound: boolean;
+  }> {
+    const tenantId = this.tenantContext.requireTenant();
+    const weekStart = this.getStartOfWeek(new Date());
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    const emptyResult = {
+      total: 0,
+      breakdown: [] as { groupId: number; groupName: string; total: number }[],
+      weekStart: weekStart.toISOString().slice(0, 10),
+      weekEnd: weekEnd.toISOString().slice(0, 10),
+    };
+
+    const attendanceFields = await this.reportFieldRepository
+      .createQueryBuilder('field')
+      .innerJoinAndSelect('field.report', 'report')
+      .where('LOWER(field.label) IN (:...labels)', {
+        labels: ReportsService.MCA_FIELD_LABELS.map((l) => l.toLowerCase()),
+      })
+      .andWhere('report.status = :status', { status: ReportStatus.ACTIVE })
+      .andWhere('report.tenant = :tenantId', { tenantId })
+      .getMany();
+
+    if (attendanceFields.length === 0) {
+      this.logger.business(
+        'warn',
+        'No MCA fields found for tenant; skipping weekly summary',
+        {
+          operation: 'getWeeklyMcaSummary',
+          metadata: { tenantId, labelsSearched: ReportsService.MCA_FIELD_LABELS },
+        },
+      );
+      return { ...emptyResult, reportFound: false };
+    }
+
+    const groupIds = await this.getUserManageableGroups(user);
+    if (groupIds.length === 0) {
+      return { ...emptyResult, reportFound: true };
+    }
+
+    const fieldIds = attendanceFields.map((f) => f.id);
+    const fieldIdSet = new Set(fieldIds);
+    const reportIds = Array.from(new Set(attendanceFields.map((f) => f.report.id)));
+
+    const submissions = await this.reportSubmissionRepository
+      .createQueryBuilder('submission')
+      .innerJoinAndSelect('submission.group', 'group')
+      .innerJoinAndSelect('submission.submissionData', 'submissionData')
+      .leftJoinAndSelect('submissionData.reportField', 'reportField')
+      .where('submission.report IN (:...reportIds)', { reportIds })
+      .andWhere('group.id IN (:...groupIds)', { groupIds })
+      .andWhere('submission.submittedAt BETWEEN :weekStart AND :weekEnd', {
+        weekStart,
+        weekEnd,
+      })
+      .getMany();
+
+    let total = 0;
+    const breakdownMap = new Map<number,{ groupId: number; groupName: string; total: number }>();
+
+    for (const submission of submissions) {
+      for (const sd of submission.submissionData) {
+        const fieldId = sd.reportField.id;
+        if (!fieldIdSet.has(fieldId)) continue;
+        const raw = sd.fieldValue;
+        const num = typeof raw === 'number' ? raw : parseFloat(String(raw));
+        if (!Number.isFinite(num)) continue;
+
+        total += num;
+        const group = submission.group;
+        const existing = breakdownMap.get(group.id);
+        if (existing) {
+          existing.total += num;
+        } else {
+          breakdownMap.set(group.id, {
+            groupId: group.id,
+            groupName: group.name,
+            total: num,
+          });
+        }
+      }
+    }
+    return {
+      total,
+      breakdown: Array.from(breakdownMap.values()).sort(
+        (a, b) => b.total - a.total,
+      ),
+      weekStart: emptyResult.weekStart,
+      weekEnd: emptyResult.weekEnd,
+      reportFound: true,
+    };
   }
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1742,8 +1742,9 @@ export class ReportsService {
         const fieldId = sd.reportField.id;
         if (!fieldIdSet.has(fieldId)) continue;
         const raw = sd.fieldValue;
-        const num = typeof raw === 'number' ? raw : parseFloat(String(raw));
-        if (!Number.isFinite(num)) continue;
+        const text = String(raw).trim();
+        const num = typeof raw === 'number' ? raw : Number(text);
+        if (text === '' || !Number.isFinite(num)) continue;
 
         total += num;
         const group = submission.group;

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1680,8 +1680,10 @@ export class ReportsService {
   }> {
     const tenantId = this.tenantContext.requireTenant();
     const weekStart = this.getStartOfWeek(new Date());
+    const weekEndExclusive = new Date(weekStart);
+    weekEndExclusive.setDate(weekEndExclusive.getDate() + 7);
     const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekEnd.getDate() + 7);
+    weekEnd.setDate(weekEnd.getDate() + 6);
 
     const emptyResult = {
       total: 0,
@@ -1728,9 +1730,8 @@ export class ReportsService {
       .leftJoinAndSelect('submissionData.reportField', 'reportField')
       .where('submission.report IN (:...reportIds)', { reportIds })
       .andWhere('group.id IN (:...groupIds)', { groupIds })
-      .andWhere('submission.submittedAt BETWEEN :weekStart AND :weekEnd', {
-        weekStart,
-        weekEnd,
+      .andWhere('submission.reportingPeriod = :reportingPeriod', {
+        reportingPeriod: emptyResult.weekStart,
       })
       .getMany();
 


### PR DESCRIPTION
# Ticket No
- MC Attendance for a Given Week (Critical)

# Summary of changes
- Added `ReportsService.getWeeklyMcaSummary(user)` which returns the total number of people who attended MC (Missional Community Attendance / MCA) for the current reporting week, scoped to every group the requesting user has leadership visibility over.
- Scope is resolved via the existing `getUserManageableGroups` helper (leadership memberships + all descendant groups) — the same reasoning already used elsewhere in this service to let a leader submit a report on behalf of a child group. This means a single MC leader sees their MC's total, a location pastor sees their location's total (sum of all MCs beneath them), and a zonal/sector pastor sees the sum across everything beneath their level — no separate role-based branching needed.
- Attendance is computed from `ReportField`s whose label matches either `MC Attendance` or `How many attended MC?` (case-insensitive), since different report definitions currently name the same underlying metric differently. Submissions from all matching reports are summed together per group for the current Sunday–Saturday week (reusing `getStartOfWeek`).
- Response shape:
```ts
  {
    total: number;
    breakdown: { groupId: number; groupName: string; total: number }[];
    weekStart: string; // yyyy-MM-dd
    weekEnd: string;   // yyyy-MM-dd
    reportFound: boolean; // false if no MCA-labelled field exists for the tenant
  }
```
- Added `GET /api/reports/mca/weekly-summary` controller endpoint (guarded by the existing `JwtAuthGuard` + `TenantContextInterceptor`, consistent with the rest of `ReportsController`).
- Added unit tests covering: no MCA field configured for tenant, user with no manageable groups, summing across both field label variants, roll-up aggregation across multiple submissions for the same group, non-numeric field values being skipped safely, and unrelated fields on the same submission not being included in the sum.
- Minor cleanup nits: promoted the field-label list to a `static readonly` class constant, switched the per-submission field-id lookup from `Array.includes()` to a `Set` for O(1) lookups, and removed a now-dead `typeof` type guard since `reportField` is always a joined entity in this query.

# How should this be tested?
- Run the unit test suite: `npm run test -- reports.service.spec.ts` — new `getWeeklyMcaSummary` describe block should pass alongside existing tests.
- Manually, with a valid JWT:
  1. `GET /api/reports/mca/weekly-summary` as a user who leads a single MC → `total` should equal the sum of that MC's attendance-field submissions for the current week; `breakdown` should have one entry.
  2. Same call as a user who leads a Location (i.e. leads a group with several MC children) → `total` should equal the sum across all those MCs; `breakdown` should have one entry per MC that submitted this week.
  3. Same call as a user who leads a Zone (Locations nested under it) → `total` should roll up across every MC under every Location under that Zone.
  4. A user with no leadership groups at all → `total: 0`, `breakdown: []`, `reportFound: true`.
  5. If no report field in the tenant is labelled `MC Attendance` or `How many attended MC?` → `reportFound: false`.
- Confirm route registration on server boot: the Nest bootstrap log should show `Mapped {/api/reports/mca/weekly-summary, GET} route`, and the compiler should report `Found 0 errors` before testing (a stale/failed build was the cause of an earlier 404 during dev).

# Notes for reviewers
- Deliberately did **not** hardcode a report name or `functionName` to identify the MCA field — report names are editable via the admin UI, so matching on field label was chosen as the more stable key. If more report variants get their own label for this metric in the future, add it to `MCA_FIELD_LABELS`.
- If the same group ever legitimately submits to two different MCA-labelled reports in the same week that represent the *same* underlying headcount (rather than two genuinely distinct counts), this will currently sum both and double-count. Flagging this as a known edge case to confirm is not happening in your report configuration — happy to add an exclusion/priority rule if needed.
- `reportFound: false` is a soft-fail (no exception thrown) so the frontend can simply hide the summary block rather than erroring, in case a tenant hasn't configured either labelled field yet.

# Out of scope
- No changes to `submitReport`, existing report submission/visibility endpoints, or permission logic — this is purely additive (new method + new route).
- Does not add a week-picker; the endpoint always returns the *current* week's total per product decision.
- Does not address the pagination cap (`limit=20`) on `submissions/mygroups` — this endpoint queries submissions directly and is unaffected by it, but that existing cap on the other endpoint is out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated weekly MCA attendance summary.
  * Summaries include total attendance, group-level breakdowns, and the reporting week.
  * Results are limited to relevant active fields, accessible groups, and valid numeric submissions.
  * Groups are listed in descending order of attendance totals.
  * Clearly indicates when no matching report data is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->