### PR TITLE
Fix/report submission period alignment

### DIFF
--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -599,7 +599,7 @@ describe('ReportsService', () => {
       expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            report: { id: 1 },
+            report: { id: 1, tenant: { id: 1 } },
             group: { id: 10 },
             reportingPeriod: currentPeriod,
           }),
@@ -655,7 +655,7 @@ describe('ReportsService', () => {
       expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            report: { id: 1 },
+            report: { id: 1, tenant: { id: 1 } },
             group: { id: 11 },
             reportingPeriod: currentPeriod,
           }),
@@ -686,7 +686,7 @@ describe('ReportsService', () => {
       expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            report: { id: 1 },
+            report: { id: 1, tenant: { id: 1 } },
             user: { id: 7 },
             reportingPeriod: currentPeriod,
           }),

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -99,6 +99,22 @@ describe('ReportsService', () => {
         return mockRepositories.report;
       }),
       getTreeRepository: jest.fn().mockReturnValue(mockRepositories.groupTree),
+      transaction: jest.fn(async (work: any) => {
+        const manager = {
+          save: jest.fn((entity: any, entityOrEntities: any) => {
+            if (entity === ReportSubmission) {
+              return mockRepositories.reportSubmission.save(entityOrEntities);
+            }
+            if (entity === ReportSubmissionData) {
+              return mockRepositories.reportSubmissionData.save(
+                entityOrEntities,
+              );
+            }
+            throw new Error(`Unexpected entity passed to manager.save`);
+          }),
+        };
+        return work(manager);
+      }),
     };
 
     // Create mock services
@@ -891,6 +907,161 @@ describe('ReportsService', () => {
       );
       expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
         expect.objectContaining({ reportingPeriod: currentMonthPeriod }),
+      );
+    });
+  });
+  describe('submitReport - transactional integrity', () => {
+    const mockUser = { id: 7, contactId: 3 } as any;
+    const savedUser = { id: 7, contactId: 3, username: 'shepherd@example.com' };
+    const makeGroup = (id: number, name: string) => ({ id, name }) as Group;
+
+    const baseReport = {
+      id: 1,
+      name: 'Weekly Report',
+      status: ReportStatus.ACTIVE,
+      submissionFrequency: 'weekly',
+      groupFieldName: 'groupId',
+      targetGroupCategory: undefined,
+      fields: [],
+    } as unknown as Report;
+
+    beforeEach(() => {
+      mockRepositories.report.findOne.mockResolvedValue(baseReport);
+      mockRepositories.user.findOne.mockResolvedValue(savedUser);
+      mockRepositories.groupTree.findOne.mockResolvedValue(
+        makeGroup(10, 'MC Nairobi'),
+      );
+      mockRepositories.groupMembership.findOne.mockResolvedValue({
+        group: { id: 10, category: undefined },
+      });
+      mockGroupPermissionsService.hasPermissionForGroup = jest
+        .fn()
+        .mockResolvedValue(true);
+      mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+      mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
+        Promise.resolve({ id: 99, ...sub }),
+      );
+      mockRepositories.reportSubmissionData.save.mockResolvedValue([]);
+    });
+
+    it('rejects an unknown field name before any row is saved, so no submission is left occupying the period', async () => {
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+
+      await expect(
+        service.submitReport(
+          1,
+          { data: { groupId: '10', bogusField: 'x' } },
+          mockUser,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockConnection.transaction).not.toHaveBeenCalled();
+      expect(mockRepositories.reportSubmission.save).not.toHaveBeenCalled();
+      expect(mockRepositories.reportSubmissionData.save).not.toHaveBeenCalled();
+    });
+
+    it('saves the submission row and its field data inside a single transaction', async () => {
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+        { name: 'notes' },
+      ]);
+
+      const result = await service.submitReport(
+        1,
+        { data: { groupId: '10', notes: 'all good' } },
+        mockUser,
+      );
+
+      expect(result.status).toBe(200);
+      expect(mockConnection.transaction).toHaveBeenCalledTimes(1);
+      expect(mockRepositories.reportSubmission.save).toHaveBeenCalledTimes(1);
+      expect(mockRepositories.reportSubmissionData.save).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            reportSubmission: expect.objectContaining({ id: 99 }),
+            reportField: { name: 'notes' },
+            fieldValue: 'all good',
+          }),
+        ]),
+      );
+    });
+
+    it('propagates a failure saving field data without swallowing it, so the transaction rolls back the submission row too', async () => {
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+      mockRepositories.reportSubmissionData.save.mockRejectedValueOnce(
+        new Error('data save failed'),
+      );
+
+      await expect(
+        service.submitReport(1, { data: { groupId: '10' } }, mockUser),
+      ).rejects.toThrow('data save failed');
+
+      // The submission row was written to the (mocked) transactional
+      // manager, but since the transaction as a whole rejects, TypeORM
+      // rolls it back -- it must never be treated as a successful,
+      // independently-committed row.
+      expect(mockConnection.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps a unique-constraint violation raised inside the transaction to a friendly duplicate-submission error', async () => {
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+      mockRepositories.reportSubmission.save.mockRejectedValueOnce({
+        code: '23505',
+      });
+
+      await expect(
+        service.submitReport(1, { data: { groupId: '10' } }, mockUser),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('computes and persists PGA in the same transaction for whmSundayService reports', async () => {
+      const sundayServiceReport = {
+        ...baseReport,
+        functionName: 'whmSundayService',
+      } as unknown as Report;
+      mockRepositories.report.findOne.mockResolvedValue(sundayServiceReport);
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+        { name: '1Sv' },
+        { name: '2Sv' },
+        { name: 'YXP' },
+        { name: 'kids' },
+        { name: 'local' },
+        { name: 'hc1' },
+        { name: 'hc2' },
+        { name: 'hc3' },
+        { name: 'pga' },
+      ]);
+
+      await service.submitReport(
+        1,
+        {
+          data: {
+            groupId: '10',
+            '1Sv': 100,
+            '2Sv': 50,
+            YXP: 10,
+            kids: 5,
+            local: 2,
+            hc1: 1,
+            hc2: 1,
+            hc3: 1,
+          },
+        },
+        mockUser,
+      );
+
+      expect(mockRepositories.reportSubmissionData.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reportField: { name: 'pga' },
+          fieldValue: '170',
+        }),
       );
     });
   });

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -8,7 +8,7 @@ import { GroupTreeService } from '../groups/services/group-tree.service';
 import { AppLogger } from '../utils/app-logger.service';
 import { TenantContext } from '../shared/tenant/tenant-context';
 import { FellowshipAttendanceService } from '../attendance/services/fellowship-attendance.service';
-import { Connection, Repository, TreeRepository } from 'typeorm';
+import { Connection, In, Repository, TreeRepository } from 'typeorm';
 import Contact from '../crm/entities/contact.entity';
 import { Report } from './entities/report.entity';
 import { ReportStatus } from './enums/report.enum';
