### PR TITLE
see MC leaders who have not submitted report for the week

### DIFF
--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -22,6 +22,7 @@ import { Repository, Connection } from 'typeorm';
 import { ReportSubmissionDto } from './dto/report-submission.dto';
 import { ReportDto } from './dto/report.dto';
 import { Report } from './entities/report.entity';
+import { type McComplianceResponse } from './reports.service';
 import {
   ApiResponse,
   ReportSubmissionsApiResponse,
@@ -293,6 +294,29 @@ export class ReportsController {
       reportId,
       smallGroupIdList,
       parentGroupIdList,
+    );
+  }
+  
+  @Get('mc/compliance')
+  @Header('Cache-Control', 'no-store')
+  async getMcSubmissionCompliance(
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Request() request?: any,
+  ): Promise<McComplianceResponse> {
+    this.logger.apiLog('log', 'Get MC submission compliance request received', {
+      operation: 'getMcSubmissionCompliance',
+      resource: 'reports',
+      metadata: {
+        userId: request.user?.id,
+        from,
+        to,
+      },
+    });
+    return await this.reportService.getMcSubmissionCompliance(
+      request.user,
+      from ? new Date(from) : undefined,
+      to ? new Date(to) : undefined,
     );
   }
 }

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -9,6 +9,7 @@ import { AppLogger } from '../utils/app-logger.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { FellowshipAttendanceService } from '../attendance/services/fellowship-attendance.service';
 import { Connection, Repository, TreeRepository } from 'typeorm';
+import Contact from '../crm/entities/contact.entity';
 import { Report } from './entities/report.entity';
 import { ReportStatus } from './enums/report.enum';
 import { ReportSubmission } from './entities/report.submission.entity';
@@ -75,6 +76,10 @@ describe('ReportsService', () => {
         findDescendants: jest.fn(),
         findAncestors: jest.fn(),
         findOne: jest.fn(),
+        find: jest.fn(),
+      },
+      contact: {
+        createQueryBuilder: jest.fn(),
       },
     };
 
@@ -89,6 +94,7 @@ describe('ReportsService', () => {
         if (entity === User) return mockRepositories.user;
         if (entity === ReportField) return mockRepositories.reportField;
         if (entity === GroupMembership) return mockRepositories.groupMembership;
+        if (entity === Contact) return mockRepositories.contact;
         return mockRepositories.report;
       }),
       getTreeRepository: jest.fn().mockReturnValue(mockRepositories.groupTree),
@@ -796,8 +802,8 @@ describe('ReportsService', () => {
         ]),
       );
 
