### PR TITLE
fix dashboard birthday locations

### DIFF
--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { Injectable, Inject, NotFoundException, Logger } from '@nestjs/common';
 import { Between, Connection, In, Repository } from 'typeorm';
 import { ReportSubmission } from '../reports/entities/report.submission.entity';
 import { Report } from '../reports/entities/report.entity';
@@ -8,6 +8,7 @@ import Person from '../crm/entities/person.entity';
 import Contact from '../crm/entities/contact.entity';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { ContactCategory } from '../crm/enums/contactCategory';
+import { GroupCategoryPurpose } from '../groups/enums/groups';
 
 interface PgaTrendPoint {
   period: string;
@@ -20,6 +21,22 @@ interface LocationPgaRanking {
   pga: number;
 }
 
+interface GroupHierarchyEntry {
+  parentId: number | null;
+  purpose: GroupCategoryPurpose | null;
+  name: string;
+}
+
+interface BirthdayEntry {
+  id: number;
+  name: string;
+  dateOfBirth: string | Date;
+  location: string;
+  upcomingDate: string;
+}
+
+const UNKNOWN_ROOT_LABEL = 'Unknown';
+
 @Injectable()
 export class DashboardService {
   private readonly reportSubmissionRepository: Repository<ReportSubmission>;
@@ -27,6 +44,7 @@ export class DashboardService {
   private readonly groupRepository: Repository<Group>;
   private readonly personRepository: Repository<Person>;
   private readonly contactRepository: Repository<Contact>;
+  private readonly logger = new Logger(DashboardService.name);
 
   constructor(
     @Inject('CONNECTION') connection: Connection,
@@ -378,63 +396,181 @@ export class DashboardService {
       pga: Number(row.pga),
     }));
   }
+  /**
+   * Build a groupId -> hierarchy entry map for the tenant, so we can walk up
+   * from a membership's group to its Location-purpose ancestor (or tenant
+   * root) without one query per contact.
+   */
+  private async loadGroupHierarchyMap(
+    tenantId: number,
+  ): Promise<Map<number, GroupHierarchyEntry>> {
+    const groups = await this.groupRepository.find({
+      where: { tenant: { id: tenantId } },
+      relations: ['category'],
+      select: {
+        id: true,
+        name: true,
+        parentId: true,
+        category: { purpose: true },
+      },
+    });
+
+    const map = new Map<number, GroupHierarchyEntry>();
+    for (const g of groups) {
+      map.set(g.id, {
+        parentId: g.parentId ?? null,
+        purpose: g.category?.purpose ?? null,
+        name: g.name,
+      });
+    }
+    return map;
+  }
+
+  /**
+   * Walk up from a group to the nearest ancestor whose category purpose is
+   * LOCATION. Returns null if no such ancestor exists.
+   */
+  private resolveLocationName(
+    groupId: number,
+    hierarchy: Map<number, GroupHierarchyEntry>,
+  ): string | null {
+    let current = hierarchy.get(groupId);
+    const seen = new Set<number>();
+
+    while (current && current.purpose !== GroupCategoryPurpose.LOCATION) {
+      if (current.parentId == null || seen.has(current.parentId)) {
+        current = undefined;
+        break;
+      }
+      seen.add(current.parentId);
+      current = hierarchy.get(current.parentId);
+    }
+
+    return current?.purpose === GroupCategoryPurpose.LOCATION ? current.name : null;
+  }
+
+  /**
+   * Resolve every distinct Location name reachable from a contact's active
+   * memberships.
+   */
+  private resolveLocationNames(
+    groupIds: number[],
+    hierarchy: Map<number, GroupHierarchyEntry>,
+  ): string[] {
+    const names = new Set<string>();
+    for (const groupId of groupIds) {
+      const name = this.resolveLocationName(groupId, hierarchy);
+      if (name) {
+        names.add(name);
+      }
+    }
+    return [...names];
+  }
+
+  /**
+   * Find the tenant's root group name(s) - group(s) with no parentId. Used
+   * as the fallback label when a contact has no resolvable Location
+   * ancestor, instead of a generic placeholder string.
+   */
+  private resolveTenantRootName(hierarchy: Map<number, GroupHierarchyEntry>): string {
+    const roots = [...hierarchy.values()].filter((g) => g.parentId == null);
+
+    if (roots.length === 0) {
+      return UNKNOWN_ROOT_LABEL;
+    }
+
+    return roots.map((r) => r.name).join(', ');
+  }
+
+  /**
+   * Parse a Person.dateOfBirth value into a local Date, treating bare
+   * 'YYYY-MM-DD' strings as local-midnight rather than UTC-midnight. Without
+   * this, `new Date('1990-05-14')` is parsed as UTC and can shift a day
+   * backward/forward depending on the server's local timezone.
+   */
+  private parseDateOnly(value: string | Date): Date {
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      const [year, month, day] = value.split('-').map(Number);
+      const date = new Date(year, month - 1, day);
+      if (
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day
+      ) {
+        return new Date(NaN);
+      }
+      return date;
+    }
+    return new Date(value);
+  }
 
   /**
    * Get birthdays for the current week (today through next 6 days).
    * Returns people sorted by birthday date (earliest first).
    * Handles edge cases: month boundaries, year boundaries, missing data.
    */
