### PR TITLE
fix: set explicit socket.io path on NotificationsGateway

### DIFF
--- a/src/notifications/notifications.gateway.ts
+++ b/src/notifications/notifications.gateway.ts
@@ -11,6 +11,7 @@ import { JwtService } from '@nestjs/jwt';
 @Injectable()
 @WebSocketGateway({
   namespace: '/notifications',
+  path: '/server/socket.io',
   cors: {
     origin: process.env.FRONTEND_ORIGIN?.split(',').map((o) => o.trim()) ?? false,
     credentials: true,


### PR DESCRIPTION
## Summary of changes
 
- Added an explicit `path: '/server/socket.io'` option to `@WebSocketGateway` on `NotificationsGateway`.

## How should this be tested?
- Confirm that the console.log errors is no longer showing up in staging
-
## Notes for reviewers
 
- Server fix for the websocket error appearing in the console

## Out of scope
 
- REST API 400 errors on `/server//api/dashboard/summary` and `/server//api/notifications` seen in the same console log — separate double-slash bug in the client's base URL handling, tracked separately.
- Any reverse proxy / ingress configuration changes required to route `/server/socket.io` — flagged above for reviewer awareness but not made as part of this change.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the notifications real-time connection path for improved compatibility and connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->