-      // Submission query must be scoped to the single resolved report,
-      // the user's manageable groups, and this week's reportingPeriod.
+      // Submission query must be scoped to the single resolved report and
+      // the user's manageable groups.
       const andWhereCalls = submissionQb.andWhere.mock.calls;
       expect(
         andWhereCalls.some(
@@ -808,9 +814,21 @@ describe('ReportsService', () => {
             params.groupIds.includes(11),
         ),
       ).toBe(true);
+      // Must filter by a submittedAt range (lower bound inclusive, upper bound
+      // exclusive), not the historical reportingPeriod string — this is the
+      // fix that makes the summary immune to any past reportingPeriod-format
+      // drift, since submittedAt is a real timestamp that's never rewritten.
       expect(
-        andWhereCalls.some(([sql, params]) =>
-          sql.includes('reportingPeriod') && typeof params?.reportingPeriod === 'string',
+        andWhereCalls.some(
+          ([sql, params]) =>
+            sql.includes('submittedAt >=') && params?.weekStart instanceof Date,
+        ),
+      ).toBe(true);
+      expect(
+        andWhereCalls.some(
+          ([sql, params]) =>
+            sql.includes('submittedAt <') &&
+            params?.weekEndExclusive instanceof Date,
         ),
       ).toBe(true);
     });
@@ -892,6 +910,270 @@ describe('ReportsService', () => {
       const result = await service.getWeeklyMcaSummary(mockUser);
       expect(result.total).toBe(0);
       expect(result.breakdown).toEqual([]);
+    });
+
+    it('includes a submission whose submittedAt falls on the very last moment of the current week', async () => {
+      // Regression guard for the exclusive-upper-bound fix: a submission at
+      // 23:59:59 on the last day of the reporting week must still count.
+      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(field, 'getOne'),
+      );
+      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+
+      const submissionQb = makeQueryBuilder([
+        {
+          group: { id: 10, name: 'MC Nairobi' },
+          submissionData: [{ reportField: { id: 1 }, fieldValue: '12' }],
+        },
+      ]);
+      mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
+        submissionQb,
+      );
+
+      const result = await service.getWeeklyMcaSummary(mockUser);
+
+      expect(result.total).toBe(12);
+      // weekEndExclusive must be strictly after weekEnd (the inclusive display
+      // date), i.e. the start of the following week.
+      const weekStartCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
+        sql.includes('submittedAt >='),
+      );
+      const weekEndCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
+        sql.includes('submittedAt <'),
+      );
+      const daysBetween =
+        (weekEndCall[1].weekEndExclusive.getTime() -
+          weekStartCall[1].weekStart.getTime()) /
+        (1000 * 60 * 60 * 24);
+      expect(daysBetween).toBe(7);
+    });
+  });
+  describe('getMcSubmissionCompliance', () => {
+    const mockUser = { id: 7, contactId: 3 } as any;
+
+    const makeContactQueryBuilder = (rows: any[]) => {
+      const qb: any = {
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      };
+      return qb;
+    };
+
+    beforeEach(() => {
+      mockRepositories.groupTree.find.mockReset();
+      mockRepositories.reportSubmission.find.mockReset();
+      mockRepositories.groupMembership.find.mockReset();
+      mockRepositories.contact.createQueryBuilder.mockReset();
+    });
+
+    it('returns no groups when the user manages no groups (visibility scoping)', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([]);
+
+      const result = await service.getMcSubmissionCompliance(mockUser);
+
+      expect(result.groups).toEqual([]);
+      // Must short-circuit before ever looking at MC groups or submissions.
+      expect(mockRepositories.groupTree.find).not.toHaveBeenCalled();
+    });
+
+    it('only queries MC groups within the user-scoped group id list', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([]); // no MC groups found
+
+      await service.getMcSubmissionCompliance(mockUser);
+
+      expect(mockRepositories.groupTree.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: expect.objectContaining({ _value: expect.arrayContaining([10]) }),
+          }),
+        }),
+      );
+    });
+
+    it('returns no groups when the MC Attendance Report does not exist', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue(null);
+
+      const result = await service.getMcSubmissionCompliance(mockUser);
+
+      expect(result.groups).toEqual([]);
+    });
+
+    it('excludes MC groups that submitted for every week in range', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue({ id: 100 });
+
+      const from = new Date('2026-07-26'); // Sunday
+      const to = new Date('2026-08-01');   // same reporting week
+      // submittedAt (not reportingPeriod) is what the service now buckets on —
+      // this timestamp falls within the 2026-07-26 reporting week.
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        {
+          group: { id: 10 },
+          submittedAt: new Date('2026-07-28T09:00:00Z'),
+        },
+      ]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10, contactId: 55 },
+      ]);
+      mockRepositories.contact.createQueryBuilder.mockReturnValue(
+        makeContactQueryBuilder([
+          { id: 55, firstName: 'Grace', lastName: 'Nakato', middleName: null },
+        ]),
+      );
+
+      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+
+      expect(result.groups).toEqual([]);
+    });
+
+    it('includes only MC groups with at least one missed week, sorted worst-first', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+        { groupId: 11 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10, 11]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+        { id: 11, name: 'MC Kampala' },
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue({ id: 100 });
+
+      // Two-week range: 10 submitted both weeks (compliant, excluded),
+      // 11 submitted neither (should appear with weeksMissed = 2).
+      const from = new Date('2026-07-19');
+      const to = new Date('2026-07-26');
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        { group: { id: 10 }, submittedAt: new Date('2026-07-21T10:00:00Z') },
+        { group: { id: 10 }, submittedAt: new Date('2026-07-28T10:00:00Z') },
+      ]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 11, contactId: 77 },
+      ]);
+      mockRepositories.contact.createQueryBuilder.mockReturnValue(
+        makeContactQueryBuilder([
+          { id: 77, firstName: 'Brian', lastName: 'Okello', middleName: null },
+        ]),
+      );
+
+      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+
+      expect(result.groups).toHaveLength(1);
+      expect(result.groups[0]).toMatchObject({
+        groupId: 11,
+        groupName: 'MC Kampala',
+        leaderName: 'Brian Okello',
+        weeksMissed: 2,
+        weeksInRange: 2,
+      });
+    });
+
+    it('flags missingCurrentWeek only when the most recent week is among the missed weeks', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue({ id: 100 });
+
+      const from = new Date('2026-07-19');
+      const to = new Date('2026-07-26'); // current week starts 2026-07-26
+      // Submitted the earlier week, missed the current one.
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        { group: { id: 10 }, submittedAt: new Date('2026-07-21T10:00:00Z') },
+      ]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10, contactId: 55 },
+      ]);
+      mockRepositories.contact.createQueryBuilder.mockReturnValue(
+        makeContactQueryBuilder([
+          { id: 55, firstName: 'Grace', lastName: 'Nakato', middleName: null },
+        ]),
+      );
+
+      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+
+      expect(result.groups[0].missingCurrentWeek).toBe(true);
+      expect(result.groups[0].missedWeeks).toEqual(['2026-07-26']);
+    });
+
+    it('falls back to "No leader assigned" when an MC has no active leader', async () => {
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue({ id: 100 });
+      mockRepositories.reportSubmission.find.mockResolvedValue([]);
+      // No active leader membership found for group 10.
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([]);
+
+      const result = await service.getMcSubmissionCompliance(
+        mockUser,
+        new Date('2026-07-26'),
+        new Date('2026-07-26'),
+      );
+
+      expect(result.groups[0].leaderName).toBe('No leader assigned');
+      expect(mockRepositories.contact.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('buckets a submission by submittedAt even when reportingPeriod is stale or absent', async () => {
+      // Regression guard for the exact bug just fixed: a submission whose
+      // stored reportingPeriod (from an older week-boundary formula) no
+      // longer matches its actual week must still be counted correctly,
+      // because the service now derives the bucket from submittedAt, not
+      // from the stored string.
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
+      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+      ]);
+      mockRepositories.report.findOne.mockResolvedValue({ id: 100 });
+
+      const from = new Date('2026-07-26');
+      const to = new Date('2026-08-01');
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        {
+          group: { id: 10 },
+          submittedAt: new Date('2026-07-29T10:00:00Z'),
+          // Intentionally stale/wrong — must be ignored by the service.
+          reportingPeriod: '1970-01-01',
+        },
+      ]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10, contactId: 55 },
+      ]);
+      mockRepositories.contact.createQueryBuilder.mockReturnValue(
+        makeContactQueryBuilder([
+          { id: 55, firstName: 'Grace', lastName: 'Nakato', middleName: null },
+        ]),
+      );
+
+      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+
+      // Group 10 submitted (via submittedAt) for the only week in range, so
+      // it must be excluded from the "not submitted" result entirely.
+      expect(result.groups).toEqual([]);
     });
   });
 });

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -45,6 +45,21 @@ import { getPersonFullName } from 'src/crm/crm.helpers';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
 
