### PR TITLE
update-package.json-engines-and-mock-console.log-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Kanzu Code Foundation",
   "license": "MIT",
   "engines": {
-    "npm": "7.5.2",
-    "node": "12.22.5"
+    "npm": ">=8.0.0",
+    "node": ">=18.0.0"
   },
   "scripts": {
     "heroku-postbuild": "npm run build",

--- a/src/tasks/tasks.service.spec.ts
+++ b/src/tasks/tasks.service.spec.ts
@@ -53,6 +53,7 @@ describe('TasksService — location-based visibility scoping', () => {
   let membershipQb: any;
   let commentQb: any;
   let mockNotificationsService:any;
+  let consoleErrorSpy: jest.SpyInstance;
 
   const buildUser = (overrides: Record<string, any> = {}) => ({
     id: 100,
@@ -105,6 +106,7 @@ describe('TasksService — location-based visibility scoping', () => {
     // Must be set before module.compile() so the TenantAwareRepository mock
     // returns the current mockGroupRepo when the service is constructed.
     groupRepoForTest = mockGroupRepo;
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const mockConnection: Partial<Connection> = {
       getRepository: jest.fn((entity: any) => {
@@ -146,6 +148,9 @@ describe('TasksService — location-based visibility scoping', () => {
     }).compile();
 
     service = module.get<TasksService>(TasksService);
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('findAll', () => {
@@ -398,6 +403,11 @@ describe('TasksService — location-based visibility scoping', () => {
           assignedToId: 42,
         } as any),
       ).resolves.toBeDefined();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to send task-assigned notification:',
+        expect.any(Error),
+      );
     });
   });
 


### PR DESCRIPTION
# Ticket No
- N/A (chore: dev tooling / test hygiene cleanup)

# Summary of changes
- Updated the `engines` field in `package.json` from a stale `node: 12.22.5` / `npm: 7.5.2` requirement to reflect the versions actually supported by current dependencies (`node: >=18.0.0`, `npm: >=8.0.0`), removing the `EBADENGINE` warning on install.
- Added a `console.error` spy (`jest.spyOn(console, 'error').mockImplementation(() => {})`) in `tasks.service.spec.ts`, set up in `beforeEach` and restored in `afterEach`, to suppress the expected error logs emitted by the notification-failure test cases (`create`, `reassign`, `update`) without weakening their assertions.
- No production logic was changed; `TasksService` still logs failed notification attempts as before. Only the test file was updated to keep test output clean.

# How should this be tested?
1. Run `npm install` and confirm no `EBADENGINE` warning appears.
2. Run `npm run test -- src/tasks/tasks.service.spec.ts` and confirm:
   - All tests pass.
   - No `console.error` output ("Failed to send task-assigned notification...") appears in the terminal.

# Notes for reviewers
- The `engines` bump is metadata-only; it does not change any dependency versions or runtime behavior — it just aligns the declared requirement with what's already in use (Node 18, npm 8).
- The `console.error` mock is scoped to `tasks.service.spec.ts` only (via `beforeEach`/`afterEach`), so it does not suppress logging in other test files or in production.
- The spy is restored after every test (`mockRestore()`) to avoid leaking into other suites.

# Out of scope
- Any changes to the actual notification-failure handling logic in `TasksService`.
- Broader dependency upgrades beyond correcting the `engines` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported runtime requirements to Node.js 18.0.0 or newer and npm 8.0.0 or newer.

* **Tests**
  * Improved coverage for task-creation notification failures.
  * Confirmed that notification errors are logged correctly without interfering with other test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->