-  async getBirthdaysThisWeek(): Promise<any> {
+  async getBirthdaysThisWeek(): Promise<{ birthdays: BirthdayEntry[] }> {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    // Get tenant from context
     const tenantId = this.tenantContext.requireTenant();
 
-    //  Added 'groupMembership' and 'groupMembership.group' relations to load location contexts
-    const contacts = await this.contactRepository.find({
-      where: {
-        tenant: { id: tenantId },
-        category: ContactCategory.Person,
-      },
-      relations: ['person', 'groupMemberships', 'groupMemberships.group'],
-      select: {
-        id: true,
-        person: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          dateOfBirth: true,
+    const [contacts, hierarchy] = await Promise.all([
+      this.contactRepository.find({
+        where: {
+          tenant: { id: tenantId },
+          category: ContactCategory.Person,
         },
-        // Select group data parameters safely
-        groupMemberships: {
+        relations: ['person', 'groupMemberships', 'groupMemberships.group'],
+        select: {
           id: true,
-          groupId: true,
-          isActive: true,
-          group: {
+          person: {
             id: true,
-            name: true,
-          }
-        }
-      },
-    });
+            firstName: true,
+            lastName: true,
+            dateOfBirth: true,
+          },
+          groupMemberships: {
+            id: true,
+            groupId: true,
+            isActive: true,
+            group: {
+              id: true,
+              name: true,
+              parentId: true,
+            },
+          },
+        },
+      }),
+      this.loadGroupHierarchyMap(tenantId),
+    ]);
 
-    // Filter contacts that have person with dateOfBirth
+    const rootFallbackName = this.resolveTenantRootName(hierarchy);
+
     const birthdaysThisWeek = contacts
-      .filter((contact) => contact.person?.dateOfBirth)
-      .map((contact) => {
-        try {
-          const person = contact.person;
-          const dob = new Date(person?.dateOfBirth);
+      .map((contact): (BirthdayEntry & { _sortDate: Date }) | null => {
+        const person = contact.person;
+        if (!person?.dateOfBirth) {
+          return null;
+        }
 
-          if (isNaN(dob.getTime())) return null;
+        try {
+          const dob = this.parseDateOnly(person.dateOfBirth);
+          if (isNaN(dob.getTime())) {
+            return null;
+          }
 
           const birthMonth = dob.getMonth();
           const birthDay = dob.getDate();
 
-          // DYNAMICALLY RESOLVE LOCATION: Find the name of their active group (MC)
-          const activeMembership = contact.groupMemberships?.find(m => m.isActive !== false);
-          const resolvedLocation = activeMembership?.group?.name || 'General Locations';
+          const activeMemberships =
+            contact.groupMemberships?.filter((m) => m.isActive) ?? [];
+          const locationNames = this.resolveLocationNames(
+            activeMemberships.map((m) => m.groupId),
+            hierarchy,
+          );
+          const resolvedLocation =
+            locationNames.length > 0 ? locationNames.join(', ') : rootFallbackName;
 
           for (let i = 0; i <= 6; i++) {
             const checkDate = new Date(today);
@@ -448,21 +584,24 @@ export class DashboardService {
               upcomingDate.setHours(0, 0, 0, 0);
 
               return {
-                id: person?.id,
-                name: `${person?.firstName} ${person?.lastName}`,
-                dateOfBirth: person?.dateOfBirth,
+                id: person.id,
+                name: `${person.firstName} ${person.lastName}`,
+                dateOfBirth: person.dateOfBirth,
                 location: resolvedLocation,
-                upcomingDate: upcomingDate.toISOString().split('T')[0],
+                upcomingDate: this.toDateString(upcomingDate),
                 _sortDate: upcomingDate,
               };
             }
           }
           return null;
         } catch (error) {
+          this.logger.warn(
+            `Failed to resolve birthday entry for contact ${contact.id}: ${error instanceof Error ? error.message : error}`,
+          );
           return null;
         }
       })
-      .filter((item) => item !== null)
+      .filter((item): item is BirthdayEntry & { _sortDate: Date } => item !== null)
       .sort((a, b) => a._sortDate.getTime() - b._sortDate.getTime())
       .map(({ _sortDate, ...birthday }) => birthday);
 

--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -557,6 +557,9 @@ export class DashboardService {
         try {
           const dob = this.parseDateOnly(person.dateOfBirth);
           if (isNaN(dob.getTime())) {
+            this.logger.warn(
+              `Skipping contact ${contact.id}: unparseable dateOfBirth`,
+            );
             return null;
           }
 

--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, NotFoundException, Logger } from '@nestjs/common';
-import { Between, Connection, In, Repository } from 'typeorm';
+import { Between, Brackets, Connection, In, Repository } from 'typeorm';
 import { ReportSubmission } from '../reports/entities/report.submission.entity';
 import { Report } from '../reports/entities/report.entity';
 import { GroupPermissionsService } from '../groups/services/group-permissions.service';
@@ -397,6 +397,54 @@ export class DashboardService {
     }));
   }
   /**
+ * The (month, day) pairs for today through the next 6 days, used to filter
+ * contacts at the SQL level instead of loading every contact in the tenant.
+ */
+  private getBirthdayWindowDays(today: Date): { month: number; day: number }[] {
+    const days: { month: number; day: number }[] = [];
+    for (let i = 0; i <= 6; i++) {
+      const d = new Date(today);
+      d.setDate(today.getDate() + i);
+      days.push({ month: d.getMonth() + 1, day: d.getDate() });
+    }
+    return days;
+  }
+  private async findBirthdayWindowContacts(
+    tenantId: number,
+    windowDays: { month: number; day: number }[],
+  ): Promise<Contact[]> {
+    const qb = this.contactRepository
+      .createQueryBuilder('contact')
+      .innerJoinAndSelect('contact.person', 'person')
+      .leftJoinAndSelect('contact.groupMemberships', 'groupMemberships')
+      .leftJoinAndSelect('groupMemberships.group', 'group')
+      .where('contact.tenantId = :tenantId', { tenantId })
+      .andWhere('contact.category = :category', {
+        category: ContactCategory.Person,
+      })
+      .andWhere('person.dateOfBirth IS NOT NULL')
+      .andWhere(
+        new Brackets((qbInner) => {
+          windowDays.forEach((wd, idx) => {
+            const condition = `(EXTRACT(MONTH FROM person."dateOfBirth"::date) = :month${idx} AND EXTRACT(DAY FROM person."dateOfBirth"::date) = :day${idx})`;
+            if (idx === 0) {
+              qbInner.where(condition, {
+                [`month${idx}`]: wd.month,
+                [`day${idx}`]: wd.day,
+              });
+            } else {
+              qbInner.orWhere(condition, {
+                [`month${idx}`]: wd.month,
+                [`day${idx}`]: wd.day,
+              });
+            }
+          });
+        }),
+      );
+
+    return qb.getMany();
+  }
+  /**
    * Build a groupId -> hierarchy entry map for the tenant, so we can walk up
    * from a membership's group to its Location-purpose ancestor (or tenant
    * root) without one query per contact.
@@ -411,7 +459,7 @@ export class DashboardService {
         id: true,
         name: true,
         parentId: true,
-        category: { purpose: true },
+        category: { id: true, purpose: true },
       },
     });
 
@@ -479,7 +527,10 @@ export class DashboardService {
       return UNKNOWN_ROOT_LABEL;
     }
 
-    return roots.map((r) => r.name).join(', ');
+    return roots
+      .map((r) => r.name)
+      .sort((a, b) => a.localeCompare(b))
+      .join(', ');
   }
 
   /**
@@ -514,34 +565,10 @@ export class DashboardService {
     today.setHours(0, 0, 0, 0);
 
     const tenantId = this.tenantContext.requireTenant();
+    const windowDays = this.getBirthdayWindowDays(today);
 
     const [contacts, hierarchy] = await Promise.all([
-      this.contactRepository.find({
-        where: {
-          tenant: { id: tenantId },
-          category: ContactCategory.Person,
-        },
-        relations: ['person', 'groupMemberships', 'groupMemberships.group'],
-        select: {
-          id: true,
-          person: {
-            id: true,
-            firstName: true,
-            lastName: true,
-            dateOfBirth: true,
-          },
-          groupMemberships: {
-            id: true,
-            groupId: true,
-            isActive: true,
-            group: {
-              id: true,
-              name: true,
-              parentId: true,
-            },
-          },
-        },
-      }),
+      this.findBirthdayWindowContacts(tenantId, windowDays),
       this.loadGroupHierarchyMap(tenantId),
     ]);
 


### PR DESCRIPTION
# Summary of changes
- Fixed `DashboardService.getBirthdaysThisWeek()` incorrectly labeling a contact's **location** with their **Missional Community (MC)** name instead of their actual campus/venue.
  - Root cause: the method read `activeMembership.group.name` directly off a contact's `GroupMembership`, but memberships are recorded at the fellowship (MC) level, not the location level. `Group` has no `type`/`level` column of its own — hierarchy level is expressed via `Group.category → GroupCategory.purpose`.
- Added `loadGroupHierarchyMap()` to load the tenant's full group tree (`id`, `parentId`, `category.purpose`, `name`) once per request, avoiding N+1 queries.
- Added `resolveLocationName()` / `resolveLocationNames()` to walk `parentId` upward from a contact's active membership(s) to the nearest ancestor whose `category.purpose === GroupCategoryPurpose.LOCATION`.
- **Multiple active memberships are now all considered**, not just the first found — a contact belonging to locations A and B now shows `"A, B"` instead of an arbitrary single pick (or a silent fallback if the first-found chain happened to be unresolvable).
- Replaced the `'General Locations'` placeholder fallback with `resolveTenantRootName()`, which returns the tenant's actual root **group** name (the group with no `parentId`) — used only when a contact has no active memberships or none resolve to a `LOCATION`-purpose ancestor. Falls back to `'Unknown'` only if the tenant's group tree is empty/unreachable, as a last-resort guard.
- Explicitly ruled out using `Tenant.name`/a new `Tenant.displayName` for this fallback — `Tenant.name` is a lower-cased, space-stripped slug (`worshipharvest`) with no reliable way to recover proper casing/spacing algorithmically, and adding a migration was out of scope for this fix.
- Fixed a date-parsing bug: bare `'YYYY-MM-DD'` values from `Person.dateOfBirth` were being parsed via `new Date(string)`, which JS treats as **UTC midnight** — this can shift the resulting local date backward by one day depending on server timezone. Added `parseDateOnly()` to parse date-only strings as local-midnight instead.
- Cleaned up type/lint issues:
  - Removed inline `any` return type from `getBirthdaysThisWeek()` in favor of an explicit `{ birthdays: BirthdayEntry[] }` return type.
  - Extracted the repeated hierarchy-entry shape into a single `GroupHierarchyEntry` interface instead of five inline duplicates.
  - Removed a silent `catch (error) { return null }` (unused `error` binding, no observability) in favor of `this.logger.warn(...)` with the contact ID and error message, while preserving the same skip-and-continue behavior.
  - Merged the separate `.filter(contact => contact.person?.dateOfBirth)` + `.map()` into a single `.map()` with an early-return guard, so `person` is correctly narrowed to non-optional within the closure that builds the birthday object (previously a latent strict-mode type gap).

# How should this be tested?
- Hit the birthdays endpoint (`getBirthdaysThisWeek`) for a tenant with:
  1. A contact whose only active membership is an MC → `location` should show the MC's parent **Location** name, not the MC name.
  2. A contact with two active memberships under two different Locations → `location` should show both, comma-separated.
  3. A contact with no active memberships (or whose chain never reaches a `LOCATION`-purpose group) → `location` should show the tenant's root group name, not `'General Locations'`.
  4. A contact whose `dateOfBirth` is stored as a bare `'YYYY-MM-DD'` string → confirm the returned `upcomingDate` lands on the correct calendar day for a server running in a non-UTC timezone (e.g. test with server TZ set to something like `America/New_York` and a birthday near midnight UTC boundary).
- Confirm no N+1 queries: `loadGroupHierarchyMap` should fire once per request regardless of contact count (check query logs).
- Confirm malformed/unparseable `dateOfBirth` values are still skipped silently from the response but now emit a `logger.warn` line with the contact ID.

# Notes for reviewers
- No migration included — this deliberately avoids adding `Tenant.displayName` (discussed and dropped in favor of using the existing group hierarchy, which required no schema changes).
- `resolveTenantRootName` currently joins multiple roots with `, ` if a tenant's groups form more than one disconnected tree (no single group with `parentId: null`... multiple). This is an edge case that shouldn't happen in normal data but is handled defensively rather than assumed away.
- Happy to split the date-parsing fix (`parseDateOnly`) into its own PR if you'd rather keep this change scoped strictly to the location-resolution bug — flagging it here since it was found in the same block during review.

# Out of scope
- Persisting a human-friendly tenant/church display name (e.g. `"Worship Harvest"` vs. the stored slug `worshipharvest`) — would require a migration and a decision on where that value is captured (signup flow vs. admin-editable field). Discussed but deferred.
- Backfilling or fixing existing `GroupCategory` rows with a `null` `purpose` — contacts under those categories will fall back to the tenant root name until those categories are stamped with the correct purpose.
- Any changes to `GroupPermissionsService` or dashboard-level (Sunday Service) location scoping — this PR only touches `getBirthdaysThisWeek`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved birthday listings by considering only active memberships.
  * Added more accurate location and hierarchy information, with tenant-level fallback names when needed.
  * Improved handling and validation of date-only birthdays.
  * Ensured malformed birthday records are handled without disrupting results.
  * Standardized birthday date formatting for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->