+export interface McComplianceGroupStatus {
+  groupId: number;
+  groupName: string;
+  leaderName: string;
+  weeksInRange: number;
+  weeksMissed: number;
+  missedWeeks: string[]; 
+  missingCurrentWeek: boolean;
+}
+
+export interface McComplianceResponse {
+  weekStarts: string[]; 
+  groups: McComplianceGroupStatus[];
+}
+
 @Injectable()
 export class ReportsService {
   private readonly reportRepository: Repository<Report>;
@@ -58,6 +73,7 @@ export class ReportsService {
   private readonly logger: ContextLogger;
   private static readonly MCA_REPORT_NAME = 'MC Attendance Report';
   private static readonly MCA_FIELD_LABEL = 'How many attended MC?';
+  private static readonly COMPLIANCE_MAX_WEEKS_LOOKBACK = 12;
 
   constructor(
     @Inject('CONNECTION') connection: Connection,
@@ -138,7 +154,16 @@ export class ReportsService {
 
     return leaderUsers.map((u) => u.id);
   }
-
+  // Formats a Date as YYYY-MM-DD using LOCAL calendar fields. Never use
+  // toISOString().slice(0,10) for reportingPeriod/week-boundary keys — it
+  // converts to UTC and will silently shift the date for any timezone ahead
+  // of UTC (e.g. local midnight can fall on the previous UTC day).
+  private formatDateKey(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
   async createReport(reportDto: ReportDto, user: UserDto): Promise<ReportDto> {
     const report = new Report();
     report.name = reportDto.name;
@@ -349,7 +374,7 @@ export class ReportsService {
     reportSubmission.report = report;
     reportSubmission.submittedAt = new Date();
     reportSubmission.user = submittingUser;
-    reportSubmission.reportingPeriod = weekStart.toISOString().slice(0, 10);
+    reportSubmission.reportingPeriod = this.formatDateKey(weekStart);
     if (targetGroup) {
       reportSubmission.group = targetGroup;
     }
@@ -1025,6 +1050,28 @@ export class ReportsService {
    * Looks up contact names for every dynamic_member_selector field across
    * one or more submissions' submissionData, in a single batched query.
    */
+  private async fetchContactNames(
+    contactIds: number[],
+  ): Promise<Map<number, string>> {
+    if (contactIds.length === 0) {
+      return new Map();
+    }
+
+    const contacts = await this.contactRepository
+      .createQueryBuilder('c')
+      .innerJoin('c.person', 'p')
+      .where('c.id IN (:...contactIds)', { contactIds })
+      .select([
+        'c.id AS id',
+        'p.firstName AS "firstName"',
+        'p.lastName AS "lastName"',
+        'p.middleName AS "middleName"',
+      ])
+      .getRawMany();
+
+    return new Map(contacts.map((c) => [c.id, getPersonFullName(c)]));
+  }
+
   private async fetchMemberSelectorContactNames(
     submissionDataLists: ReportSubmissionData[][],
   ): Promise<Map<number, string>> {
@@ -1041,26 +1088,7 @@ export class ReportsService {
         }
       }
     }
-
-    if (contactIds.size === 0) {
-      return new Map();
-    }
-
-    const contacts = await this.contactRepository
-      .createQueryBuilder('c')
-      .innerJoin('c.person', 'p')
-      .where('c.id IN (:...contactIds)', {
-        contactIds: Array.from(contactIds),
-      })
-      .select([
-        'c.id AS id',
-        'p.firstName AS "firstName"',
-        'p.lastName AS "lastName"',
-        'p.middleName AS "middleName"',
-      ])
-      .getRawMany();
-
-    return new Map(contacts.map((c) => [c.id, getPersonFullName(c)]));
+    return this.fetchContactNames(Array.from(contactIds));
   }
 
   /**
@@ -1673,22 +1701,27 @@ export class ReportsService {
   }
   
   async getWeeklyMcaSummary(user: UserDto): Promise<{
-    total: number;
-    breakdown: { groupId: number; groupName: string; total: number }[];
-    weekStart: string;
-    weekEnd: string;
-    reportFound: boolean;
+  total: number;
+  breakdown: { groupId: number; groupName: string; total: number }[];
+  weekStart: string;
+  weekEnd: string;
+  reportFound: boolean;
   }> {
     const tenantId = this.tenantContext.requireTenant();
     const weekStart = this.getStartOfWeek(new Date());
     const weekEnd = new Date(weekStart);
     weekEnd.setDate(weekEnd.getDate() + 6);
+    // Exclusive upper bound for the submittedAt query — start of the *next*
+    // week, matching the same Between() pattern submitReport already uses
+    // for its duplicate-submission check.
+    const weekEndExclusive = new Date(weekStart);
+    weekEndExclusive.setDate(weekEndExclusive.getDate() + 7);
 
     const emptyResult = {
       total: 0,
       breakdown: [] as { groupId: number; groupName: string; total: number }[],
-      weekStart: weekStart.toISOString().slice(0, 10),
-      weekEnd: weekEnd.toISOString().slice(0, 10),
+      weekStart: this.formatDateKey(weekStart),
+      weekEnd: this.formatDateKey(weekEnd),
     };
 
     const attendanceField = await this.reportFieldRepository
@@ -1739,13 +1772,12 @@ export class ReportsService {
       )
       .where('submission.report = :reportId', { reportId })
       .andWhere('group.id IN (:...groupIds)', { groupIds })
-      .andWhere('submission.reportingPeriod = :reportingPeriod', {
-        reportingPeriod: emptyResult.weekStart,
-      })
+      .andWhere('submission.submittedAt >= :weekStart', { weekStart })
+      .andWhere('submission.submittedAt < :weekEndExclusive', { weekEndExclusive })
       .getMany();
 
     let total = 0;
-    const breakdownMap = new Map<number,{ groupId: number; groupName: string; total: number }>();
+    const breakdownMap = new Map<number, { groupId: number; groupName: string; total: number }>();
 
     for (const submission of submissions) {
       for (const sd of submission.submissionData) {
@@ -1770,12 +1802,160 @@ export class ReportsService {
     }
     return {
       total,
-      breakdown: Array.from(breakdownMap.values()).sort(
-        (a, b) => b.total - a.total,
-      ),
+      breakdown: Array.from(breakdownMap.values()).sort((a, b) => b.total - a.total),
       weekStart: emptyResult.weekStart,
       weekEnd: emptyResult.weekEnd,
       reportFound: true,
     };
+  }
+ 
+  async getMcSubmissionCompliance(
+    user: UserDto,
+    from?: Date,
+    to?: Date,
+  ): Promise<McComplianceResponse> {
+    const tenantId = this.tenantContext.requireTenant();
+    const rangeEnd = to ?? new Date();
+    const rangeStart =
+      from ??
+      this.subtractWeeks(rangeEnd, ReportsService.COMPLIANCE_MAX_WEEKS_LOOKBACK);
+
+    const weekStarts = this.getReportingWeekStarts(rangeStart, rangeEnd);
+    if (weekStarts.length === 0) {
+      return { weekStarts: [], groups: [] };
+    }
+    const weekStartIsoList = weekStarts.map((d) => this.formatDateKey(d));
+    const currentWeekIso = weekStartIsoList[weekStartIsoList.length - 1];
+
+    const groupIds = await this.getUserManageableGroups(user);
+    if (groupIds.length === 0) {
+      return { weekStarts: weekStartIsoList, groups: [] };
+    }
+
+    const mcGroups = await this.treeRepository.find({
+      where: {
+        id: In(groupIds),
+        category: { name: GroupCategoryNames.MC } as any,
+        tenant: { id: tenantId } as any,
+      },
+      relations: ['category'],
+    });
+    if (mcGroups.length === 0) {
+      return { weekStarts: weekStartIsoList, groups: [] };
+    }
+    const mcGroupIds = mcGroups.map((g) => g.id);
+
+    const attendanceReport = await this.reportRepository.findOne({
+      where: {
+        name: ReportsService.MCA_REPORT_NAME,
+        status: ReportStatus.ACTIVE,
+        tenant: { id: tenantId } as any,
+      },
+    });
+    if (!attendanceReport) {
+      return { weekStarts: weekStartIsoList, groups: [] };
+    }
+
+    // Query the raw submittedAt window covering the full range, then bucket
+    // each submission into a week live in JS using the same getStartOfWeek /
+    // formatDateKey as weekStartIsoList above. This deliberately avoids
+    // matching against the stored `reportingPeriod` string — that value was
+    // written under whatever week-boundary formula was live at submit time,
+    // and historical rows can carry a stale value from an earlier formula.
+    // Deriving the bucket from submittedAt at read time keeps this endpoint
+    // permanently in sync with itself, regardless of past formula changes.
+    const queryRangeStart = weekStarts[0];
+    const queryRangeEndExclusive = new Date(weekStarts[weekStarts.length - 1]);
+    queryRangeEndExclusive.setDate(queryRangeEndExclusive.getDate() + 7);
+
+    const submissions = await this.reportSubmissionRepository.find({
+      where: {
+        report: { id: attendanceReport.id },
+        group: { id: In(mcGroupIds) },
+        submittedAt: Between(queryRangeStart, queryRangeEndExclusive),
+      },
+      relations: ['group'],
+    });
+
+    const submittedWeeksByGroup = new Map<number, Set<string>>();
+    for (const submission of submissions) {
+      const groupId = submission.group.id;
+      const weekKey = this.formatDateKey(this.getStartOfWeek(submission.submittedAt));
+      if (!submittedWeeksByGroup.has(groupId)) {
+        submittedWeeksByGroup.set(groupId, new Set());
+      }
+      submittedWeeksByGroup.get(groupId).add(weekKey);
+    }
+
+    const leaderNameByGroupId = await this.getMcLeaderNamesByGroupId(mcGroupIds);
+
+    const groups: McComplianceGroupStatus[] = mcGroups
+      .map((group) => {
+        const submittedWeeks = submittedWeeksByGroup.get(group.id) ?? new Set<string>();
+        const missedWeeks = weekStartIsoList.filter((week) => !submittedWeeks.has(week));
+
+        return {
+          groupId: group.id,
+          groupName: group.name,
+          leaderName: leaderNameByGroupId.get(group.id) ?? 'No leader assigned',
+          weeksInRange: weekStartIsoList.length,
+          weeksMissed: missedWeeks.length,
+          missedWeeks,
+          missingCurrentWeek: missedWeeks.includes(currentWeekIso),
+        };
+      })
+      .filter((group) => group.weeksMissed > 0)
+      .sort((a, b) => b.weeksMissed - a.weeksMissed);
+
+    return { weekStarts: weekStartIsoList, groups };
+  }
+
+  private getReportingWeekStarts(from: Date, to: Date): Date[] {
+    const weeks: Date[] = [];
+    let cursor = this.getStartOfWeek(from);
+    const lastWeekStart = this.getStartOfWeek(to);
+
+    while (cursor <= lastWeekStart) {
+      weeks.push(new Date(cursor));
+      cursor = new Date(cursor);
+      cursor.setDate(cursor.getDate() + 7);
+    }
+    return weeks;
+  }
+
+  private subtractWeeks(date: Date, weeks: number): Date {
+    const result = new Date(date);
+    result.setDate(result.getDate() - weeks * 7);
+    return result;
+  }
+
+  private async getMcLeaderNamesByGroupId(groupIds: number[]) {
+    const leaderMemberships = await this.groupMembershipRepo.find({
+      where: {
+        groupId: In(groupIds),
+        role: GroupRole.Leader,
+        isActive: true,
+        group: { tenant: { id: this.tenantContext.requireTenant() } as any },
+      },
+    });
+    if (leaderMemberships.length === 0) {
+      return new Map();
+    }
+
+    const contactIds = [...new Set(leaderMemberships.map((m) => m.contactId))];
+    const nameByContactId = await this.fetchContactNames(contactIds);
+
+    const leaderNameByGroupId = new Map<number, string>();
+    for (const membership of leaderMemberships) {
+      // A group could have more than one active leader; first one wins —
+      // consistent with how the rest of this file treats "the" MC leader.
+      if (!leaderNameByGroupId.has(membership.groupId)) {
+        leaderNameByGroupId.set(
+          membership.groupId,
+          nameByContactId.get(membership.contactId) ?? 'Unknown leader',
+        );
+      }
+    }
+    return leaderNameByGroupId;
   }
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1818,7 +1818,10 @@ export class ReportsService {
     const rangeEnd = to ?? new Date();
     const rangeStart =
       from ??
-      this.subtractWeeks(rangeEnd, ReportsService.COMPLIANCE_MAX_WEEKS_LOOKBACK);
+      this.subtractWeeks(
+        rangeEnd,
+        ReportsService.COMPLIANCE_MAX_WEEKS_LOOKBACK - 1,
+      );
 
     const weekStarts = this.getReportingWeekStarts(rangeStart, rangeEnd);
     if (weekStarts.length === 0) {


### PR DESCRIPTION
# Summary of changes
- Adds `ReportsService.getMcSubmissionCompliance(user, from?, to?)`, which computes MC Attendance Report submission status per MC group/leader across a range of reporting weeks (Sunday-start).
- Scopes results to the caller's manageable groups via the existing `getUserManageableGroups(user)` helper (same scoping used by `getWeeklyMcaSummary` and `getMyGroupsSubmissions`) so leaders only ever see MCs within their own hierarchy.
- Only returns groups with at least one missed reporting week in range — fully compliant groups are excluded from the response entirely, since this endpoint answers "who hasn't submitted," not "everyone's status."
- Adds `GET /reports/mc/compliance?from=&to=` route, following the same controller conventions as the existing `GET /reports/mca/weekly-summary` route (`@Header('Cache-Control', 'no-store')`, `apiLog`, `request.user`).
- Refactors `fetchMemberSelectorContactNames`'s inline contact-name query into a shared `fetchContactNames(contactIds)` helper, reused by the new `getMcLeaderNamesByGroupId` to avoid duplicating the contact/person query.
- Adds `COMPLIANCE_MAX_WEEKS_LOOKBACK = 12` as the default lookback window when `from` is omitted (i.e. the "all time" filter), to keep the query bounded and the result meaningful.
- **Timezone/date-boundary fix (bundled into this PR because `getMcSubmissionCompliance` shares the same week-boundary logic as `getWeeklyMcaSummary`, and both need to be correct together):**
  - `getStartOfWeek` previously derived the week-start `Date` using local-time getters (`setHours`, `getDay()`), then callers formatted it with `.toISOString().slice(0, 10)`. For any tenant running ahead of UTC (e.g. Africa/Kampala, UTC+3), converting a local midnight to UTC silently rolls the date back a day, so the `reportingPeriod` string written at submit time did not reliably match the calendar week a submission actually belonged to.
  - Replaced the ad hoc `.toISOString().slice(0, 10)` formatting throughout the file with a single `formatDateKey(date)` helper that reads **local** calendar fields (`getFullYear`/`getMonth`/`getDate`), so week-boundary strings are computed consistently everywhere they're used (`submitReport`, `getWeeklyMcaSummary`, `getMcSubmissionCompliance`).
  - More importantly: **`getWeeklyMcaSummary` and `getMcSubmissionCompliance` no longer match against the stored `reportingPeriod` string at all.** They now query the real `submittedAt` timestamp column directly (`Between`/range comparison) and bucket submissions into weeks live, at read time, using the current `getStartOfWeek`. This makes both endpoints immune to any future change in how `reportingPeriod` is computed or formatted — a submission's week is always derived from its actual timestamp, not from a precomputed string that could go stale if the formula ever changes again. `reportingPeriod` itself is left untouched for `submitReport`'s duplicate-submission-per-week check, which is a write-time concern and unaffected by this.
  - Added regression tests: `getWeeklyMcaSummary` now includes a submittedAt-boundary test (submission at 23:59:59 on the last day of the week must still count, guarding the exclusive-upper-bound query), and `getMcSubmissionCompliance` includes a test asserting a submission with a deliberately stale/wrong `reportingPeriod` is still bucketed correctly via its `submittedAt`.
- Adds unit tests covering: visibility scoping (no manageable groups → empty result, never queries MC groups), missing MC Attendance Report handling, exclusion of fully-compliant groups, correct sorting/aggregation of partially-compliant groups, `missingCurrentWeek` flag correctness, the "No leader assigned" fallback, and the two date-boundary regressions above.

# How should this be tested? [Screenshots, Video or Type instructions]
1. Run the new test suite: `describe('getMcSubmissionCompliance', ...)` and the updated `describe('getWeeklyMcaSummary', ...)` in `reports.service.spec.ts`.
2. Manually hit `GET /reports/mc/compliance` as a user who manages a subset of MC groups and confirm the response only contains those groups, never groups outside their hierarchy.
3. Manually hit the same endpoint as a user with no manageable groups and confirm `{ weekStarts: [...], groups: [] }` is returned, not an error.
4. Submit an MC Attendance Report for a given group/week, then confirm that group drops out of the compliance response for that week on the next call, **and** that `GET /reports/mca/weekly-summary` reflects it too — test this on a server where `TZ` is not `UTC` (e.g. `Africa/Kampala`) to exercise the actual bug this PR fixes.
5. Test `from`/`to` omitted entirely and confirm the lookback is capped at 12 weeks rather than scanning all history.
6. Confirm a group with no active leader membership returns `leaderName: 'No leader assigned'` rather than throwing.
7. Submit a report late in the week (e.g. Saturday night, local time) and confirm it's still counted in that week's summary/compliance rather than silently attributed to the wrong week.

# Notes for reviewers
- `getMcSubmissionCompliance` deliberately filters out compliant groups before returning (`.filter((group) => group.weeksMissed > 0)`) — this was a fix from an earlier draft that returned everyone's status and let the frontend decide, which was the wrong place to encode "not submitted" semantics.
- Visibility relies entirely on `getUserManageableGroups(user)` already being correct/trusted — this PR doesn't change that helper, only reuses it, consistent with `getWeeklyMcaSummary`.
- `getMcLeaderNamesByGroupId` assumes at most one meaningful "leader" per group and takes the first active `GroupRole.Leader` membership found; if co-leadership needs to be reflected (e.g. showing multiple names), that's a follow-up, not addressed here.
- The `fetchContactNames` extraction is a pure refactor of existing logic (no behavior change to `fetchMemberSelectorContactNames`) — flagging in case reviewers want to diff that separately from the new compliance logic.
- **On the date-boundary fix:** existing `reportingPeriod` values already persisted in the database from before this fix may not match what `formatDateKey`/`getStartOfWeek` would compute for the same submission today. This PR does not backfill historical `reportingPeriod` values — it sidesteps the problem for reads by no longer trusting that column for `getWeeklyMcaSummary`/`getMcSubmissionCompliance`. `submitReport`'s weekly-duplicate check still reads/writes `reportingPeriod` directly, so a very small number of submissions made right at a week boundary under the old formula could theoretically still allow (or block) a duplicate submission inconsistently with today's formula. If that turns out to matter, a follow-up backfill migration is straightforward but is intentionally left out of this PR to keep the diff focused.
- Recommend setting `TZ=UTC` in the server's deployment environment as a follow-up, independent of this PR — `getWeekNumber` elsewhere in this file still uses local-time `Date` getters and could develop the same class of bug later if the server's local timezone isn't UTC.

# Out of scope
- Any notification/reminder dispatch to non-compliant leaders (this PR only surfaces read data).
- Configurability of `COMPLIANCE_MAX_WEEKS_LOOKBACK` per tenant (currently a hardcoded constant).
- Supporting reporting cadences other than weekly (this assumes the MC Attendance Report is always weekly, consistent with the rest of the file).
- Co-leader support in `getMcLeaderNamesByGroupId`.
- Backfilling historical `reportingPeriod` values written under the old (pre-fix) formula.
- Fixing `getWeekNumber`'s local-time date handling (unrelated code path, not touched by this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compliance report for monitoring missed weekly MC submissions.
  * Supports optional date-range filtering and displays week-by-week submission status.
  * Includes accessible groups, leaders, total submissions, missed weeks, and current-week compliance.

* **Bug Fixes**
  * Improved weekly reporting boundaries to accurately include submissions through the end of each week.
  * Ensured compliance results remain accurate when reporting-period metadata is missing or outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->