### PR TITLE
fix: make notifications gateway socket.io path configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,10 +15,12 @@ EMAIL_SENDER=example@email.com
 DATABASE_URL="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}?schema=public"
 REACT_APP_SENTRY_DSN=sentry_dsn
 
-# Path the notifications Socket.IO gateway listens on. Leave unset for local
-# dev (defaults to /socket.io, matching the client's default). In
-# environments behind a reverse proxy that strips a path prefix (e.g. prod
-# serving under /server), set this to match, e.g. /server/socket.io.
+# Path the notifications Socket.IO gateway listens on, as seen by THIS
+# process (after any reverse-proxy rewriting). Leave unset for local dev, or
+# when the proxy strips a path prefix before forwarding (e.g. strips
+# /server), since the default (/socket.io) already matches what this
+# process receives. Only set this if the proxy preserves or rewrites the
+# upstream path to include the prefix, e.g. SOCKET_IO_PATH=/server/socket.io.
 # SOCKET_IO_PATH=/server/socket.io
 
 # Google Spreadsheet Config

--- a/.env.sample
+++ b/.env.sample
@@ -15,6 +15,12 @@ EMAIL_SENDER=example@email.com
 DATABASE_URL="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}?schema=public"
 REACT_APP_SENTRY_DSN=sentry_dsn
 
+# Path the notifications Socket.IO gateway listens on. Leave unset for local
+# dev (defaults to /socket.io, matching the client's default). In
+# environments behind a reverse proxy that strips a path prefix (e.g. prod
+# serving under /server), set this to match, e.g. /server/socket.io.
+# SOCKET_IO_PATH=/server/socket.io
+
 # Google Spreadsheet Config
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-acc-auth.json
 GOOGLE_SPREADSHEET_ID=spread-sheet-id-here

--- a/src/notifications/notifications.gateway.ts
+++ b/src/notifications/notifications.gateway.ts
@@ -11,13 +11,16 @@ import { JwtService } from '@nestjs/jwt';
 @Injectable()
 @WebSocketGateway({
   namespace: '/notifications',
-  path: '/server/socket.io',
+  path: process.env.SOCKET_IO_PATH || '/socket.io',
   cors: {
-    origin: process.env.FRONTEND_ORIGIN?.split(',').map((o) => o.trim()) ?? false,
+    origin:
+      process.env.FRONTEND_ORIGIN?.split(',').map((o) => o.trim()) ?? false,
     credentials: true,
   },
 })
-export class NotificationsGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class NotificationsGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
   @WebSocketServer()
   server!: Server;
   private readonly logger = new Logger(NotificationsGateway.name);
@@ -46,7 +49,11 @@ export class NotificationsGateway implements OnGatewayConnection, OnGatewayDisco
       }
       this.userSockets.get(userId)!.add(client.id);
     } catch (err) {
-      this.logger.warn(`Rejecting socket connection: ${err instanceof Error ? err.message : err}`);
+      this.logger.warn(
+        `Rejecting socket connection: ${
+          err instanceof Error ? err.message : err
+        }`,
+      );
       client.disconnect(true);
     }
   }
@@ -61,6 +68,8 @@ export class NotificationsGateway implements OnGatewayConnection, OnGatewayDisco
 
   // Called by NotificationsService right after a notification is persisted
   emitToUser(tenantId: number, userId: number, payload: unknown) {
-    this.server.to(`tenant:${tenantId}:user:${userId}`).emit('notification:new', payload);
+    this.server
+      .to(`tenant:${tenantId}:user:${userId}`)
+      .emit('notification:new', payload);
   }
 }


### PR DESCRIPTION
# Ticket No
-  BugFix

# Summary of changes
- Previously hardcoded to `/server/socket.io`, which only matches the client in production (behind a reverse proxy stripping `/server`). In local dev, the client connects to the un-prefixed default /socket.io, so the handshake 404'd. Now driven by SOCKET_IO_PATH, defaulting to /socket.io to match local dev; set it to /server/socket.io in production.


# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration guidance for customizing the Socket.IO gateway path, including reverse-proxy deployments.
  * The gateway now supports a configurable connection path and defaults to `/socket.io`.

* **Documentation**
  * Updated sample environment configuration with Socket.IO path examples and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->