### PR TITLE
Normalize Contacts CSV headers to accept human-readable labels

### DIFF
--- a/src/crm/contollers/contact-import.controller.spec.ts
+++ b/src/crm/contollers/contact-import.controller.spec.ts
@@ -3,6 +3,10 @@ import {
   parseDateOfBirth,
   parseName,
 } from '../utils/importUtils';
+import {
+  mapContactHeaders,
+  DuplicateContactHeaderError,
+} from './contact-import.controller';
 
 describe('ContactImportController', () => {
   it('parseContacts create a person', async () => {
@@ -72,5 +76,69 @@ describe('ContactImportController', () => {
     expect(parseDateOfBirth('20/12')).toEqual('1900-12-20');
     expect(parseDateOfBirth('31/March')).toEqual('1900-03-31');
     expect(parseDateOfBirth('3/9/1996')).toEqual('1996-09-03');
+  });
+});
+describe('mapContactHeaders', () => {
+  it('maps human-readable headers to canonical camelCase keys', () => {
+    expect(
+      mapContactHeaders([
+        'First Name',
+        'Last Name',
+        'Email',
+        'Phone',
+        'Date of Birth',
+        'Gender',
+        'District',
+        'Country',
+        'Group ID',
+      ]),
+    ).toEqual([
+      'firstName',
+      'lastName',
+      'email',
+      'phone',
+      'dateOfBirth',
+      'gender',
+      'district',
+      'country',
+      'groupId',
+    ]);
+  });
+
+  it('is tolerant of separator and casing variants', () => {
+    expect(
+      mapContactHeaders(['first_name', 'LAST-NAME', 'DateOfBirth']),
+    ).toEqual(['firstName', 'lastName', 'dateOfBirth']);
+  });
+
+  it('strips a leading BOM from the first header', () => {
+    expect(mapContactHeaders(['\uFEFFFirst Name', 'Last Name'])).toEqual([
+      'firstName',
+      'lastName',
+    ]);
+  });
+
+  it('passes unknown headers through unchanged', () => {
+    expect(
+      mapContactHeaders(['First Name', 'Favorite Color', 'groupName']),
+    ).toEqual(['firstName', 'Favorite Color', 'groupName']);
+  });
+
+  it('throws when two headers resolve to the same canonical field', () => {
+    expect(() =>
+      mapContactHeaders(['Email', 'email', 'First Name']),
+    ).toThrow(DuplicateContactHeaderError);
+  });
+
+  it('throws for duplicate aliases with different original spellings', () => {
+    expect(() =>
+      mapContactHeaders(['Group ID', 'groupid', 'First Name']),
+    ).toThrow(/Duplicate column for "groupId"/);
+  });
+
+  it('does not treat repeated unknown headers as duplicates', () => {
+    expect(() =>
+      mapContactHeaders(['Notes', 'Notes', 'First Name']),
+    ).not.toThrow();
   });
 });

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -57,6 +57,33 @@ const CONTACT_HEADER_ALIASES: Record<string, string> = {
   groupid: 'groupId',
 };
 
+const CANONICAL_CONTACT_KEYS = new Set(Object.values(CONTACT_HEADER_ALIASES));
+
+export class DuplicateContactHeaderError extends Error {
+  constructor(public readonly field: string) {
+    super(`Duplicate column for "${field}" found in CSV headers.`);
+  }
+}
+
+// Wraps normalizeContactHeader with per-parse duplicate detection: if two
+// input headers resolve to the same canonical field (e.g. "Email" and
+// "email", or "Group ID" and "groupId"), csv-parse would otherwise silently
+// keep only the last column's values. Reject the file instead. Unrecognized
+// headers are passed through unchanged and are never treated as duplicates.
+export function mapContactHeaders(headers: string[]): string[] {
+  const seenCanonical = new Set<string>();
+  return headers.map((header) => {
+    const mapped = normalizeContactHeader(header);
+    if (CANONICAL_CONTACT_KEYS.has(mapped)) {
+      if (seenCanonical.has(mapped)) {
+        throw new DuplicateContactHeaderError(mapped);
+      }
+      seenCanonical.add(mapped);
+    }
+    return mapped;
+  });
+}
+
 function normalizeContactHeader(header: string): string {
   const key = header
     .replace(/^\uFEFF/, '')
@@ -104,12 +131,15 @@ export class ContactImportController {
     let list: any[];
     try {
       list = parseCsv(file.buffer, {
-        columns: (headers: string[]) => headers.map(normalizeContactHeader),
+        columns: mapContactHeaders,
         skip_empty_lines: true,
         delimiter: ',',
         relax_column_count: false,
       }) as any[];
     } catch (parseErr) {
+      if (parseErr instanceof DuplicateContactHeaderError) {
+        throw new BadRequestException({ message: parseErr.message });
+      }
       throw new BadRequestException({
         message:
           'The CSV file could not be parsed. Please ensure every row has a value for each column and that the file uses comma-separated format.',
@@ -210,12 +240,15 @@ export class ContactImportController {
     let list: any[];
     try {
       list = parseCsv(file.buffer, {
-        columns: (headers: string[]) => headers.map(normalizeContactHeader),
+        columns: mapContactHeaders,
         skip_empty_lines: true,
         delimiter: ',',
         relax_column_count: false,
       }) as any[];
     } catch (parseErr) {
+      if (parseErr instanceof DuplicateContactHeaderError) {
+        throw new BadRequestException({ message: parseErr.message });
+      }
       throw new BadRequestException({
         message:
           'The CSV file could not be parsed. Please ensure every row has a value for each column and that the file uses comma-separated format.',

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -39,6 +39,32 @@ class Entity {
   email: string;
 }
 
+// parseContact()/getValueByKeys() already resolves firstName/lastName/email/phone/
+// dateOfBirth/gender headers case- and whitespace-insensitively. country, district,
+// and groupId are read directly off the raw row (see uploadFile/uploadGroupLeaders
+// below) and bypass that resolution, so we normalize headers here to keep those
+// direct reads working with human-readable CSV columns (e.g. "Country", "District").
+const CONTACT_HEADER_ALIASES: Record<string, string> = {
+  firstname: 'firstName',
+  lastname: 'lastName',
+  email: 'email',
+  phone: 'phone',
+  dateofbirth: 'dateOfBirth',
+  gender: 'gender',
+  district: 'district',
+  country: 'country',
+  address: 'address',
+  groupid: 'groupId',
+};
+
+function normalizeContactHeader(header: string): string {
+  const key = header
+    .replace(/^\uFEFF/, '')
+    .replace(/[\s_-]/g, '')
+    .toLowerCase();
+  return CONTACT_HEADER_ALIASES[key] ?? header;
+}
+
 @UseInterceptors(SentryInterceptor, TenantContextInterceptor)
 @UseGuards(JwtAuthGuard)
 @ApiTags('Crm Contacts')
@@ -78,7 +104,7 @@ export class ContactImportController {
     let list: any[];
     try {
       list = parseCsv(file.buffer, {
-        columns: true,
+        columns: (headers: string[]) => headers.map(normalizeContactHeader),
         skip_empty_lines: true,
         delimiter: ',',
         relax_column_count: false,
@@ -184,7 +210,7 @@ export class ContactImportController {
     let list: any[];
     try {
       list = parseCsv(file.buffer, {
-        columns: true,
+        columns: (headers: string[]) => headers.map(normalizeContactHeader),
         skip_empty_lines: true,
         delimiter: ',',
         relax_column_count: false,


### PR DESCRIPTION
# Normalize CSV headers for Contacts import (backend)

## Summary of Changes
- Added `normalizeContactHeader` / `CONTACT_HEADER_ALIASES` to `contact-import.controller.ts`, applied via `csv-parse`'s `columns` option (function form) in both `uploadFile` and `uploadGroupLeaders`.
- This maps incoming CSV headers (case/whitespace/separator-insensitive, e.g. `"First Name"`, `"first_name"`, `"firstName"`) to the canonical camelCase keys the rest of the pipeline expects.
- Needed specifically because `country`, `district`, `groupId`, and (in `uploadGroupLeaders`) `email` are read directly off the raw parsed row (`uploadedContact.country`, etc.) rather than through `parseContact`/`getValueByKeys`, which already did case/whitespace-insensitive resolution for `firstName`/`lastName`/`email`/`phone`/`dateOfBirth`/`gender`. Those direct-access fields would otherwise silently break once the frontend template switched to human-readable headers.

## How This Should Be Tested
- Upload a Contacts CSV using the new human-readable template (`First Name,Last Name,Email,Phone,Date of Birth,Gender,District,Country`) via `POST /api/crm/import` and confirm contacts are created with correct `country`/`district` on the residence record and correct `groupId` resolution.
- Upload a CSV with the old camelCase headers and confirm behavior is unchanged (no regression).
- Upload a CSV mixing header styles (e.g. `First Name`, `email`, `Country`) and confirm all fields resolve correctly.
- Test `POST /api/crm/import/groupLeaders` with a human-readable header CSV, confirming `groupId`/`email` (used for the created user's username) resolve correctly. Note `groupName`/`groupParentId` are unaffected — still camelCase-only.
- Confirm a CSV with a totally unrecognized header (not required, not in the alias map) still parses and is simply ignored/unset, without throwing.

## Note for Reviewers
- Deliberately did **not** touch `parseContact`/`getValueByKeys` in `importUtils.ts` — they already handle case/whitespace-insensitive matching for their fields, and duplicating that logic risked inconsistent alias resolution between the two mechanisms. The new alias map only covers the fields that bypass `parseContact` via direct property access.
- Pairs with the companion client PR that updates the Contacts CSV template and help text to human-readable headers — this PR is what makes that template actually work end-to-end.
- `Entity` class near the top of the controller is pre-existing, unused by anything touched here — left as-is.

## Out of Scope
- `groupName` / `groupParentId` (used only in `uploadGroupLeaders` when no `groupId` is given) are not in the alias map and remain camelCase-only. Flagged as a possible follow-up if Group Leaders bulk upload needs the same human-readable treatment.
- `parseDateOfBirth`'s silent `null`-on-unparseable-date behavior (no warning surfaced, unlike `ServiceRecordingService`'s `parseDate`) is unchanged — not part of this ticket.
- No changes made to `service-recording.service.ts` (Guests/Believers/Red Zone) — its `col()`-based lowercase header matching already handles human-readable headers correctly and needed no fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV imports for contacts and group leaders by recognizing column headers regardless of capitalization, spacing, separators, or a leading BOM.
  * Added support for common header aliases, including `firstname`, `groupid`, and `dateofbirth`.
  * Duplicate recognized columns and aliases now produce a clear import error instead of overwriting data.
  * Unknown headers continue to pass through, and existing row processing remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->