@@ -35,7 +35,7 @@ describe('ReportsService', () => {
   let mockAppLogger: Partial<AppLogger>;
   let mockTenantContext: Partial<TenantContext>;
   let mockFellowshipAttendanceService: Partial<FellowshipAttendanceService>;
-  let mockNotificationsService:Partial<NotificationsService>;
+  let mockNotificationsService: Partial<NotificationsService>;
   let mockRepositories: any;
 
   beforeEach(async () => {
@@ -55,7 +55,7 @@ describe('ReportsService', () => {
         findOne: jest.fn(),
         save: jest.fn(),
         create: jest.fn(),
-        createQueryBuilder: jest.fn(), 
+        createQueryBuilder: jest.fn(),
       },
       reportSubmissionData: {
         find: jest.fn(),
@@ -67,7 +67,7 @@ describe('ReportsService', () => {
       reportField: {
         save: jest.fn(),
         find: jest.fn(),
-        createQueryBuilder: jest.fn(), 
+        createQueryBuilder: jest.fn(),
       },
       groupMembership: {
         find: jest.fn(),
@@ -154,7 +154,6 @@ describe('ReportsService', () => {
         security: jest.fn(),
         error: jest.fn(),
       }),
-      
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -193,7 +192,7 @@ describe('ReportsService', () => {
           useValue: mockFellowshipAttendanceService,
         },
         {
-          provide: NotificationsService, 
+          provide: NotificationsService,
           useValue: mockNotificationsService,
         },
       ],
@@ -516,6 +515,7 @@ describe('ReportsService', () => {
       id: 1,
       name: 'Weekly Report',
       status: ReportStatus.ACTIVE,
+      submissionFrequency: 'weekly',
       groupFieldName: 'groupId',
       targetGroupCategory: undefined,
       fields: [],
@@ -545,15 +545,35 @@ describe('ReportsService', () => {
         .mockResolvedValue(true);
     });
 
+    // Mirrors getStartOfWeek/formatDateKey in reports.service.ts rather
+    // than reaching into the service instance, since these are pure
+    // calendar-math helpers with no dependency on service state.
+    const formatDateKey = (date: Date): string => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
+    const currentPeriodStart = new Date();
+    currentPeriodStart.setHours(0, 0, 0, 0);
+    currentPeriodStart.setDate(
+      currentPeriodStart.getDate() - currentPeriodStart.getDay(),
+    );
+    const previousPeriodStart = new Date(currentPeriodStart);
+    previousPeriodStart.setDate(previousPeriodStart.getDate() - 7);
+    const currentPeriod = formatDateKey(currentPeriodStart);
+    const previousPeriod = formatDateKey(previousPeriodStart);
+
     it('blocks a second submission of the same report for the same group in the same week', async () => {
       mockRepositories.groupTree.findOne.mockResolvedValue(
         makeGroup(10, 'MC Nairobi'),
       );
-      // Simulate an existing submission already on file for group 10.
+      // The current week already has a submission on file for group 10.
       mockRepositories.reportSubmission.findOne.mockResolvedValue({
         id: 55,
         report: { id: 1 },
         group: { id: 10 },
+        reportingPeriod: currentPeriod,
       });
 
       await expect(
@@ -565,10 +585,35 @@ describe('ReportsService', () => {
           where: expect.objectContaining({
             report: { id: 1 },
             group: { id: 10 },
+            reportingPeriod: currentPeriod,
           }),
         }),
       );
       expect(mockRepositories.reportSubmission.save).not.toHaveBeenCalled();
+    });
+
+    it('allows the submission when the current week is not yet covered, even if last week was missed', async () => {
+      mockRepositories.groupTree.findOne.mockResolvedValue(
+        makeGroup(10, 'MC Nairobi'),
+      );
+      // Nothing on file for the current week -- whether or not last week
+      // was ever submitted is irrelevant for a report with no configured
+      // due day: it should never be silently reassigned to last week.
+      mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+
+      const result = await service.submitReport(
+        1,
+        { data: { groupId: '10' } },
+        mockUser,
+      );
+
+      expect(result.status).toBe(200);
+      expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
+        expect.objectContaining({ reportingPeriod: currentPeriod }),
+      );
     });
 
     it('allows submitting the same report again for a different group in the same week', async () => {
@@ -596,6 +641,7 @@ describe('ReportsService', () => {
           where: expect.objectContaining({
             report: { id: 1 },
             group: { id: 11 },
+            reportingPeriod: currentPeriod,
           }),
         }),
       );
@@ -614,6 +660,7 @@ describe('ReportsService', () => {
         id: 77,
         report: { id: 1 },
         user: { id: 7 },
+        reportingPeriod: currentPeriod,
       });
 
       await expect(
@@ -625,8 +672,225 @@ describe('ReportsService', () => {
           where: expect.objectContaining({
             report: { id: 1 },
             user: { id: 7 },
+            reportingPeriod: currentPeriod,
           }),
         }),
+      );
+    });
+
+    describe('MC Attendance Report due-day (Wednesday) handling', () => {
+      const mcReport = {
+        ...baseReport,
+        name: 'MC Attendance Report',
+      } as unknown as Report;
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it.each([
+        ['Sunday', 0],
+        ['Monday', 1],
+        ['Tuesday', 2],
+      ])(
+        'targets the previous week when submitting on %s (catch-up window)',
+        async (_label, dayOffset) => {
+          const day = new Date(currentPeriodStart);
+          day.setDate(day.getDate() + dayOffset);
+          jest.useFakeTimers().setSystemTime(day);
+          mockRepositories.report.findOne.mockResolvedValue(mcReport);
+          mockRepositories.groupTree.findOne.mockResolvedValue(
+            makeGroup(10, 'MC Nairobi'),
+          );
+          mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+          mockRepositories.reportField.find.mockResolvedValue([
+            { name: 'groupId' },
+          ]);
+
+          const result = await service.submitReport(
+            1,
+            { data: { groupId: '10' } },
+            mockUser,
+          );
+
+          expect(result.status).toBe(200);
+          expect(
+            mockRepositories.reportSubmission.findOne,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              where: expect.objectContaining({
+                reportingPeriod: previousPeriod,
+              }),
+            }),
+          );
+          expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
+            expect.objectContaining({ reportingPeriod: previousPeriod }),
+          );
+        },
+      );
+
+      it('targets the current week when submitting on the Wednesday due day, even if last week was missed', async () => {
+        const thisWeekWednesday = new Date(currentPeriodStart);
+        thisWeekWednesday.setDate(thisWeekWednesday.getDate() + 3);
+        jest.useFakeTimers().setSystemTime(thisWeekWednesday);
+        mockRepositories.report.findOne.mockResolvedValue(mcReport);
+        mockRepositories.groupTree.findOne.mockResolvedValue(
+          makeGroup(10, 'MC Nairobi'),
+        );
+        // Current week is open; whether last week has a submission must
+        // not matter -- an on-time Wednesday submission always targets
+        // this week, never gets silently redirected to last week.
+        mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+        mockRepositories.reportField.find.mockResolvedValue([
+          { name: 'groupId' },
+        ]);
+
+        const result = await service.submitReport(
+          1,
+          { data: { groupId: '10' } },
+          mockUser,
+        );
+
+        expect(result.status).toBe(200);
+        expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ reportingPeriod: currentPeriod }),
+          }),
+        );
+        expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
+          expect.objectContaining({ reportingPeriod: currentPeriod }),
+        );
+      });
+
+      it('rejects outright when the catch-up period is already filled, without falling back to another period', async () => {
+        jest.useFakeTimers().setSystemTime(currentPeriodStart); // Sunday
+        mockRepositories.report.findOne.mockResolvedValue(mcReport);
+        mockRepositories.groupTree.findOne.mockResolvedValue(
+          makeGroup(10, 'MC Nairobi'),
+        );
+        // Last week's (the catch-up target's) slot is already filled.
+        mockRepositories.reportSubmission.findOne.mockResolvedValue({
+          id: 54,
+          report: { id: 1 },
+          group: { id: 10 },
+          reportingPeriod: previousPeriod,
+        });
+
+        await expect(
+          service.submitReport(1, { data: { groupId: '10' } }, mockUser),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(mockRepositories.reportSubmission.save).not.toHaveBeenCalled();
+      });
+
+      it('a Sunday catch-up followed by an on-time Wednesday submission covers two distinct weeks, not one', async () => {
+        // End-to-end sequence for the exact frustration this feature fixes:
+        // forgetting last Wednesday, catching up on Sunday, then still
+        // being able to submit on time this Wednesday.
+        mockRepositories.report.findOne.mockResolvedValue(mcReport);
+        mockRepositories.groupTree.findOne.mockResolvedValue(
+          makeGroup(10, 'MC Nairobi'),
+        );
+        mockRepositories.reportField.find.mockResolvedValue([
+          { name: 'groupId' },
+        ]);
+
+        // Step 1: catch-up submission on this week's Sunday. Nothing on
+        // file yet for either period.
+        jest.useFakeTimers().setSystemTime(currentPeriodStart);
+        mockRepositories.reportSubmission.findOne.mockResolvedValueOnce(null);
+        const firstResult = await service.submitReport(
+          1,
+          { data: { groupId: '10' } },
+          mockUser,
+        );
+        expect(firstResult.status).toBe(200);
+        expect(mockRepositories.reportSubmission.save).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ reportingPeriod: previousPeriod }),
+        );
+
+        // Step 2: on-time submission on this week's Wednesday. The
+        // catch-up above only filled previousPeriod, so currentPeriod is
+        // still open.
+        const thisWeekWednesday = new Date(currentPeriodStart);
+        thisWeekWednesday.setDate(thisWeekWednesday.getDate() + 3);
+        jest.useFakeTimers().setSystemTime(thisWeekWednesday);
+        mockRepositories.reportSubmission.findOne.mockResolvedValueOnce(null);
+        const secondResult = await service.submitReport(
+          1,
+          { data: { groupId: '10' } },
+          mockUser,
+        );
+        expect(secondResult.status).toBe(200);
+        expect(mockRepositories.reportSubmission.save).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ reportingPeriod: currentPeriod }),
+        );
+      });
+    });
+
+    it('skips the period check entirely for custom-frequency reports', async () => {
+      const customReport = {
+        ...baseReport,
+        submissionFrequency: 'custom',
+      } as unknown as Report;
+      mockRepositories.report.findOne.mockResolvedValue(customReport);
+      mockRepositories.groupTree.findOne.mockResolvedValue(
+        makeGroup(10, 'MC Nairobi'),
+      );
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+
+      const result = await service.submitReport(
+        1,
+        { data: { groupId: '10' } },
+        mockUser,
+      );
+
+      expect(result.status).toBe(200);
+      // No lookup for prior submissions, and reportingPeriod is left unset.
+      expect(mockRepositories.reportSubmission.findOne).not.toHaveBeenCalled();
+      expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
+        expect.objectContaining({ reportingPeriod: undefined }),
+      );
+    });
+
+    it('targets the current calendar month for a monthly report (no configured due day, no backfill)', async () => {
+      const monthlyReport = {
+        ...baseReport,
+        submissionFrequency: 'monthly',
+      } as unknown as Report;
+      mockRepositories.report.findOne.mockResolvedValue(monthlyReport);
+      mockRepositories.groupTree.findOne.mockResolvedValue(
+        makeGroup(10, 'MC Nairobi'),
+      );
+      mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
+
+      const now = new Date();
+      const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+      const currentMonthPeriod = formatDateKey(currentMonthStart);
+
+      const result = await service.submitReport(
+        1,
+        { data: { groupId: '10' } },
+        mockUser,
+      );
+
+      expect(result.status).toBe(200);
+      expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            reportingPeriod: currentMonthPeriod,
+          }),
+        }),
+      );
+      expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
+        expect.objectContaining({ reportingPeriod: currentMonthPeriod }),
       );
     });
   });
@@ -640,7 +904,11 @@ describe('ReportsService', () => {
       fields: [],
     } as unknown as Report;
 
-    const mockTargetGroup = { id: 10, name: 'MC Nairobi', parentId: undefined } as Group;
+    const mockTargetGroup = {
+      id: 10,
+      name: 'MC Nairobi',
+      parentId: undefined,
+    } as Group;
 
     const reportId = 1;
     const submittingUser = { id: 7, contactId: 3 } as any;
@@ -649,15 +917,25 @@ describe('ReportsService', () => {
       (mockNotificationsService.create as jest.Mock).mockClear();
 
       mockRepositories.report.findOne.mockResolvedValue(baseReportWithGroup);
-      mockRepositories.user.findOne.mockResolvedValue({ id: 7, contactId: 3, username: 'shepherd@example.com' });
-      mockRepositories.groupMembership.findOne.mockResolvedValue({ group: { id: 10, category: undefined } });
-      mockGroupPermissionsService.hasPermissionForGroup = jest.fn().mockResolvedValue(true);
+      mockRepositories.user.findOne.mockResolvedValue({
+        id: 7,
+        contactId: 3,
+        username: 'shepherd@example.com',
+      });
+      mockRepositories.groupMembership.findOne.mockResolvedValue({
+        group: { id: 10, category: undefined },
+      });
+      mockGroupPermissionsService.hasPermissionForGroup = jest
+        .fn()
+        .mockResolvedValue(true);
       mockRepositories.groupTree.findOne.mockResolvedValue(mockTargetGroup);
       mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
       mockRepositories.reportSubmission.save.mockImplementation((sub: any) =>
         Promise.resolve({ id: 99, ...sub }),
       );
-      mockRepositories.reportField.find.mockResolvedValue([{ name: 'groupId' }]);
+      mockRepositories.reportField.find.mockResolvedValue([
+        { name: 'groupId' },
+      ]);
 
       jest
         .spyOn(service as any, 'resolveReportSubmissionRecipients')
@@ -665,7 +943,11 @@ describe('ReportsService', () => {
     });
 
     it('dispatches a notification per resolved recipient and tolerates individual failures', async () => {
-      await service.submitReport(reportId, { data: { groupId: '10' } }, submittingUser);
+      await service.submitReport(
+        reportId,
+        { data: { groupId: '10' } },
+        submittingUser,
+      );
 
       expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
       expect(mockNotificationsService.create).toHaveBeenCalledWith(
@@ -747,7 +1029,11 @@ describe('ReportsService', () => {
     });
 
     it('returns zero total when the MCA field exists but user manages no groups', async () => {
-      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
       const fieldQb = makeQueryBuilder(field, 'getOne');
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(fieldQb);
       mockRepositories.groupMembership.find.mockResolvedValue([]);
@@ -767,12 +1053,18 @@ describe('ReportsService', () => {
     });
 
     it('sums attendance across groups the user manages for the single MCA field', async () => {
-      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(field, 'getOne'),
       );
 
-      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
       mockGroupTreeService.getGroupAndAllChildren = jest
         .fn()
         .mockResolvedValue([10, 11]);
@@ -815,27 +1107,26 @@ describe('ReportsService', () => {
             params.groupIds.includes(11),
         ),
       ).toBe(true);
-      // Must filter by a submittedAt range (lower bound inclusive, upper bound
-      // exclusive), not the historical reportingPeriod string — this is the
-      // fix that makes the summary immune to any past reportingPeriod-format
-      // drift, since submittedAt is a real timestamp that's never rewritten.
+      // Must filter by reportingPeriod equal to this week's start, not a
+      // submittedAt range -- reportingPeriod is the period submitReport
+      // deliberately assigned (including MC's Wednesday catch-up window),
+      // so it's the authoritative "which week" answer, not just when the
+      // row was physically typed in.
       expect(
         andWhereCalls.some(
           ([sql, params]) =>
-            sql.includes('submittedAt >=') && params?.weekStart instanceof Date,
-        ),
-      ).toBe(true);
-      expect(
-        andWhereCalls.some(
-          ([sql, params]) =>
-            /submittedAt\s*<(?!=)/.test(sql) &&
-            params?.weekEndExclusive instanceof Date,
+            sql.includes('submission.reportingPeriod =') &&
+            typeof params?.period === 'string',
         ),
       ).toBe(true);
     });
 
     it('aggregates multiple submissions for the same group into a single breakdown entry (roll-up scenario)', async () => {
-      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(field, 'getOne'),
       );
@@ -868,11 +1159,17 @@ describe('ReportsService', () => {
     });
 
     it('skips non-numeric field values without throwing or affecting the total', async () => {
-      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(field, 'getOne'),
       );
-      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
       mockGroupTreeService.getGroupAndAllChildren = jest
         .fn()
         .mockResolvedValue([10]);
@@ -891,18 +1188,26 @@ describe('ReportsService', () => {
     });
 
     it('rejects values with a numeric prefix followed by trailing text (e.g. "15 attendees")', async () => {
-      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(field, 'getOne'),
       );
-      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
       mockGroupTreeService.getGroupAndAllChildren = jest
         .fn()
         .mockResolvedValue([10]);
       const submissions = [
         {
           group: { id: 10, name: 'MC Nairobi' },
-          submissionData: [{ reportField: { id: 1 }, fieldValue: '15 attendees' }],
+          submissionData: [
+            { reportField: { id: 1 }, fieldValue: '15 attendees' },
+          ],
         },
       ];
       mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
@@ -913,14 +1218,18 @@ describe('ReportsService', () => {
       expect(result.breakdown).toEqual([]);
     });
 
-    it('computes a 7-day, exclusive-upper-bound submittedAt window', async () => {
-      // Verifies the query window spans exactly 7 days with an exclusive
-      // upper bound (weekEndExclusive is the start of the following week).
-      const field = { id: 1, label: 'How many attended MC?', report: { id: 100 } };
+    it("filters submissions by the current week's reportingPeriod, matching the displayed weekStart", async () => {
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
       mockRepositories.reportField.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(field, 'getOne'),
       );
-      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
       mockGroupTreeService.getGroupAndAllChildren = jest
         .fn()
         .mockResolvedValue([10]);
@@ -938,19 +1247,10 @@ describe('ReportsService', () => {
       const result = await service.getWeeklyMcaSummary(mockUser);
 
       expect(result.total).toBe(12);
-      // weekEndExclusive must be strictly after weekEnd (the inclusive display
-      // date), i.e. the start of the following week.
-      const weekStartCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
-        sql.includes('submittedAt >='),
+      const periodCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
+        sql.includes('submission.reportingPeriod ='),
       );
-      const weekEndCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
-        /submittedAt\s*<(?!=)/.test(sql),
-      );
-      const daysBetween =
-        (weekEndCall[1].weekEndExclusive.getTime() -
-          weekStartCall[1].weekStart.getTime()) /
-        (1000 * 60 * 60 * 24);
-      expect(daysBetween).toBe(7);
+      expect(periodCall[1].period).toBe(result.weekStart);
     });
   });
   describe('getMcSubmissionCompliance', () => {
@@ -986,7 +1286,9 @@ describe('ReportsService', () => {
 
     it('returns no groups when the user manages no groups (visibility scoping)', async () => {
       mockRepositories.groupMembership.find.mockResolvedValue([]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([]);
 
       const result = await service.getMcSubmissionCompliance(mockUser);
 
@@ -996,8 +1298,12 @@ describe('ReportsService', () => {
     });
 
     it('only queries MC groups within the user-scoped group id list', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
       mockRepositories.groupTree.find.mockResolvedValue([]); // no MC groups found
 
       await service.getMcSubmissionCompliance(mockUser);
@@ -1005,15 +1311,21 @@ describe('ReportsService', () => {
       expect(mockRepositories.groupTree.find).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            id: expect.objectContaining({ value: expect.arrayContaining([10]) }),
+            id: expect.objectContaining({
+              value: expect.arrayContaining([10]),
+            }),
           }),
         }),
       );
     });
 
     it('returns no groups when the MC Attendance Report does not exist', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValue([{ groupId: 10 }]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
       mockRepositories.groupTree.find.mockResolvedValue([
         { id: 10, name: 'MC Nairobi' },
       ]);
@@ -1027,8 +1339,12 @@ describe('ReportsService', () => {
     });
 
     it('excludes MC groups that submitted for every week in range', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
       mockRepositories.groupTree.find.mockResolvedValue([
         { id: 10, name: 'MC Nairobi' },
       ]);
@@ -1037,13 +1353,13 @@ describe('ReportsService', () => {
       );
 
       const from = new Date('2026-07-26'); // Sunday
-      const to = new Date('2026-08-01');   // same reporting week
-      // submittedAt (not reportingPeriod) is what the service now buckets on —
-      // this timestamp falls within the 2026-07-26 reporting week.
+      const to = new Date('2026-08-01'); // same reporting week
+      // reportingPeriod (not submittedAt) is what the service buckets on.
       mockRepositories.reportSubmission.find.mockResolvedValue([
         {
           group: { id: 10 },
           submittedAt: new Date('2026-07-28T09:00:00Z'),
+          reportingPeriod: '2026-07-26',
         },
       ]);
       mockRepositories.groupMembership.find.mockResolvedValueOnce([
@@ -1055,7 +1371,11 @@ describe('ReportsService', () => {
         ]),
       );
 
-      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+      const result = await service.getMcSubmissionCompliance(
+        mockUser,
+        from,
+        to,
+      );
 
       expect(result.groups).toEqual([]);
     });
@@ -1084,9 +1404,9 @@ describe('ReportsService', () => {
       const from = new Date('2026-07-19');
       const to = new Date('2026-07-26');
       mockRepositories.reportSubmission.find.mockResolvedValue([
-        { group: { id: 10 }, submittedAt: new Date('2026-07-21T10:00:00Z') },
-        { group: { id: 10 }, submittedAt: new Date('2026-07-28T10:00:00Z') },
-        { group: { id: 12 }, submittedAt: new Date('2026-07-21T10:00:00Z') },
+        { group: { id: 10 }, reportingPeriod: '2026-07-19' },
+        { group: { id: 10 }, reportingPeriod: '2026-07-26' },
+        { group: { id: 12 }, reportingPeriod: '2026-07-19' },
       ]);
       mockRepositories.groupMembership.find.mockResolvedValueOnce([
         { groupId: 11, contactId: 77 },
@@ -1099,7 +1419,11 @@ describe('ReportsService', () => {
         ]),
       );
 
-      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+      const result = await service.getMcSubmissionCompliance(
+        mockUser,
+        from,
+        to,
+      );
 
       expect(result.groups).toHaveLength(2);
       expect(result.groups.map((g) => g.groupId)).toEqual([11, 12]);
@@ -1120,8 +1444,12 @@ describe('ReportsService', () => {
     });
 
     it('flags missingCurrentWeek only when the most recent week is among the missed weeks', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
       mockRepositories.groupTree.find.mockResolvedValue([
         { id: 10, name: 'MC Nairobi' },
       ]);
@@ -1133,7 +1461,7 @@ describe('ReportsService', () => {
       const to = new Date('2026-07-26'); // current week starts 2026-07-26
       // Submitted the earlier week, missed the current one.
       mockRepositories.reportSubmission.find.mockResolvedValue([
-        { group: { id: 10 }, submittedAt: new Date('2026-07-21T10:00:00Z') },
+        { group: { id: 10 }, reportingPeriod: '2026-07-19' },
       ]);
       mockRepositories.groupMembership.find.mockResolvedValueOnce([
         { groupId: 10, contactId: 55 },
@@ -1144,15 +1472,23 @@ describe('ReportsService', () => {
         ]),
       );
 
-      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+      const result = await service.getMcSubmissionCompliance(
+        mockUser,
+        from,
+        to,
+      );
 
       expect(result.groups[0].missingCurrentWeek).toBe(true);
       expect(result.groups[0].missedWeeks).toEqual(['2026-07-26']);
     });
 
     it('falls back to "No leader assigned" when an MC has no active leader', async () => {
-      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
       mockRepositories.groupTree.find.mockResolvedValue([
         { id: 10, name: 'MC Nairobi' },
       ]);
@@ -1170,17 +1506,23 @@ describe('ReportsService', () => {
       );
 
       expect(result.groups[0].leaderName).toBe('No leader assigned');
-      expect(mockRepositories.contact.createQueryBuilder).not.toHaveBeenCalled();
+      expect(
+        mockRepositories.contact.createQueryBuilder,
+      ).not.toHaveBeenCalled();
     });
 
-    it('buckets a submission by submittedAt even when reportingPeriod is stale or absent', async () => {
-      // Regression guard for the exact bug just fixed: a submission whose
-      // stored reportingPeriod (from an older week-boundary formula) no
-      // longer matches its actual week must still be counted correctly,
-      // because the service now derives the bucket from submittedAt, not
-      // from the stored string.
-      mockRepositories.groupMembership.find.mockResolvedValueOnce([{ groupId: 10 }]);
-      mockGroupTreeService.getGroupAndAllChildren = jest.fn().mockResolvedValue([10]);
+    it('trusts the stored reportingPeriod over submittedAt when a submission was physically typed late', async () => {
+      // reportingPeriod is the period submitReport deliberately assigned;
+      // submittedAt is just when it was typed in and can legitimately fall
+      // outside that week (e.g. someone finishing a submission after
+      // midnight). The service must bucket on reportingPeriod, not
+      // re-derive the week from submittedAt.
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
       mockRepositories.groupTree.find.mockResolvedValue([
         { id: 10, name: 'MC Nairobi' },
       ]);
@@ -1193,9 +1535,8 @@ describe('ReportsService', () => {
       mockRepositories.reportSubmission.find.mockResolvedValue([
         {
           group: { id: 10 },
-          submittedAt: new Date('2026-07-29T10:00:00Z'),
-          // Intentionally stale/wrong — must be ignored by the service.
-          reportingPeriod: '1970-01-01',
+          submittedAt: new Date('2026-08-01T23:50:00Z'), // typed the following Saturday
+          reportingPeriod: '2026-07-26', // but covers this week
         },
       ]);
       mockRepositories.groupMembership.find.mockResolvedValueOnce([
@@ -1207,11 +1548,62 @@ describe('ReportsService', () => {
         ]),
       );
 
-      const result = await service.getMcSubmissionCompliance(mockUser, from, to);
+      const result = await service.getMcSubmissionCompliance(
+        mockUser,
+        from,
+        to,
+      );
 
-      // Group 10 submitted (via submittedAt) for the only week in range, so
-      // it must be excluded from the "not submitted" result entirely.
+      // Group 10 covered the only week in range, so it's excluded from the
+      // "not submitted" result entirely.
       expect(result.groups).toEqual([]);
+    });
+
+    it('still flags the current week as missed when a catch-up submission targets the previous week', async () => {
+      // A Sunday catch-up for MC Attendance Report is stored against last
+      // week's reportingPeriod (submitReport's due-day logic) even though
+      // it was typed during the current week. Compliance must not let that
+      // submittedAt timestamp make it look like the current week was
+      // covered.
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+      mockRepositories.groupTree.find.mockResolvedValue([
+        { id: 10, name: 'MC Nairobi' },
+      ]);
+      mockRepositories.report.createQueryBuilder.mockReturnValue(
+        makeReportQueryBuilder({ id: 100 }),
+      );
+
+      const from = new Date('2026-07-19');
+      const to = new Date('2026-07-26');
+      mockRepositories.reportSubmission.find.mockResolvedValue([
+        {
+          group: { id: 10 },
+          submittedAt: new Date('2026-07-26T08:00:00Z'), // typed on the current week's Sunday
+          reportingPeriod: '2026-07-19', // recorded as catch-up for last week
+        },
+      ]);
+      mockRepositories.groupMembership.find.mockResolvedValueOnce([
+        { groupId: 10, contactId: 55 },
+      ]);
+      mockRepositories.contact.createQueryBuilder.mockReturnValue(
+        makeContactQueryBuilder([
+          { id: 55, firstName: 'Grace', lastName: 'Nakato', middleName: null },
+        ]),
+      );
+
+      const result = await service.getMcSubmissionCompliance(
+        mockUser,
+        from,
+        to,
+      );
+
+      expect(result.groups[0].missedWeeks).toEqual(['2026-07-26']);
+      expect(result.groups[0].missingCurrentWeek).toBe(true);
     });
   });
 });

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -5,16 +5,7 @@ import {
   HttpStatus,
   BadRequestException,
 } from '@nestjs/common';
-import {
-  Connection,
-  Repository,
-  In,
-  Not,
-  Between,
-  And,
-  MoreThanOrEqual,
-  LessThan,
-} from 'typeorm';
+import { Connection, Repository, In, Not } from 'typeorm';
 import { UserDto } from 'src/auth/dto/user.dto';
 import { Report } from './entities/report.entity';
 import { ReportSubmission } from './entities/report.submission.entity';
@@ -61,12 +52,12 @@ export interface McComplianceGroupStatus {
   leaderName: string;
   weeksInRange: number;
   weeksMissed: number;
-  missedWeeks: string[]; 
+  missedWeeks: string[];
   missingCurrentWeek: boolean;
 }
 
 export interface McComplianceResponse {
-  weekStarts: string[]; 
+  weekStarts: string[];
   groups: McComplianceGroupStatus[];
 }
 
@@ -84,6 +75,21 @@ export class ReportsService {
   private static readonly MCA_REPORT_NAME = 'MC Attendance Report';
   private static readonly MCA_FIELD_LABEL = 'How many attended MC?';
   private static readonly COMPLIANCE_MAX_WEEKS_LOOKBACK = 12;
+  // Weekly reports whose expected submission day is known (0=Sun..6=Sat).
+  // Only reports listed here get "catch up on the day that already passed"
+  // treatment in submitReport's period selection -- other weekly reports
+  // (Sunday Service, Weekly Oikos, etc.) have no configured due day, so
+  // they fall back to plain "current week only" duplicate checking rather
+  // than guessing which day they're supposed to land on.
+  //
+  // Keyed by report name, not id, which is fragile: renaming "MC
+  // Attendance Report" silently drops it back to no-due-day behavior with
+  // no error. Acceptable short-term, but the due day should move to a
+  // real column on Report (alongside submissionFrequency) so it survives
+  // renames and can be configured per-report instead of hardcoded here.
+  private static readonly REPORT_DUE_DAY_OF_WEEK: Record<string, number> = {
+    [ReportsService.MCA_REPORT_NAME.toLowerCase()]: 3, // Wednesday
+  };
 
   constructor(
     @Inject('CONNECTION') connection: Connection,
@@ -94,7 +100,7 @@ export class ReportsService {
     private readonly appLogger: AppLogger,
     private readonly tenantContext: TenantContext,
     private readonly fellowshipAttendanceService: FellowshipAttendanceService,
-    private readonly notificationsService: NotificationsService, 
+    private readonly notificationsService: NotificationsService,
   ) {
     this.reportRepository = connection.getRepository(Report);
     this.reportFieldRepository = connection.getRepository(ReportField);
@@ -108,11 +114,11 @@ export class ReportsService {
     this.contactRepository = connection.getRepository(Contact);
     this.logger = this.appLogger.createContextLogger('ReportsService');
   }
-    private async resolveReportSubmissionRecipients(
+  private async resolveReportSubmissionRecipients(
     targetGroup: Group,
   ): Promise<number[]> {
     const tenantId = this.tenantContext.requireTenant();
-    
+
     // Manual parentId walk, mirroring GroupTreeService.findAncestorIds.
     // treeRepository.findAncestors() relies on the closure table, which can
     // drift from parentId — same reason GroupTreeService avoids it.
@@ -132,7 +138,9 @@ export class ReportsService {
         where: { id: currentParentId, tenant: { id: tenantId } as any },
         select: ['id', 'parentId'],
       });
-      currentParentId = parentGroup?.parentId ? Number(parentGroup.parentId) : null;
+      currentParentId = parentGroup?.parentId
+        ? Number(parentGroup.parentId)
+        : null;
     }
 
     // groupIds above were only ever discovered via tenant-scoped
@@ -351,40 +359,76 @@ export class ReportsService {
       targetGroup = userGroups[0];
     }
 
-    // A report may only be submitted once per week per group (week starts
-    // Sunday). This allows a user managing multiple groups to submit the same
-    // report once for each group, and to submit other reports freely during
-    // the week. Reports with no associated group fall back to limiting the
-    // submitting user to one submission per week.
-    const weekStart = this.getStartOfWeek(new Date());
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekEnd.getDate() + 7);
-    const duplicateSubmissionWhere: any = {
-      report: { id: reportId },
-      submittedAt: Between(weekStart, weekEnd),
-    };
-    if (targetGroup) {
-      duplicateSubmissionWhere.group = { id: targetGroup.id };
-    } else {
-      duplicateSubmissionWhere.user = { id: submittingUser.id };
-    }
-    const existingSubmission = await this.reportSubmissionRepository.findOne({
-      where: duplicateSubmissionWhere,
-    });
-    if (existingSubmission) {
-      throw new BadRequestException(
-        targetGroup
-          ? `"${report.name}" has already been submitted for ${targetGroup.name} this week`
-          : `You have already submitted "${report.name}" for this week`,
+    // A report may only be submitted once per reporting period per group,
+    // where the period length is driven by report.submissionFrequency.
+    // Reports with no associated group fall back to limiting the
+    // submitting user to one submission per period. 'custom' has no fixed
+    // cadence defined anywhere in the schema, so it's exempt from this
+    // check entirely and its reportingPeriod is left undefined (NULLs
+    // never collide with the unique index on
+    // report+group/user+reportingPeriod).
+    //
+    // For weekly reports with a known due day (see
+    // REPORT_DUE_DAY_OF_WEEK -- currently only MC Attendance Report,
+    // due Wednesdays), the target period is chosen by where "today" sits
+    // relative to that due day: days before it in the current Sun-Sat
+    // week are a catch-up window for last week's due day, so they target
+    // the *previous* period; days on/after it target the current period.
+    // This is deliberately day-aware, not "whichever period happens to be
+    // empty" -- an on-time Wednesday submission always targets the
+    // current week even if last week was never submitted, and a late
+    // catch-up never eats the slot for the upcoming on-time submission.
+    // Reports with no configured due day (Sunday Service, Weekly Oikos,
+    // daily/monthly reports, etc.) don't get this treatment since their
+    // expected day isn't known -- they simply target the current period.
+    // Whichever single period is selected, a submission that already
+    // exists for it is rejected outright; it is never silently
+    // reassigned to a different period.
+    const now = new Date();
+    let targetPeriod: string | undefined = undefined;
+    if (report.submissionFrequency !== 'custom') {
+      const currentPeriodStart = this.getPeriodStart(
+        now,
+        report.submissionFrequency,
       );
+      const dueDayOfWeek =
+        report.submissionFrequency === 'weekly'
+          ? ReportsService.REPORT_DUE_DAY_OF_WEEK[report.name?.toLowerCase()]
+          : undefined;
+
+      const periodStart =
+        dueDayOfWeek !== undefined && now.getDay() < dueDayOfWeek
+          ? this.getPreviousPeriodStart(currentPeriodStart, 'weekly')
+          : currentPeriodStart;
+      targetPeriod = this.formatDateKey(periodStart);
+
+      const periodScopeWhere: any = {
+        report: { id: reportId },
+        reportingPeriod: targetPeriod,
+      };
+      if (targetGroup) {
+        periodScopeWhere.group = { id: targetGroup.id };
+      } else {
+        periodScopeWhere.user = { id: submittingUser.id };
+      }
+      const existingSubmission = await this.reportSubmissionRepository.findOne({
+        where: periodScopeWhere,
+      });
+      if (existingSubmission) {
+        throw new BadRequestException(
+          targetGroup
+            ? `"${report.name}" has already been submitted for ${targetGroup.name} for the period starting ${targetPeriod}`
+            : `You have already submitted "${report.name}" for the period starting ${targetPeriod}`,
+        );
+      }
     }
 
     // Create and save the report submission
     const reportSubmission = new ReportSubmission();
     reportSubmission.report = report;
-    reportSubmission.submittedAt = new Date();
+    reportSubmission.submittedAt = now;
     reportSubmission.user = submittingUser;
-    reportSubmission.reportingPeriod = this.formatDateKey(weekStart);
+    reportSubmission.reportingPeriod = targetPeriod;
     if (targetGroup) {
       reportSubmission.group = targetGroup;
     }
@@ -396,8 +440,8 @@ export class ReportsService {
       if ((err as any).code === '23505') {
         throw new BadRequestException(
           targetGroup
-            ? `"${report.name}" has already been submitted for ${targetGroup.name} this week`
-            : `You have already submitted "${report.name}" for this week`,
+            ? `"${report.name}" has already been submitted for ${targetGroup.name} for the period starting ${targetPeriod}`
+            : `You have already submitted "${report.name}" for the period starting ${targetPeriod}`,
         );
       }
       throw err;
@@ -497,7 +541,7 @@ export class ReportsService {
         },
       );
     }
-    
+
     const formattedDate = getHumanReadableDate(savedSubmission.submittedAt);
     const fullName = getUserDisplayName(savedSubmission.user);
 
@@ -512,7 +556,7 @@ export class ReportsService {
               type: NotificationType.REPORT_SUBMITTED,
               title: `${report.name} submitted`,
               body: `${fullName} submitted for ${targetGroup.name}`,
-              link: `/reports`,
+              link: '/reports',
             }),
           ),
         );
@@ -693,6 +737,39 @@ export class ReportsService {
     startOfWeek.setHours(0, 0, 0, 0);
     startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay()); // Sunday = 0
     return startOfWeek;
+  }
+
+  // Start of the period containing `date`, keyed by submissionFrequency.
+  // Never called for 'custom' -- callers skip period logic for that case.
+  private getPeriodStart(date: Date, frequency: string): Date {
+    switch (frequency) {
+      case 'daily': {
+        const startOfDay = new Date(date);
+        startOfDay.setHours(0, 0, 0, 0);
+        return startOfDay;
+      }
+      case 'monthly':
+        return new Date(date.getFullYear(), date.getMonth(), 1);
+      case 'weekly':
+      default:
+        return this.getStartOfWeek(date);
+    }
+  }
+
+  private getPreviousPeriodStart(periodStart: Date, frequency: string): Date {
+    const previous = new Date(periodStart);
+    switch (frequency) {
+      case 'daily':
+        previous.setDate(previous.getDate() - 1);
+        return previous;
+      case 'monthly':
+        previous.setMonth(previous.getMonth() - 1);
+        return previous;
+      case 'weekly':
+      default:
+        previous.setDate(previous.getDate() - 7);
+        return previous;
+    }
   }
 
   async getReport(reportId: number): Promise<Report> {
@@ -1711,23 +1788,18 @@ export class ReportsService {
       return [];
     }
   }
-  
+
   async getWeeklyMcaSummary(user: UserDto): Promise<{
-  total: number;
-  breakdown: { groupId: number; groupName: string; total: number }[];
-  weekStart: string;
-  weekEnd: string;
-  reportFound: boolean;
+    total: number;
+    breakdown: { groupId: number; groupName: string; total: number }[];
+    weekStart: string;
+    weekEnd: string;
+    reportFound: boolean;
   }> {
     const tenantId = this.tenantContext.requireTenant();
     const weekStart = this.getStartOfWeek(new Date());
     const weekEnd = new Date(weekStart);
     weekEnd.setDate(weekEnd.getDate() + 6);
-    // Exclusive upper bound for the submittedAt query — start of the *next*
-    // week, matching the same Between() pattern submitReport already uses
-    // for its duplicate-submission check.
-    const weekEndExclusive = new Date(weekStart);
-    weekEndExclusive.setDate(weekEndExclusive.getDate() + 7);
 
     const emptyResult = {
       total: 0,
@@ -1773,6 +1845,13 @@ export class ReportsService {
     const fieldId = attendanceField.id;
     const reportId = attendanceField.report.id;
 
+    // Filter by reportingPeriod, not submittedAt: reportingPeriod is the
+    // period submitReport deliberately assigned this submission to
+    // (including MC's Wednesday due-day catch-up window -- see
+    // REPORT_DUE_DAY_OF_WEEK), while submittedAt is just when it was
+    // physically typed in. A Sunday catch-up submission is stored against
+    // *last* week's reportingPeriod on purpose; bucketing by submittedAt
+    // here would wrongly fold it into this week's total.
     const submissions = await this.reportSubmissionRepository
       .createQueryBuilder('submission')
       .innerJoinAndSelect('submission.group', 'group')
@@ -1784,12 +1863,16 @@ export class ReportsService {
       )
       .where('submission.report = :reportId', { reportId })
       .andWhere('group.id IN (:...groupIds)', { groupIds })
-      .andWhere('submission.submittedAt >= :weekStart', { weekStart })
-      .andWhere('submission.submittedAt < :weekEndExclusive', { weekEndExclusive })
+      .andWhere('submission.reportingPeriod = :period', {
+        period: this.formatDateKey(weekStart),
+      })
       .getMany();
 
     let total = 0;
-    const breakdownMap = new Map<number, { groupId: number; groupName: string; total: number }>();
+    const breakdownMap = new Map<
+      number,
+      { groupId: number; groupName: string; total: number }
+    >();
 
     for (const submission of submissions) {
       for (const sd of submission.submissionData) {
@@ -1814,13 +1897,15 @@ export class ReportsService {
     }
     return {
       total,
-      breakdown: Array.from(breakdownMap.values()).sort((a, b) => b.total - a.total),
+      breakdown: Array.from(breakdownMap.values()).sort(
+        (a, b) => b.total - a.total,
+      ),
       weekStart: emptyResult.weekStart,
       weekEnd: emptyResult.weekEnd,
       reportFound: true,
     };
   }
- 
+
   async getMcSubmissionCompliance(
     user: UserDto,
     from?: Date,
@@ -1832,14 +1917,13 @@ export class ReportsService {
       rangeEnd,
       ReportsService.COMPLIANCE_MAX_WEEKS_LOOKBACK,
     );
-    const rangeStart =
-      from && from > earliestAllowed ? from : earliestAllowed;
+    const rangeStart = from && from > earliestAllowed ? from : earliestAllowed;
     const weekStarts = this.getReportingWeekStarts(rangeStart, rangeEnd);
     if (weekStarts.length === 0) {
       return { weekStarts: [], groups: [] };
     }
     const weekStartIsoList = weekStarts.map((d) => this.formatDateKey(d));
-    const currentWeekIso = weekStartIsoList[weekStartIsoList.length - 1];;
+    const currentWeekIso = weekStartIsoList[weekStartIsoList.length - 1];
 
     const groupIds = await this.getUserManageableGroups(user);
     if (groupIds.length === 0) {
@@ -1859,7 +1943,7 @@ export class ReportsService {
     }
     const mcGroupIds = mcGroups.map((g) => g.id);
 
-     const attendanceReport = await this.reportRepository
+    const attendanceReport = await this.reportRepository
       .createQueryBuilder('report')
       .where('LOWER(report.name) = LOWER(:reportName)', {
         reportName: ReportsService.MCA_REPORT_NAME,
@@ -1871,26 +1955,18 @@ export class ReportsService {
       return { weekStarts: weekStartIsoList, groups: [] };
     }
 
-    // Query the raw submittedAt window covering the full range, then bucket
-    // each submission into a week live in JS using the same getStartOfWeek /
-    // formatDateKey as weekStartIsoList above. This deliberately avoids
-    // matching against the stored `reportingPeriod` string — that value was
-    // written under whatever week-boundary formula was live at submit time,
-    // and historical rows can carry a stale value from an earlier formula.
-    // Deriving the bucket from submittedAt at read time keeps this endpoint
-    // permanently in sync with itself, regardless of past formula changes.
-    const queryRangeStart = weekStarts[0];
-    const queryRangeEndExclusive = new Date(weekStarts[weekStarts.length - 1]);
-    queryRangeEndExclusive.setDate(queryRangeEndExclusive.getDate() + 7);
-
+    // Bucket by the stored reportingPeriod, not submittedAt: reportingPeriod
+    // is the period submitReport deliberately assigned each submission to
+    // (including MC's Wednesday due-day catch-up window -- see
+    // REPORT_DUE_DAY_OF_WEEK), so it's the authoritative answer to "which
+    // week did this cover." Deriving the bucket from submittedAt instead
+    // would mark a legitimately-covered week as missed whenever a late
+    // catch-up submission's timestamp falls in the following week.
     const submissions = await this.reportSubmissionRepository.find({
       where: {
         report: { id: attendanceReport.id },
         group: { id: In(mcGroupIds) },
-        submittedAt: And(
-          MoreThanOrEqual(queryRangeStart),
-          LessThan(queryRangeEndExclusive),
-        ),
+        reportingPeriod: In(weekStartIsoList),
       },
       relations: ['group'],
     });
@@ -1898,19 +1974,23 @@ export class ReportsService {
     const submittedWeeksByGroup = new Map<number, Set<string>>();
     for (const submission of submissions) {
       const groupId = submission.group.id;
-      const weekKey = this.formatDateKey(this.getStartOfWeek(submission.submittedAt));
+      const weekKey = submission.reportingPeriod;
       if (!submittedWeeksByGroup.has(groupId)) {
         submittedWeeksByGroup.set(groupId, new Set());
       }
       submittedWeeksByGroup.get(groupId).add(weekKey);
     }
 
-    const leaderNameByGroupId = await this.getMcLeaderNamesByGroupId(mcGroupIds);
+    const leaderNameByGroupId =
+      await this.getMcLeaderNamesByGroupId(mcGroupIds);
 
     const groups: McComplianceGroupStatus[] = mcGroups
       .map((group) => {
-        const submittedWeeks = submittedWeeksByGroup.get(group.id) ?? new Set<string>();
-        const missedWeeks = weekStartIsoList.filter((week) => !submittedWeeks.has(week));
+        const submittedWeeks =
+          submittedWeeksByGroup.get(group.id) ?? new Set<string>();
+        const missedWeeks = weekStartIsoList.filter(
+          (week) => !submittedWeeks.has(week),
+        );
 
         return {
           groupId: group.id,

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -547,7 +547,7 @@ export class ReportsService {
           metadata: {
             reportId,
             submissionId: savedSubmission.id,
-            error: err.message,
+            error: err?.message,
           },
         },
       );
@@ -601,7 +601,7 @@ export class ReportsService {
             metadata: {
               reportId,
               submissionId: savedSubmission.id,
-              reason: err.message,
+              reason: err?.message,
             },
           },
         );
@@ -633,7 +633,7 @@ export class ReportsService {
           metadata: {
             reportId,
             submissionId: savedSubmission.id,
-            reason: err?.message,
+            reason: err.message,
           },
         },
       );

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -220,9 +220,14 @@ export class ReportsService {
   ): Promise<ApiResponse<ReportSubmissionDataDto>> {
     const { data } = submissionDto;
 
-    // Retrieve the report by its ID
+    // Retrieve the report by its ID, scoped to the active tenant
+    const tenantId = this.tenantContext.requireTenant();
     const report = await this.reportRepository.findOne({
-      where: { id: reportId, status: ReportStatus.ACTIVE },
+      where: {
+        id: reportId,
+        status: ReportStatus.ACTIVE,
+        tenant: { id: tenantId },
+      },
       relations: ['targetGroupCategory', 'fields'],
     });
     if (!report) {
@@ -405,7 +410,7 @@ export class ReportsService {
       targetPeriod = this.formatDateKey(periodStart);
 
       const periodScopeWhere: any = {
-        report: { id: reportId },
+        report: { id: reportId, tenant: { id: tenantId } },
         reportingPeriod: targetPeriod,
       };
       if (targetGroup) {

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -71,6 +71,7 @@ export class ReportsService {
   private readonly groupMembershipRepo: Repository<GroupMembership>;
   private readonly treeRepository: TreeRepository<Group>;
   private readonly contactRepository: Repository<Contact>;
+  private readonly connection: Connection;
   private readonly logger: ContextLogger;
   private static readonly MCA_REPORT_NAME = 'MC Attendance Report';
   private static readonly MCA_FIELD_LABEL = 'How many attended MC?';
@@ -112,6 +113,7 @@ export class ReportsService {
     this.treeRepository = connection.getTreeRepository(Group);
     this.userRepository = connection.getRepository(User);
     this.contactRepository = connection.getRepository(Contact);
+    this.connection = connection;
     this.logger = this.appLogger.createContextLogger('ReportsService');
   }
   private async resolveReportSubmissionRecipients(
@@ -423,19 +425,78 @@ export class ReportsService {
       }
     }
 
-    // Create and save the report submission
-    const reportSubmission = new ReportSubmission();
-    reportSubmission.report = report;
-    reportSubmission.submittedAt = now;
-    reportSubmission.user = submittingUser;
-    reportSubmission.reportingPeriod = targetPeriod;
-    if (targetGroup) {
-      reportSubmission.group = targetGroup;
+    // Retrieve all fields for the report to map field names to their respective
+    // entities, and validate every submitted field name up front -- before any
+    // row is persisted -- so an unknown field can never leave a parent
+    // ReportSubmission stranded in the database with no data underneath it.
+    const fields = await this.reportFieldRepository.find({
+      where: { report: { id: report.id } },
+    });
+    const fieldNameToFieldMap = new Map(
+      fields.map((field) => [field.name, field]),
+    );
+    for (const fieldName of Object.keys(data)) {
+      if (!fieldNameToFieldMap.has(fieldName)) {
+        throw new BadRequestException(
+          `Field with name '${fieldName}' not found in report`,
+        );
+      }
     }
+
+    // Create the report submission, its field data, and any computed fields
+    // (e.g. PGA) in a single transaction, so a failure partway through never
+    // leaves a parent submission occupying the period with no data behind it.
     let savedSubmission: ReportSubmission;
     try {
-      savedSubmission =
-        await this.reportSubmissionRepository.save(reportSubmission);
+      savedSubmission = await this.connection.transaction(async (manager) => {
+        const reportSubmission = new ReportSubmission();
+        reportSubmission.report = report;
+        reportSubmission.submittedAt = now;
+        reportSubmission.user = submittingUser;
+        reportSubmission.reportingPeriod = targetPeriod;
+        if (targetGroup) {
+          reportSubmission.group = targetGroup;
+        }
+        const saved = await manager.save(ReportSubmission, reportSubmission);
+
+        const submissionDataEntities = Object.entries(data).map(
+          ([fieldName, fieldValue]) => {
+            const submissionData = new ReportSubmissionData();
+            submissionData.reportSubmission = saved;
+            submissionData.reportField = fieldNameToFieldMap.get(fieldName);
+            submissionData.fieldValue = fieldValue;
+            return submissionData;
+          },
+        );
+        await manager.save(ReportSubmissionData, submissionDataEntities);
+
+        // WHM Sunday Service Report: compute and persist PGA = 1Sv + 2Sv + YXP + kids
+        if (report.functionName === 'whmSundayService') {
+          const slot = (name: string) => {
+            const v = data[name];
+            return typeof v === 'number' ? v : parseFloat(String(v ?? 0)) || 0;
+          };
+          const pga =
+            slot('1Sv') +
+            slot('2Sv') +
+            slot('YXP') +
+            slot('kids') +
+            slot('local') +
+            slot('hc1') +
+            slot('hc2') +
+            slot('hc3');
+          const pgaField = fieldNameToFieldMap.get('pga');
+          if (pgaField) {
+            const pgaRow = new ReportSubmissionData();
+            pgaRow.reportSubmission = saved;
+            pgaRow.reportField = pgaField;
+            pgaRow.fieldValue = String(pga);
+            await manager.save(ReportSubmissionData, pgaRow);
+          }
+        }
+
+        return saved;
+      });
     } catch (err) {
       if ((err as any).code === '23505') {
         throw new BadRequestException(
@@ -445,56 +506,6 @@ export class ReportsService {
         );
       }
       throw err;
-    }
-
-    // Retrieve all fields for the report to map field names to their respective entities
-    const fields = await this.reportFieldRepository.find({
-      where: { report: { id: report.id } },
-    });
-    const fieldNameToFieldMap = new Map(
-      fields.map((field) => [field.name, field]),
-    );
-    // Prepare SubmissionData entities
-    const submissionDataEntities = Object.entries(data).map(
-      ([fieldName, fieldValue]) => {
-        const field = fieldNameToFieldMap.get(fieldName);
-        if (!field) {
-          throw new Error(`Field with name '${fieldName}' not found in report`);
-        }
-        const submissionData = new ReportSubmissionData();
-        submissionData.reportSubmission = savedSubmission;
-        submissionData.reportField = field; // Directly use the field entity
-        submissionData.fieldValue = fieldValue;
-        return submissionData;
-      },
-    );
-
-    // Save all SubmissionData entities
-    await this.reportSubmissionDataRepository.save(submissionDataEntities);
-
-    // WHM Sunday Service Report: compute and persist PGA = 1Sv + 2Sv + YXP + kids
-    if (report.functionName === 'whmSundayService') {
-      const slot = (name: string) => {
-        const v = data[name];
-        return typeof v === 'number' ? v : parseFloat(String(v ?? 0)) || 0;
-      };
-      const pga =
-        slot('1Sv') +
-        slot('2Sv') +
-        slot('YXP') +
-        slot('kids') +
-        slot('local') +
-        slot('hc1') +
-        slot('hc2') +
-        slot('hc3');
-      const pgaField = fieldNameToFieldMap.get('pga');
-      if (pgaField) {
-        const pgaRow = new ReportSubmissionData();
-        pgaRow.reportSubmission = savedSubmission;
-        pgaRow.reportField = pgaField;
-        pgaRow.fieldValue = String(pga);
-        await this.reportSubmissionDataRepository.save(pgaRow);
-      }
     }
 
     // Record fellowship attendance if the report contains the relevant dynamic fields
@@ -607,11 +618,26 @@ export class ReportsService {
       status: HttpStatus.OK,
       message: 'Report submitted successfully.',
     };
-    await this.sendMail(
-      savedSubmission.user.username,
-      'Project Zoe - Report Submitted',
-      { submissionDate: formattedDate, fullName },
-    );
+    try {
+      await this.sendMail(
+        savedSubmission.user.username,
+        'Project Zoe - Report Submitted',
+        { submissionDate: formattedDate, fullName },
+      );
+    } catch (err) {
+      this.logger.business(
+        'warn',
+        'Report submitted but confirmation email failed',
+        {
+          operation: 'submitReport',
+          metadata: {
+            reportId,
+            submissionId: savedSubmission.id,
+            reason: err?.message,
+          },
+        },
+      );
+    }
 
     return response;
   }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -638,7 +638,7 @@ export class ReportsService {
           metadata: {
             reportId,
             submissionId: savedSubmission.id,
-            reason: err.message,
+            reason: err?.message,
           },
         },
       );


### PR DESCRIPTION
# Ticket No
- BugFix

# Summary of changes
- Late report submissions were forcing period bucketing onto the calendar
week/month containing "now", so a forgotten weekly report submitted late
(e.g. on Sunday instead of the usual Wednesday) would consume the current
period's slot and block the next on-time submission until the following
cycle.

- `submitReport` now targets a single, deliberately-chosen reportingPeriod per
submission instead. Weekly reports with a known due day (currently only MC
Attendance Report, due Wednesday, via `REPORT_DUE_DAY_OF_WEEK`) treat days
before the due day as a catch-up window for the previous period and days
on/after it as the current period; other reports target the current
period. Whichever period is selected, an existing submission for it is
rejected outright rather than silently reassigned elsewhere.

-  `getWeeklyMcaSummary` and `getMcSubmissionCompliance` are updated to read by
reportingPeriod instead of submittedAt, so a late catch-up is credited to
the period it was recorded against rather than the period it happened to be
typed in, matching how the dashboard already treats reportingPeriod as the
reporting time axis. 

- Save the `ReportSubmission` row, its ReportSubmissionData rows, and any
computed fields (e.g. PGA) in a single transaction, and validate
submitted field names before persisting anything. Previously a failure
after the parent row was saved (unknown field, data-save error) left
the row in place, permanently occupying the period and rejecting
retries as duplicates.

`Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>`

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Wednesday due-day support for MC Attendance Reports.
  * Improved catch-up handling for weekly report submissions.
  * Added daily, weekly, monthly, and previous-period reporting calculations.

* **Bug Fixes**
  * Prevented duplicate submissions using the correct reporting period.
  * Improved transaction safety so incomplete submissions are not saved.
  * Validated report fields before saving submissions.
  * Corrected summaries and compliance calculations for late and catch-up entries.
  * Preserved submissions when notification or confirmation emails fail.
  * Improved handling for custom and monthly reporting schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->