### PR TITLE
fix(contacts): enforce tenant-scoped unique email check on create and update

### DIFF
--- a/src/crm/contacts.service.spec.ts
+++ b/src/crm/contacts.service.spec.ts
@@ -43,7 +43,11 @@ describe('ContactsService', () => {
       },
       company: { save: jest.fn() },
       phone: { save: jest.fn() },
-      email: { save: jest.fn() },
+      email: {
+        save: jest.fn(),
+        create: jest.fn((data) => data),
+        remove: jest.fn(),
+      },
       address: { save: jest.fn() },
       membership: {
         find: jest.fn(),
@@ -71,6 +75,14 @@ describe('ContactsService', () => {
         return mockRepositories.contact;
       }),
       getTreeRepository: jest.fn().mockReturnValue(mockRepositories.groupTree),
+      transaction: jest.fn((callback: any) =>
+        callback({
+          getRepository: jest.fn((entity: any) => {
+            if (entity === Email) return mockRepositories.email;
+            return mockRepositories.contact;
+          }),
+        }),
+      ),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -140,6 +152,39 @@ describe('ContactsService', () => {
     );
     expect(mockConnection.getRepository).toHaveBeenCalledWith(Tenant);
     expect(mockConnection.getTreeRepository).toHaveBeenCalledWith(Group);
+  });
+
+  it('keeps existing emails unchanged when creating a replacement email fails', async () => {
+    const existingEmail = {
+      id: 10,
+      value: 'old@example.com',
+      contactId: 1,
+      tenantId: 1,
+    } as Email;
+    const existingContact = {
+      id: 1,
+      emails: [existingEmail],
+    } as Contact;
+    mockRepositories.email.save.mockRejectedValueOnce(
+      new Error('email save failed'),
+    );
+
+    await expect(
+      (mockConnection.transaction as jest.Mock)((manager: any) =>
+        (service as any).updateEmailsEfficiently(
+          existingContact,
+          [{ value: 'new@example.com' }],
+          manager,
+        ),
+      ),
+    ).rejects.toThrow('email save failed');
+
+    expect(mockConnection.transaction).toHaveBeenCalled();
+    expect(mockRepositories.email.remove).toHaveBeenCalledWith([
+      existingEmail,
+    ]);
+    expect(existingContact.emails).toEqual([existingEmail]);
+    expect(existingEmail.value).toBe('old@example.com');
   });
 
   describe('handleGroupMembershipsUpdate', () => {

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -599,6 +599,12 @@ export class ContactsService {
       const tenantId = this.tenantContext.requireTenant();
       data.tenant = { id: tenantId } as any;
 
+      // Stamp tenantId onto every email row so the DB-level tenant-scoped
+      // unique index (IDX_email_tenant_normalized_value) can enforce
+      // uniqueness — email has no other path to tenantId at insert time.
+      (data.emails || []).forEach((e) => {
+        (e as any).tenantId = tenantId;
+      });
       // Stringent duplicate-email guard — applies to single creates and
       // to each row processed via createMany() for bulk upload.
       const incomingEmails = (data.emails || []).map((e) => e.value);
@@ -748,26 +754,25 @@ export class ContactsService {
       contactId: request?.user?.contactId,
     });
 
-  let tenantId: number;
-  try {
-     tenantId = this.tenantContext.requireTenant();
-     const allEmails = dataList.flatMap((d) =>
-       (d.emails || []).map((e) => e.value),
-     );
+    try {
+      const tenantId = this.tenantContext.requireTenant();
+      const allEmails = dataList.flatMap((d) =>
+        (d.emails || []).map((e) => e.value),
+      );
 
-     // Fail fast ONLY on duplicates within the submitted batch itself —
-     // that's a malformed-payload error, not tied to any one row, so it
-     // still throws for the caller to handle up front. We deliberately
-     // do NOT check here whether an email already exists in the DB
-     // (checkPersisted: false): that check runs per-row inside create()
-     // below, so one contact whose email already exists fails only that
-     // row and does not prevent the other rows in the batch from being
-     // created.
-     await this.assertEmailsAreUnique(allEmails, tenantId, undefined, false);
-   } catch (error) {
-     this.logger.endTracking(tracking, false);
-     throw error;
-   }
+      // Fail fast ONLY on duplicates within the submitted batch itself —
+      // that's a malformed-payload error, not tied to any one row, so it
+      // still throws for the caller to handle up front. We deliberately
+      // do NOT check here whether an email already exists in the DB
+      // (checkPersisted: false): that check runs per-row inside create()
+      // below, so one contact whose email already exists fails only that
+      // row and does not prevent the other rows in the batch from being
+      // created.
+      await this.assertEmailsAreUnique(allEmails, tenantId, undefined, false);
+    } catch (error) {
+      this.logger.endTracking(tracking, false);
+      throw error;
+    }
 
     const succeeded: Contact[] = [];
     const failed: BulkContactFailure[] = [];
@@ -898,20 +903,6 @@ export class ContactsService {
       }
 
       // Handle emails update with efficient upsert
-      if (data.emails) {
-        await this.updateEmailsEfficiently(existingContact, data.emails);
-      }
-
-      // Handle phones update with efficient upsert
-      if (data.phones) {
-        await this.updatePhonesEfficiently(existingContact, data.phones);
-      }
-
-      // Handle addresses update with efficient upsert
-      if (data.addresses) {
-        await this.updateAddressesEfficiently(existingContact, data.addresses);
-      }
-
       // Handle other contact fields (excluding nested entities and group assignment)
       const {
         person,
@@ -927,44 +918,60 @@ export class ContactsService {
       }
 
       try {
-        // Save the contact first (without group memberships to avoid constraint issues)
-        let savedContact: Contact;
-        try {
-          savedContact = await this.repository.save(existingContact);
-        } catch (saveError) {
-          if (ContactsService.isUniqueEmailViolation(saveError)) {
-            this.logger.business(
-              'warn',
-              'Duplicate email detected at database level on save',
-              {
-                operation: 'updateContact',
-                userId: request?.user?.id,
-                contactId: request?.user?.contactId,
-                resourceId: id,
-                metadata: { tenantId },
-              },
-            );
-            throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+        const savedContact = await this.connection.transaction(async (manager) => {
+          const contactRepository = manager.getRepository(Contact);
+
+          if (data.emails) {
+            await this.updateEmailsEfficiently(existingContact, data.emails, manager);
           }
-          throw saveError;
-        }
+          if (data.phones) {
+            await this.updatePhonesEfficiently(existingContact, data.phones, manager);
+          }
+          if (data.addresses) {
+            await this.updateAddressesEfficiently(existingContact, data.addresses, manager);
+          }
 
-        // Handle group membership updates after contact is saved
-        const groups = (data as any).groups;
+          // Save the contact first (without group memberships to avoid constraint issues)
+          let savedContact: Contact;
+          try {
+            savedContact = await contactRepository.save(existingContact);
+          } catch (saveError) {
+            if (ContactsService.isUniqueEmailViolation(saveError)) {
+              this.logger.business(
+                'warn',
+                'Duplicate email detected at database level on save',
+                {
+                  operation: 'updateContact',
+                  userId: request?.user?.id,
+                  contactId: request?.user?.contactId,
+                  resourceId: id,
+                  metadata: { tenantId },
+                },
+              );
+              throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+            }
+            throw saveError;
+          }
 
-        if (groups !== undefined) {
-          // Reload contact to get fresh group memberships
-          const contactWithMemberships = await this.repository.findOne({
-            where: { id: savedContact.id },
-            relations: ['groupMemberships'],
-          });
+          // Handle group membership updates after contact is saved
+          const groups = (data as any).groups;
 
-          await this.handleGroupMembershipsUpdate(
-            contactWithMemberships,
-            groups,
-            request,
-          );
-        }
+          if (groups !== undefined) {
+            const contactWithMemberships = await contactRepository.findOne({
+              where: { id: savedContact.id },
+              relations: ['groupMemberships'],
+            });
+
+            await this.handleGroupMembershipsUpdate(
+              contactWithMemberships,
+              groups,
+              request,
+              manager,
+            );
+          }
+
+          return savedContact;
+        });
 
         this.logger.business('log', 'Contact updated successfully', {
           operation: 'updateContact',
@@ -1010,6 +1017,7 @@ export class ContactsService {
     contact: Contact,
     newGroups: Array<{ id: number; role?: GroupRole }>,
     request?: any,
+    manager?: EntityManager,
   ): Promise<void> {
     try {
       const contactId = contact.id;
@@ -1087,6 +1095,9 @@ export class ContactsService {
       });
 
       // Deactivate memberships that should be removed
+      const membershipRepository = manager
+        ? manager.getRepository(GroupMembership)
+        : this.membershipRepository;
       for (const membership of membershipsToDeactivate) {
         this.logger.business('log', 'Deactivating group membership', {
           operation: 'updateContact',
@@ -1100,7 +1111,7 @@ export class ContactsService {
           },
         });
 
-        await this.membershipRepository
+        await membershipRepository
           .createQueryBuilder()
           .update(GroupMembership)
           .set({
@@ -1131,7 +1142,7 @@ export class ContactsService {
           },
         });
 
-        await this.membershipRepository
+        await membershipRepository
           .createQueryBuilder()
           .update(GroupMembership)
           .set({ role: newRole })
@@ -1184,11 +1195,16 @@ export class ContactsService {
             },
           });
 
-          await this.groupsMembershipService.create({
+          const membershipData = {
             groupId: groupToAdd.id,
             members: [contactId],
             role: targetRole,
-          });
+          };
+          if (manager) {
+            await this.groupsMembershipService.create(membershipData, manager);
+          } else {
+            await this.groupsMembershipService.create(membershipData);
+          }
         }
       }
 
@@ -1625,20 +1641,6 @@ export class ContactsService {
       }
 
       // Handle nested email updates
-      if (data.emails) {
-        await this.updateEmailsEfficiently(existingContact, data.emails);
-      }
-
-      // Handle nested phone updates
-      if (data.phones) {
-        await this.updatePhonesEfficiently(existingContact, data.phones);
-      }
-
-      // Handle nested address updates
-      if (data.addresses) {
-        await this.updateAddressesEfficiently(existingContact, data.addresses);
-      }
-
       // Remove groups field from contact data since it's handled separately
       const {
         person: __person,
@@ -1654,42 +1656,58 @@ export class ContactsService {
       }
 
       try {
-        // Save the contact first (without group memberships to avoid constraint issues)
-        let savedContact: Contact;
-        try {
-          savedContact = await this.repository.save(existingContact);
-        } catch (saveError) {
-          if (ContactsService.isUniqueEmailViolation(saveError)) {
-            this.logger.business(
-              'warn',
-              'Duplicate email detected at database level on save',
-              {
-                operation: 'updateContactWithGroups',
-                userId: request?.user?.id,
-                contactId: request?.user?.contactId,
-                resourceId: id,
-                metadata: { tenantId },
-              },
-            );
-            throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+        const savedContact = await this.connection.transaction(async (manager) => {
+          const contactRepository = manager.getRepository(Contact);
+
+          if (data.emails) {
+            await this.updateEmailsEfficiently(existingContact, data.emails, manager);
           }
-          throw saveError;
-        }
+          if (data.phones) {
+            await this.updatePhonesEfficiently(existingContact, data.phones, manager);
+          }
+          if (data.addresses) {
+            await this.updateAddressesEfficiently(existingContact, data.addresses, manager);
+          }
 
-        // Handle group membership updates after contact is saved
-        if (data.groups !== undefined) {
-          // Reload contact to get fresh group memberships
-          const contactWithMemberships = await this.repository.findOne({
-            where: { id: savedContact.id },
-            relations: ['groupMemberships'],
-          });
+          // Save the contact first (without group memberships to avoid constraint issues)
+          let savedContact: Contact;
+          try {
+            savedContact = await contactRepository.save(existingContact);
+          } catch (saveError) {
+            if (ContactsService.isUniqueEmailViolation(saveError)) {
+              this.logger.business(
+                'warn',
+                'Duplicate email detected at database level on save',
+                {
+                  operation: 'updateContactWithGroups',
+                  userId: request?.user?.id,
+                  contactId: request?.user?.contactId,
+                  resourceId: id,
+                  metadata: { tenantId },
+                },
+              );
+              throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+            }
+            throw saveError;
+          }
 
-          await this.handleGroupMembershipsUpdate(
-            contactWithMemberships,
-            data.groups,
-            request,
-          );
-        }
+          // Handle group membership updates after contact is saved
+          if (data.groups !== undefined) {
+            const contactWithMemberships = await contactRepository.findOne({
+              where: { id: savedContact.id },
+              relations: ['groupMemberships'],
+            });
+
+            await this.handleGroupMembershipsUpdate(
+              contactWithMemberships,
+              data.groups,
+              request,
+              manager,
+            );
+          }
+
+          return savedContact;
+        });
 
         this.logger.business(
           'log',
@@ -1741,6 +1759,12 @@ export class ContactsService {
     const model = getContactModel(createPersonDto);
     model.tenant = { id: tenantId } as Tenant;
 
+    // Stamp tenantId onto every email row so the DB-level tenant-scoped
+    // unique index (IDX_email_tenant_normalized_value) can enforce
+    // uniqueness — email has no other path to tenantId at insert time.
+    (model.emails || []).forEach((e) => {
+      (e as any).tenantId = tenantId;
+    });
 
     let newPerson: Contact;
     try {
@@ -2048,50 +2072,58 @@ export class ContactsService {
   private async updateEmailsEfficiently(
     existingContact: Contact,
     newEmails: Partial<Email>[],
+    manager: EntityManager,
   ): Promise<void> {
+    const tenantId = this.tenantContext.requireTenant();
+    const emailRepository = manager.getRepository(Email);
     const existingEmails = existingContact.emails || [];
     const emailsToKeep: Email[] = [];
     const emailsToUpdate: Email[] = [];
     const emailsToCreate: Partial<Email>[] = [];
 
     // Process new emails
-    newEmails.forEach((newEmail, index) => {
-      if (newEmail.id && index < existingEmails.length) {
-        // Update existing email
-        const existingEmail = existingEmails.find((e) => e.id === newEmail.id);
-        if (existingEmail) {
-          Object.assign(existingEmail, newEmail);
-          emailsToUpdate.push(existingEmail);
-          emailsToKeep.push(existingEmail);
-        }
-      } else {
-        // Create new email
-        emailsToCreate.push({
-          ...newEmail,
-          contactId: existingContact.id,
-        });
+    newEmails.forEach((newEmail) => {
+      // Only an id that this contact already owns may drive an update.
+      const existingEmail = newEmail.id
+        ? existingEmails.find((e) => e.id === newEmail.id)
+        : undefined;
+      if (existingEmail) {
+        const { value, category, isPrimary } = newEmail;
+        Object.assign(existingEmail, { value, category, isPrimary });
+        existingEmail.contact = existingContact;
+        existingEmail.contactId = existingContact.id;
+        existingEmail.tenantId = tenantId;
+        emailsToUpdate.push(existingEmail);
+        emailsToKeep.push(existingEmail);
+        return;
       }
+      // Drop any caller-supplied id so save() cannot hijack another row.
+      const { id: _ignoredId, ...emailData } = newEmail;
+      emailsToCreate.push({
+        ...emailData,
+        contactId: existingContact.id,
+        tenantId,
+      });
     });
-
     // Remove emails that are no longer needed
     const emailsToRemove = existingEmails.filter(
       (email) => !emailsToKeep.some((kept) => kept.id === email.id),
     );
 
     if (emailsToRemove.length > 0) {
-      await this.emailRepository.remove(emailsToRemove);
+      await emailRepository.remove(emailsToRemove);
     }
 
     // Update existing emails
     if (emailsToUpdate.length > 0) {
-      await this.emailRepository.save(emailsToUpdate);
+      await emailRepository.save(emailsToUpdate);
     }
 
     // Create new emails
     if (emailsToCreate.length > 0) {
-      const createdEmails = await this.emailRepository.save(
+      const createdEmails = await emailRepository.save(
         emailsToCreate.map((emailData) =>
-          this.emailRepository.create(emailData),
+          emailRepository.create(emailData),
         ),
       );
       emailsToKeep.push(...createdEmails);
@@ -2103,7 +2135,9 @@ export class ContactsService {
   private async updatePhonesEfficiently(
     existingContact: Contact,
     newPhones: Partial<Phone>[],
+    manager: EntityManager,
   ): Promise<void> {
+    const phoneRepository = manager.getRepository(Phone);
     const existingPhones = existingContact.phones || [];
     const phonesToKeep: Phone[] = [];
     const phonesToUpdate: Phone[] = [];
@@ -2134,19 +2168,19 @@ export class ContactsService {
     );
 
     if (phonesToRemove.length > 0) {
-      await this.phoneRepository.remove(phonesToRemove);
+      await phoneRepository.remove(phonesToRemove);
     }
 
     // Update existing phones
     if (phonesToUpdate.length > 0) {
-      await this.phoneRepository.save(phonesToUpdate);
+      await phoneRepository.save(phonesToUpdate);
     }
 
     // Create new phones
     if (phonesToCreate.length > 0) {
-      const createdPhones = await this.phoneRepository.save(
+      const createdPhones = await phoneRepository.save(
         phonesToCreate.map((phoneData) =>
-          this.phoneRepository.create(phoneData),
+          phoneRepository.create(phoneData),
         ),
       );
       phonesToKeep.push(...createdPhones);
@@ -2158,7 +2192,9 @@ export class ContactsService {
   private async updateAddressesEfficiently(
     existingContact: Contact,
     newAddresses: Partial<Address>[],
+    manager: EntityManager,
   ): Promise<void> {
+    const addressRepository = manager.getRepository(Address);
     const existingAddresses = existingContact.addresses || [];
     const addressesToKeep: Address[] = [];
     const addressesToUpdate: Address[] = [];
@@ -2191,19 +2227,19 @@ export class ContactsService {
     );
 
     if (addressesToRemove.length > 0) {
-      await this.addressRepository.remove(addressesToRemove);
+      await addressRepository.remove(addressesToRemove);
     }
 
     // Update existing addresses
     if (addressesToUpdate.length > 0) {
-      await this.addressRepository.save(addressesToUpdate);
+      await addressRepository.save(addressesToUpdate);
     }
 
     // Create new addresses
     if (addressesToCreate.length > 0) {
-      const createdAddresses = await this.addressRepository.save(
+      const createdAddresses = await addressRepository.save(
         addressesToCreate.map((addressData) =>
-          this.addressRepository.create(addressData),
+          addressRepository.create(addressData),
         ),
       );
       addressesToKeep.push(...createdAddresses);

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -742,16 +742,22 @@ export class ContactsService {
       contactId: request?.user?.contactId,
     });
 
-    const tenantId = this.tenantContext.requireTenant();
-    const allEmails = dataList.flatMap((d) =>
-      (d.emails || []).map((e) => e.value),
-    );
+  let tenantId: number;
+  try {
+     tenantId = this.tenantContext.requireTenant();
+     const allEmails = dataList.flatMap((d) =>
+       (d.emails || []).map((e) => e.value),
+     );
 
-    // Fail fast on duplicates within the batch before touching the DB.
-    // This is a whole-batch validation error on the submitted payload
-    // itself (not a per-row runtime failure), so it still throws for
-    // the caller to handle up front.
-    await this.assertEmailsAreUnique(allEmails, tenantId);
+     // Fail fast on duplicates within the batch before touching the DB.
+     // This is a whole-batch validation error on the submitted payload
+     // itself (not a per-row runtime failure), so it still throws for
+     // the caller to handle up front.
+     await this.assertEmailsAreUnique(allEmails, tenantId);
+   } catch (error) {
+     this.logger.endTracking(tracking, false);
+     throw error;
+   }
 
     const succeeded: Contact[] = [];
     const failed: BulkContactFailure[] = [];
@@ -1725,7 +1731,6 @@ export class ContactsService {
     const model = getContactModel(createPersonDto);
     model.tenant = { id: tenantId } as Tenant;
 
-    await this.getGroupRequest(createPersonDto);
 
     let newPerson: Contact;
     try {
@@ -1744,6 +1749,7 @@ export class ContactsService {
       }
       throw saveError;
     }
+    await this.getGroupRequest(createPersonDto);
 
     if (hasValue(createPersonDto.residence)) {
       createPersonDto.residence.contactId = newPerson.id;

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -180,6 +180,7 @@ export class ContactsService {
     rawEmails: (string | undefined | null)[],
     tenantId: number,
     excludeContactId?: number,
+    checkPersisted: boolean = true,
   ): Promise<void> {
     const normalized = rawEmails
       .filter((e): e is string => hasValue(e))
@@ -208,7 +209,9 @@ export class ContactsService {
       );
       throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
     }
-
+    if (!checkPersisted) {
+      return;
+    }
     const existing = await this.findExistingEmails(
       [...seen],
       tenantId,
@@ -749,11 +752,15 @@ export class ContactsService {
        (d.emails || []).map((e) => e.value),
      );
 
-     // Fail fast on duplicates within the batch before touching the DB.
-     // This is a whole-batch validation error on the submitted payload
-     // itself (not a per-row runtime failure), so it still throws for
-     // the caller to handle up front.
-     await this.assertEmailsAreUnique(allEmails, tenantId);
+     // Fail fast ONLY on duplicates within the submitted batch itself —
+     // that's a malformed-payload error, not tied to any one row, so it
+     // still throws for the caller to handle up front. We deliberately
+     // do NOT check here whether an email already exists in the DB
+     // (checkPersisted: false): that check runs per-row inside create()
+     // below, so one contact whose email already exists fails only that
+     // row and does not prevent the other rows in the batch from being
+     // created.
+     await this.assertEmailsAreUnique(allEmails, tenantId, undefined, false);
    } catch (error) {
      this.logger.endTracking(tracking, false);
      throw error;

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -57,6 +57,8 @@ import { groupCategories } from 'src/groups/groups.constants';
 import { AppLogger, ContextLogger } from 'src/utils/app-logger.service';
 import { GroupsMembershipService } from 'src/groups/services/group-membership.service';
 
+const CONTACT_EMAIL_EXISTS_MESSAGE = 'CONTACT ALREADY EXISTS WITH THAT EMAIL';
+
 @Injectable()
 export class ContactsService {
   private readonly repository: Repository<Contact>;
@@ -96,6 +98,106 @@ export class ContactsService {
 
   private static escapeLike(value: string): string {
     return value.replace(/[%_\\]/g, (match) => `\\${match}`);
+  }
+
+  private static normalizeEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
+
+  /**
+   * Returns which of the given (already-normalized) emails already exist
+   * for this tenant, optionally excluding a specific contact (used when
+   * editing a contact so it isn't blocked by its own current email).
+   */
+  private async findExistingEmails(
+    normalizedEmails: string[],
+    tenantId: number,
+    excludeContactId?: number,
+  ): Promise<string[]> {
+    if (normalizedEmails.length === 0) {
+      return [];
+    }
+    const qb = this.emailRepository
+      .createQueryBuilder('email')
+      .innerJoin('email.contact', 'contact')
+      .where('contact.tenantId = :tenantId', { tenantId })
+      .andWhere('LOWER(TRIM(email.value)) IN (:...normalizedEmails)', {
+        normalizedEmails,
+      });
+    if (excludeContactId) {
+      qb.andWhere('email.contactId != :excludeContactId', {
+        excludeContactId,
+      });
+    }
+    const rows = await qb.getMany();
+    return rows.map((r) => ContactsService.normalizeEmail(r.value));
+  }
+
+  private static maskEmail(email: string): string {
+    const [local, domain] = email.split('@');
+    return `${local.slice(0, 1)}***@${domain ?? ''}`;
+  }
+
+  /**
+   * Stringent duplicate-email guard used by every contact create/update
+   * path (single signup, bulk upload, and edits). Rejects:
+   *  - emails duplicated within the same submitted payload, and
+   *  - emails already registered for this tenant (unless they belong to
+   *    excludeContactId, e.g. the contact currently being edited).
+   */
+  private async assertEmailsAreUnique(
+    rawEmails: (string | undefined | null)[],
+    tenantId: number,
+    excludeContactId?: number,
+  ): Promise<void> {
+    const normalized = rawEmails
+      .filter((e): e is string => hasValue(e))
+      .map((e) => ContactsService.normalizeEmail(e));
+
+    if (normalized.length === 0) {
+      return;
+    }
+
+    const seen = new Set<string>();
+    const intraBatchDuplicates = new Set<string>();
+    for (const email of normalized) {
+      if (seen.has(email)) {
+        intraBatchDuplicates.add(email);
+      }
+      seen.add(email);
+    }
+    if (intraBatchDuplicates.size > 0) {
+      this.logger.business(
+        'warn',
+        'Duplicate email(s) found within submitted data',
+        {
+          operation: 'assertEmailsAreUnique',
+          metadata: { duplicateCount: intraBatchDuplicates.size },
+        },
+      );
+      throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+    }
+
+    const existing = await this.findExistingEmails(
+      [...seen],
+      tenantId,
+      excludeContactId,
+    );
+    if (existing.length > 0) {
+      this.logger.business(
+        'warn',
+        'Attempt to create/update contact with an email that already exists',
+        {
+          operation: 'assertEmailsAreUnique',
+          metadata: {
+            conflictingEmails: existing.map(ContactsService.maskEmail),
+            tenantId,
+            excludeContactId,
+          },
+        },
+      );
+      throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+    }
   }
 
   async findAll(req: ContactSearchDto, user?: any): Promise<ContactListDto[]> {
@@ -447,6 +549,13 @@ export class ContactsService {
         data.tenant = request.tenant;
       }
 
+      const tenantId = this.tenantContext.requireTenant();
+      data.tenant = { id: tenantId } as any;
+
+      // Stringent duplicate-email guard — applies to single creates and
+      // to each row processed via createMany() for bulk upload.
+      const incomingEmails = (data.emails || []).map((e) => e.value);
+      await this.assertEmailsAreUnique(incomingEmails, tenantId);
       const savedContact = await this.repository.save(data);
 
       this.logger.business('log', 'Contact created successfully', {
@@ -538,6 +647,61 @@ export class ContactsService {
     }
   }
 
+  /**
+   * Bulk creation entry point (e.g. bulk upload). Validates all emails in
+   * the batch up front — this catches duplicates *within* the submitted
+   * batch itself — then creates rows sequentially so each row's DB
+   * uniqueness check (inside create()) sees rows already committed
+   * earlier in the same batch.
+   *
+   * IMPORTANT: this loop must stay sequential (do not Promise.all it).
+   * Parallelizing would let two rows in the same batch race past the
+   * per-row DB check before either commits, reintroducing duplicates.
+   */
+  async createMany(dataList: Contact[], request?: any): Promise<Contact[]> {
+    const tracking = this.logger.startTracking('createManyContacts', {
+      userId: request?.user?.id,
+      contactId: request?.user?.contactId,
+    });
+
+    try {
+      const tenantId = this.tenantContext.requireTenant();
+      const allEmails = dataList.flatMap((d) =>
+        (d.emails || []).map((e) => e.value),
+      );
+
+      // Fail fast on duplicates within the batch before touching the DB.
+      await this.assertEmailsAreUnique(allEmails, tenantId);
+
+      const created: Contact[] = [];
+      for (const data of dataList) {
+        created.push(await this.create(data, request));
+      }
+
+      this.logger.business('log', 'Bulk contact creation completed', {
+        operation: 'createManyContacts',
+        userId: request?.user?.id,
+        contactId: request?.user?.contactId,
+        metadata: { requested: dataList.length, created: created.length },
+      });
+
+      this.logger.endTracking(tracking, true);
+      return created;
+    } catch (error) {
+      this.logger.error(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          operation: 'createManyContacts',
+          userId: request?.user?.id,
+          contactId: request?.user?.contactId,
+          resource: 'contacts',
+        },
+      );
+      this.logger.endTracking(tracking, false);
+      throw error;
+    }
+  }
+
   async update(data: Contact): Promise<Contact> {
     return await this.repository.save(data);
   }
@@ -588,6 +752,21 @@ export class ContactsService {
           resourceId: id,
         });
         throw new BadRequestException('Contact not found');
+      }
+
+      // Stringent duplicate-email guard — excludes this contact's own
+      // current email addresses so editing other fields (or re-saving
+      // the same email) doesn't falsely trip the check.
+      if (data.emails) {
+        const tenantId = this.tenantContext.requireTenant();
+        const incomingEmails = data.emails
+          .map((e) => e.value)
+          .filter((v): v is string => hasValue(v));
+        await this.assertEmailsAreUnique(
+          incomingEmails,
+          tenantId,
+          existingContact.id,
+        );
       }
 
       // Handle nested person update
@@ -1273,6 +1452,21 @@ export class ContactsService {
         throw new BadRequestException('Contact not found');
       }
 
+      // Stringent duplicate-email guard — excludes this contact's own
+      // current email addresses so editing other fields (or re-saving
+      // the same email) doesn't falsely trip the check.
+      if (data.emails) {
+        const tenantId = this.tenantContext.requireTenant();
+        const incomingEmails = (data.emails as Partial<Email>[])
+          .map((e) => e.value)
+          .filter((v): v is string => hasValue(v));
+        await this.assertEmailsAreUnique(
+          incomingEmails,
+          tenantId,
+          existingContact.id,
+        );
+      }
+
       // Handle nested person update
       if (data.person) {
         const personData = Array.isArray(data.person)
@@ -1374,23 +1568,12 @@ export class ContactsService {
   }
 
   async createPerson(createPersonDto: CreatePersonDto): Promise<Contact> {
-    //First check if email address exists
-    const emailData = await this.emailRepository.find({
-      where: [{ value: createPersonDto.email }],
-    });
-    if (emailData.length > 0) {
-      throw new BadRequestException({
-        message:
-          'Email already exists. This email has already been registered.',
-      });
-    }
+    const tenantId = this.tenantContext.requireTenant();
+
+    // Stringent, tenant-scoped, case-insensitive duplicate check
+    await this.assertEmailsAreUnique([createPersonDto.email], tenantId);
 
     const model = getContactModel(createPersonDto);
-
-    // Set tenant from context
-    const tenantId = this.tenantContext.requireTenant();
-    Logger.log('tenantId');
-    Logger.log(tenantId);
     model.tenant = { id: tenantId } as Tenant;
 
     await this.getGroupRequest(createPersonDto);
@@ -1571,11 +1754,21 @@ export class ContactsService {
     await this.repository.delete(id);
   }
 
+  /**
+   * Tenant-scoped, case-insensitive email lookup. Used for dedup checks
+   * outside the creation path. Kept consistent with assertEmailsAreUnique
+   * so a contact can never be "missed" here due to case/whitespace and
+   * accidentally resolve to a contact belonging to a different tenant.
+   */
   async findByEmail(email: string): Promise<Contact | undefined> {
-    const emailRecord = await this.emailRepository.findOne({
-      where: { value: email },
-      relations: ['contact'],
-    });
+    const tenantId = this.tenantContext.requireTenant();
+    const normalized = ContactsService.normalizeEmail(email);
+    const emailRecord = await this.emailRepository
+      .createQueryBuilder('email')
+      .innerJoinAndSelect('email.contact', 'contact')
+      .where('contact.tenantId = :tenantId', { tenantId })
+      .andWhere('LOWER(TRIM(email.value)) = :normalized', { normalized })
+      .getOne();
     return emailRecord?.contact;
   }
 

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -16,6 +16,7 @@ import {
   Connection,
   TreeRepository,
   DeepPartial,
+  EntityManager,
 } from 'typeorm';
 import Contact from './entities/contact.entity';
 import { CreatePersonDto } from './dto/create-person.dto';
@@ -59,8 +60,30 @@ import { GroupsMembershipService } from 'src/groups/services/group-membership.se
 
 const CONTACT_EMAIL_EXISTS_MESSAGE = 'CONTACT ALREADY EXISTS WITH THAT EMAIL';
 
+/**
+ * Postgres unique_violation SQLSTATE. Used as a defense-in-depth check
+ * against the assertEmailsAreUnique()/save() race: two concurrent
+ * requests can both pass the pre-check and then both attempt to save
+ * the same normalized email before either commits. This requires a
+ * DB-level unique index on (tenantId, LOWER(TRIM(email.value))) to
+ * actually prevent the race — without that index in place this catch
+ * is a no-op safety net only.
+ */
+const UNIQUE_VIOLATION_CODE = '23505';
+
+export interface BulkContactFailure {
+  index: number;
+  error: string;
+}
+
+export interface BulkContactResult {
+  succeeded: Contact[];
+  failed: BulkContactFailure[];
+}
+
 @Injectable()
 export class ContactsService {
+  private readonly connection: Connection;
   private readonly repository: Repository<Contact>;
   private readonly personRepository: Repository<Person>;
   private readonly companyRepository: Repository<Company>;
@@ -83,6 +106,7 @@ export class ContactsService {
     private groupsMembershipService: GroupsMembershipService,
     private tenantContext: TenantContext,
   ) {
+    this.connection = connection;
     this.repository = connection.getRepository(Contact);
     this.personRepository = connection.getRepository(Person);
     this.companyRepository = connection.getRepository(Company);
@@ -102,6 +126,13 @@ export class ContactsService {
 
   private static normalizeEmail(email: string): string {
     return email.trim().toLowerCase();
+  }
+
+  private static isUniqueEmailViolation(error: any): boolean {
+    return (
+      error?.code === UNIQUE_VIOLATION_CODE ||
+      error?.driverError?.code === UNIQUE_VIOLATION_CODE
+    );
   }
 
   /**
@@ -521,7 +552,20 @@ export class ContactsService {
     };
   }
 
-  async create(data: Contact, request?: any): Promise<Contact> {
+  /**
+   * Creates a single contact. Accepts an optional `manager` so callers
+   * (e.g. createMany()) can run this inside their own transaction —
+   * when omitted, the service's default repositories are used.
+   */
+  async create(
+    data: Contact,
+    request?: any,
+    manager?: EntityManager,
+  ): Promise<Contact> {
+    const repository = manager
+      ? manager.getRepository(Contact)
+      : this.repository;
+
     const tracking = this.logger.startTracking('createContact', {
       userId: request?.user?.id,
       contactId: request?.user?.contactId,
@@ -556,7 +600,31 @@ export class ContactsService {
       // to each row processed via createMany() for bulk upload.
       const incomingEmails = (data.emails || []).map((e) => e.value);
       await this.assertEmailsAreUnique(incomingEmails, tenantId);
-      const savedContact = await this.repository.save(data);
+
+      let savedContact: Contact;
+      try {
+        savedContact = await repository.save(data);
+      } catch (saveError) {
+        if (ContactsService.isUniqueEmailViolation(saveError)) {
+          // Defense-in-depth: closes the race window between the
+          // assertEmailsAreUnique() check above and this save, in case
+          // two concurrent requests both passed the pre-check. Requires
+          // a DB-level unique index on (tenantId, normalized email) to
+          // actually trigger here.
+          this.logger.business(
+            'warn',
+            'Duplicate email detected at database level on save',
+            {
+              operation: 'createContact',
+              userId: request?.user?.id,
+              contactId: request?.user?.contactId,
+              metadata: { tenantId },
+            },
+          );
+          throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+        }
+        throw saveError;
+      }
 
       this.logger.business('log', 'Contact created successfully', {
         operation: 'createContact',
@@ -657,49 +725,78 @@ export class ContactsService {
    * IMPORTANT: this loop must stay sequential (do not Promise.all it).
    * Parallelizing would let two rows in the same batch race past the
    * per-row DB check before either commits, reintroducing duplicates.
+   *
+   * Each row is created inside its own transaction: a failure on row N
+   * (contact save OR group assignment) rolls back only that row's
+   * writes and does not affect any other row — no half-created contact
+   * is left behind, and no earlier/later successful row is undone. The
+   * method never throws for a per-row failure; it always finishes and
+   * returns exactly which rows succeeded and which failed.
    */
-  async createMany(dataList: Contact[], request?: any): Promise<Contact[]> {
+  async createMany(
+    dataList: Contact[],
+    request?: any,
+  ): Promise<BulkContactResult> {
     const tracking = this.logger.startTracking('createManyContacts', {
       userId: request?.user?.id,
       contactId: request?.user?.contactId,
     });
 
-    try {
-      const tenantId = this.tenantContext.requireTenant();
-      const allEmails = dataList.flatMap((d) =>
-        (d.emails || []).map((e) => e.value),
-      );
+    const tenantId = this.tenantContext.requireTenant();
+    const allEmails = dataList.flatMap((d) =>
+      (d.emails || []).map((e) => e.value),
+    );
 
-      // Fail fast on duplicates within the batch before touching the DB.
-      await this.assertEmailsAreUnique(allEmails, tenantId);
+    // Fail fast on duplicates within the batch before touching the DB.
+    // This is a whole-batch validation error on the submitted payload
+    // itself (not a per-row runtime failure), so it still throws for
+    // the caller to handle up front.
+    await this.assertEmailsAreUnique(allEmails, tenantId);
 
-      const created: Contact[] = [];
-      for (const data of dataList) {
-        created.push(await this.create(data, request));
+    const succeeded: Contact[] = [];
+    const failed: BulkContactFailure[] = [];
+
+    for (let index = 0; index < dataList.length; index++) {
+      const data = dataList[index];
+      try {
+        // Isolated transaction per row: if the contact save or the
+        // group assignment inside create() throws, this row's writes
+        // roll back completely, leaving no orphaned/half-broken contact,
+        // while previously committed rows are unaffected.
+        const created = await this.connection.transaction((manager) =>
+          this.create(data, request, manager),
+        );
+        succeeded.push(created);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        failed.push({ index, error: message });
+        this.logger.error(
+          error instanceof Error ? error : new Error(message),
+          {
+            operation: 'createManyContacts',
+            userId: request?.user?.id,
+            contactId: request?.user?.contactId,
+            resource: 'contacts',
+            metadata: { rowIndex: index },
+          },
+        );
       }
-
-      this.logger.business('log', 'Bulk contact creation completed', {
-        operation: 'createManyContacts',
-        userId: request?.user?.id,
-        contactId: request?.user?.contactId,
-        metadata: { requested: dataList.length, created: created.length },
-      });
-
-      this.logger.endTracking(tracking, true);
-      return created;
-    } catch (error) {
-      this.logger.error(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          operation: 'createManyContacts',
-          userId: request?.user?.id,
-          contactId: request?.user?.contactId,
-          resource: 'contacts',
-        },
-      );
-      this.logger.endTracking(tracking, false);
-      throw error;
     }
+
+    this.logger.business('log', 'Bulk contact creation completed', {
+      operation: 'createManyContacts',
+      userId: request?.user?.id,
+      contactId: request?.user?.contactId,
+      metadata: {
+        requested: dataList.length,
+        succeeded: succeeded.length,
+        failed: failed.length,
+      },
+    });
+
+    this.logger.endTracking(tracking, failed.length === 0);
+    return { succeeded, failed };
   }
 
   async update(data: Contact): Promise<Contact> {
@@ -733,8 +830,13 @@ export class ContactsService {
       // Input validation
       this.validateUpdateData(data);
 
+      // Tenant-scoped lookup — prevents a request from loading and
+      // mutating a contact that belongs to a different tenant simply by
+      // supplying its id. Consistent with findAll/findByEmail/
+      // findByNameAndGroup elsewhere in this service.
+      const tenantId = this.tenantContext.requireTenant();
       const existingContact = await this.repository.findOne({
-        where: { id },
+        where: { id, tenant: { id: tenantId } },
         relations: [
           'person',
           'emails',
@@ -758,7 +860,6 @@ export class ContactsService {
       // current email addresses so editing other fields (or re-saving
       // the same email) doesn't falsely trip the check.
       if (data.emails) {
-        const tenantId = this.tenantContext.requireTenant();
         const incomingEmails = data.emails
           .map((e) => e.value)
           .filter((v): v is string => hasValue(v));
@@ -811,7 +912,26 @@ export class ContactsService {
 
       try {
         // Save the contact first (without group memberships to avoid constraint issues)
-        const savedContact = await this.repository.save(existingContact);
+        let savedContact: Contact;
+        try {
+          savedContact = await this.repository.save(existingContact);
+        } catch (saveError) {
+          if (ContactsService.isUniqueEmailViolation(saveError)) {
+            this.logger.business(
+              'warn',
+              'Duplicate email detected at database level on save',
+              {
+                operation: 'updateContact',
+                userId: request?.user?.id,
+                contactId: request?.user?.contactId,
+                resourceId: id,
+                metadata: { tenantId },
+              },
+            );
+            throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+          }
+          throw saveError;
+        }
 
         // Handle group membership updates after contact is saved
         const groups = (data as any).groups;
@@ -848,6 +968,9 @@ export class ContactsService {
           resourceId: id,
         });
         this.logger.endTracking(tracking, false);
+        if (error instanceof BadRequestException) {
+          throw error;
+        }
         throw new BadRequestException(
           `Failed to update contact: ${error.message}`,
         );
@@ -1431,8 +1554,13 @@ export class ContactsService {
       // Input validation
       this.validateUpdateData(data);
 
+      // Tenant-scoped lookup — prevents a request from loading and
+      // mutating a contact that belongs to a different tenant simply by
+      // supplying its id. Consistent with findAll/findByEmail/
+      // findByNameAndGroup elsewhere in this service.
+      const tenantId = this.tenantContext.requireTenant();
       const existingContact = await this.repository.findOne({
-        where: { id },
+        where: { id, tenant: { id: tenantId } },
         relations: [
           'person',
           'emails',
@@ -1456,7 +1584,6 @@ export class ContactsService {
       // current email addresses so editing other fields (or re-saving
       // the same email) doesn't falsely trip the check.
       if (data.emails) {
-        const tenantId = this.tenantContext.requireTenant();
         const incomingEmails = (data.emails as Partial<Email>[])
           .map((e) => e.value)
           .filter((v): v is string => hasValue(v));
@@ -1512,7 +1639,26 @@ export class ContactsService {
 
       try {
         // Save the contact first (without group memberships to avoid constraint issues)
-        const savedContact = await this.repository.save(existingContact);
+        let savedContact: Contact;
+        try {
+          savedContact = await this.repository.save(existingContact);
+        } catch (saveError) {
+          if (ContactsService.isUniqueEmailViolation(saveError)) {
+            this.logger.business(
+              'warn',
+              'Duplicate email detected at database level on save',
+              {
+                operation: 'updateContactWithGroups',
+                userId: request?.user?.id,
+                contactId: request?.user?.contactId,
+                resourceId: id,
+                metadata: { tenantId },
+              },
+            );
+            throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+          }
+          throw saveError;
+        }
 
         // Handle group membership updates after contact is saved
         if (data.groups !== undefined) {
@@ -1551,6 +1697,9 @@ export class ContactsService {
           resourceId: id,
         });
         this.logger.endTracking(tracking, false);
+        if (error instanceof BadRequestException) {
+          throw error;
+        }
         throw new BadRequestException(
           `Failed to update contact with groups: ${error.message}`,
         );
@@ -1577,7 +1726,25 @@ export class ContactsService {
     model.tenant = { id: tenantId } as Tenant;
 
     await this.getGroupRequest(createPersonDto);
-    const newPerson = await this.repository.save(model, { reload: true });
+
+    let newPerson: Contact;
+    try {
+      newPerson = await this.repository.save(model, { reload: true });
+    } catch (saveError) {
+      if (ContactsService.isUniqueEmailViolation(saveError)) {
+        this.logger.business(
+          'warn',
+          'Duplicate email detected at database level on save',
+          {
+            operation: 'createPerson',
+            metadata: { tenantId },
+          },
+        );
+        throw new BadRequestException(CONTACT_EMAIL_EXISTS_MESSAGE);
+      }
+      throw saveError;
+    }
+
     if (hasValue(createPersonDto.residence)) {
       createPersonDto.residence.contactId = newPerson.id;
       await this.addressesService.create(createPersonDto.residence);

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -662,11 +662,14 @@ export class ContactsService {
 
       for (const assignment of groupAssignments) {
         try {
-          await this.groupsMembershipService.create({
-            groupId: assignment.id,
-            members: [savedContact.id],
-            role: assignment.role || GroupRole.Member,
-          });
+          await this.groupsMembershipService.create(
+            {
+              groupId: assignment.id,
+              members: [savedContact.id],
+              role: assignment.role || GroupRole.Member,
+            },
+            manager,
+          );
 
           this.logger.business(
             'log',

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -311,8 +311,9 @@ export class ContactImportController {
 
           // createPerson() already enforces the tenant-scoped, stringent
           // duplicate-email check — a row whose email already exists for
-          // this tenant throws here and is handled below like any other
-          // row error.
+          // this tenant throws here. Unlike uploadFile(), the catch below
+          // rethrows, so one duplicate aborts the remaining rows of this
+          // upload.
           const newPerson = await this.service.createPerson(contactModel);
           const newPersonsGroup = {
             groupId: groupData.id,

--- a/src/crm/contollers/contact-import.controller.ts
+++ b/src/crm/contollers/contact-import.controller.ts
@@ -17,6 +17,7 @@ import { ContactsService } from '../contacts.service';
 import { Express } from 'express';
 import { Repository, Connection } from 'typeorm';
 import Company from '../entities/company.entity';
+import Contact from '../entities/contact.entity';
 import CompanyListDto from '../dto/company-list.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
@@ -32,12 +33,6 @@ import { UsersService } from 'src/users/users.service';
 import { generateRandomPassword } from 'src/utils/stringHelpers';
 import { TenantContextInterceptor } from 'src/interceptors/tenant-context.interceptor';
 import { ServiceRecordingService } from 'src/service-recording/service-recording.service';
-
-class Entity {
-  name: string;
-  phone: string;
-  email: string;
-}
 
 // parseContact()/getValueByKeys() already resolves firstName/lastName/email/phone/
 // dateOfBirth/gender headers case- and whitespace-insensitively. country, district,
@@ -145,9 +140,11 @@ export class ContactImportController {
           'The CSV file could not be parsed. Please ensure every row has a value for each column and that the file uses comma-separated format.',
       });
     }
-    const created = [];
-    const notCreated = [];
+
+    const created: Contact[] = [];
+    const notCreated: Record<string, any>[] = [];
     const errors: string[] = [];
+
     for (const [index, uploadedContact] of list.entries()) {
       try {
         const contactModel = parseContact(uploadedContact);
@@ -187,20 +184,34 @@ export class ContactImportController {
             });
           }
 
-          // Email-less contacts (e.g. children) fall back to (firstName, lastName, groupId)
-          // dedup — weaker than email since name collisions within a group are possible.
-          // Once child-to-parent linking lands, the parent becomes the authoritative anchor.
+          // Stringent duplicate-email enforcement: a row whose email is
+          // already registered for this tenant must be REJECTED, not
+          // silently merged into the existing contact. We therefore go
+          // straight to createPerson() for emailed contacts and let its
+          // tenant-scoped, case-insensitive uniqueness check reject
+          // duplicates (caught below and reported per-row, same as any
+          // other row-level failure).
+          //
+          // Email-less contacts (e.g. children) have no unique email to
+          // enforce, so they keep the weaker (firstName, lastName, groupId)
+          // dedup heuristic — reused if a match exists, created otherwise.
+          // Once child-to-parent linking lands, the parent becomes the
+          // authoritative anchor for this case.
           // See: https://github.com/kanzucodefoundation/project-zoe-server/issues/208
-          let person = contactModel.email
-            ? await this.service.findByEmail(contactModel.email)
-            : await this.service.findByNameAndGroup(
-                contactModel.firstName,
-                contactModel.lastName,
-                effectiveGroupId,
-              );
-          if (!person) {
+          let person: Contact;
+          if (contactModel.email) {
             person = await this.service.createPerson(contactModel);
+          } else {
+            person = await this.service.findByNameAndGroup(
+              contactModel.firstName,
+              contactModel.lastName,
+              effectiveGroupId,
+            );
+            if (!person) {
+              person = await this.service.createPerson(contactModel);
+            }
           }
+
           await this.groupMembershipService.create({
             groupId: effectiveGroupId,
             members: [person.id],
@@ -255,8 +266,8 @@ export class ContactImportController {
       });
     }
 
-    const created = [];
-    const notCreated = [];
+    const created: Contact[] = [];
+    const notCreated: Record<string, any>[] = [];
     for (const [index, uploadedContact] of list.entries()) {
       try {
         const contactModel = parseContact(uploadedContact);
@@ -298,6 +309,10 @@ export class ContactImportController {
             });
           }
 
+          // createPerson() already enforces the tenant-scoped, stringent
+          // duplicate-email check — a row whose email already exists for
+          // this tenant throws here and is handled below like any other
+          // row error.
           const newPerson = await this.service.createPerson(contactModel);
           const newPersonsGroup = {
             groupId: groupData.id,
@@ -314,7 +329,7 @@ export class ContactImportController {
             isActive: true,
           };
 
-          const newUser = await this.usersService.createUser(newUserObj);
+          await this.usersService.createUser(newUserObj);
         }
       } catch (err) {
         notCreated.push(uploadedContact);

--- a/src/crm/entities/email.entity.ts
+++ b/src/crm/entities/email.entity.ts
@@ -6,6 +6,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import Contact from './contact.entity';
+import { Tenant } from '../../tenants/entities/tenant.entity';
 import { EmailCategory } from '../enums/emailCategory';
 
 @Entity()
@@ -38,4 +39,14 @@ export default class Email {
 
   @Column()
   contactId: number;
+
+  @JoinColumn()
+  @ManyToOne((type) => Tenant, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  tenant?: Tenant;
+
+  @Column()
+  tenantId: number;
 }

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -258,8 +258,8 @@ describe('GroupsMembershipService', () => {
         where: expect.objectContaining({
           // Check for FindOperator with 'in' type and correct value
           id: expect.objectContaining({
-            _type: 'in',
-            _value: [51],
+            type: 'in',
+            value: [51],
           }),
           tenant: { id: TENANT_ID },
         }),

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -73,7 +73,17 @@ describe('GroupsMembershipService', () => {
       // to know about this repository. `In(ids)` produces a FindOperator
       // whose `.value` is the original id array.
       find: jest.fn().mockImplementation((options: any) => {
-        const ids: number[] = options?.where?.id?.value ?? [];
+        // Handle both direct arrays and FindOperator objects
+        let ids: number[] = [];
+        if (options?.where?.id) {
+          if (Array.isArray(options.where.id)) {
+            ids = options.where.id;
+          } else if (options.where.id && typeof options.where.id === 'object' && 'value' in options.where.id) {
+            ids = options.where.id.value;
+          }
+        } else if (options?.where?.id?.value) {
+          ids = options.where.id.value;
+        }
         return Promise.resolve(ids.map((id) => ({ id })));
       }),
     };
@@ -222,6 +232,16 @@ describe('GroupsMembershipService', () => {
     await expect(
       service.create({ groupId: 9, members: [51], role: GroupRole.Member }),
     ).rejects.toThrow(BadRequestException);
+
+    // Verify tenant-scoped query was made
+    expect(mockGroupRepository.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 9,
+          tenant: { id: TENANT_ID },
+        }),
+      }),
+    );
   });
 
   it('should reject adding a contact that does not belong to the current tenant', async () => {
@@ -231,6 +251,20 @@ describe('GroupsMembershipService', () => {
     await expect(
       service.create({ groupId: 9, members: [51], role: GroupRole.Member }),
     ).rejects.toThrow(BadRequestException);
+
+    // Verify tenant-scoped query was made
+    expect(mockContactRepository.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          // Check for FindOperator with 'in' type and correct value
+          id: expect.objectContaining({
+            _type: 'in',
+            _value: [51],
+          }),
+          tenant: { id: TENANT_ID },
+        }),
+      }),
+    );
   });
 
   it('should list memberships by contactId', async () => {

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -3,6 +3,7 @@ import { GroupsMembershipService } from './group-membership.service';
 import { Connection } from 'typeorm';
 import GroupMembership from '../entities/groupMembership.entity';
 import Group from '../entities/group.entity';
+import Contact from '../../crm/entities/contact.entity';
 import { AppLogger } from '../../utils/app-logger.service';
 import { GroupRole } from '../enums/groupRole';
 import { BadRequestException } from '@nestjs/common';
@@ -13,6 +14,7 @@ describe('GroupsMembershipService', () => {
   let mockConnection: Partial<Connection>;
   let mockMembershipRepository: any;
   let mockGroupRepository: any;
+  let mockContactRepository: any;
   let mockAppLogger: any;
   let mockContextLogger: any;
   let mockQb: any;
@@ -65,10 +67,21 @@ describe('GroupsMembershipService', () => {
         },
       },
     };
+    mockContactRepository = {
+      // Default: pretend every requested contact id belongs to the
+      // current tenant, so tests unrelated to tenant-scoping don't have
+      // to know about this repository. `In(ids)` produces a FindOperator
+      // whose `.value` is the original id array.
+      find: jest.fn().mockImplementation((options: any) => {
+        const ids: number[] = options?.where?.id?.value ?? [];
+        return Promise.resolve(ids.map((id) => ({ id })));
+      }),
+    };
 
     mockConnection = {
       getRepository: jest.fn().mockImplementation((entity) => {
         if (entity === Group) return mockGroupRepository;
+        if (entity === Contact) return mockContactRepository;
         return mockMembershipRepository;
       }),
       getTreeRepository: jest.fn().mockImplementation((entity) => {
@@ -201,6 +214,23 @@ describe('GroupsMembershipService', () => {
     });
 
     expect(inserted).toBe(1);
+  });
+  
+  it('should reject creating memberships for a group belonging to a different tenant', async () => {
+    mockGroupRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.create({ groupId: 9, members: [51], role: GroupRole.Member }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('should reject adding a contact that does not belong to the current tenant', async () => {
+    // No contacts come back for this tenant, even though the group is valid.
+    mockContactRepository.find.mockResolvedValue([]);
+
+    await expect(
+      service.create({ groupId: 9, members: [51], role: GroupRole.Member }),
+    ).rejects.toThrow(BadRequestException);
   });
 
   it('should list memberships by contactId', async () => {

--- a/src/groups/services/group-membership.service.spec.ts
+++ b/src/groups/services/group-membership.service.spec.ts
@@ -6,6 +6,7 @@ import Group from '../entities/group.entity';
 import { AppLogger } from '../../utils/app-logger.service';
 import { GroupRole } from '../enums/groupRole';
 import { BadRequestException } from '@nestjs/common';
+import { TenantContext } from 'src/shared/tenant/tenant-context';
 
 describe('GroupsMembershipService', () => {
   let service: GroupsMembershipService;
@@ -15,7 +16,8 @@ describe('GroupsMembershipService', () => {
   let mockAppLogger: any;
   let mockContextLogger: any;
   let mockQb: any;
-
+  let mockTenantContext: any;
+  const TENANT_ID = 1;
   beforeEach(async () => {
     mockQb = {
       select: jest.fn().mockReturnThis(),
@@ -89,6 +91,10 @@ describe('GroupsMembershipService', () => {
       createContextLogger: jest.fn().mockReturnValue(mockContextLogger),
     };
 
+    mockTenantContext = {
+      requireTenant: jest.fn().mockReturnValue(TENANT_ID),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GroupsMembershipService,
@@ -100,6 +106,10 @@ describe('GroupsMembershipService', () => {
           provide: AppLogger,
           useValue: mockAppLogger,
         },
+        {
+          provide: TenantContext,
+          useValue: mockTenantContext,
+        }
       ],
     }).compile();
 

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -224,7 +224,7 @@ export class GroupsMembershipService {
     }
     const tenantId = this.tenantContext.requireTenant();
     const group = await groupRepository.findOne({
-      where: { id: groupId, tenant: { id: tenantId } } as any,
+      where: { id: groupId, tenant: { id: tenantId } },
     });
     if (!group) {
       throw new BadRequestException(
@@ -238,7 +238,7 @@ export class GroupsMembershipService {
     // contact just saved earlier in the same transaction is visible
     // here even though it isn't committed yet.
     const tenantContacts = await contactRepository.find({
-      where: { id: In(uniqueMemberIds), tenant: { id: tenantId } } as any,
+      where: { id: In(uniqueMemberIds), tenant: { id: tenantId } },
       select: ['id'],
     });
     const tenantContactIds = new Set(tenantContacts.map((c) => c.id));

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -17,6 +17,7 @@ import { hasNoValue, hasValue } from '../../utils/validation';
 import Group from '../entities/group.entity';
 import { GroupRole } from '../enums/groupRole';
 import { AppLogger, ContextLogger } from 'src/utils/app-logger.service';
+import { TenantContext } from '../../shared/tenant/tenant-context';
 
 @Injectable()
 export class GroupsMembershipService {
@@ -28,6 +29,7 @@ export class GroupsMembershipService {
   constructor(
     @Inject('CONNECTION') connection: Connection,
     private readonly appLogger: AppLogger,
+    private readonly tenantContext: TenantContext,
   ) {
     this.repository = connection.getRepository(GroupMembership);
     this.groupRepository = connection.getRepository(Group);
@@ -192,6 +194,11 @@ export class GroupsMembershipService {
    * all-or-nothing rollback guarantee. When no manager is supplied, the
    * service's default repository is used, preserving existing behavior for
    * every other call site.
+   * 
+   * Tenant-scoped: the target group must belong to the caller's current
+   * tenant. Without this check, a request could supply a groupId
+   * belonging to a different tenant and attach a contact to it, crossing
+   * tenant boundaries.
    */
   async create(
     data: BatchGroupMembershipDto,
@@ -200,14 +207,24 @@ export class GroupsMembershipService {
     const repository = manager
       ? manager.getRepository(GroupMembership)
       : this.repository;
-
+     const groupRepository = manager
+      ? manager.getRepository(Group)
+      : this.groupRepository;
     const { groupId, members, role } = data;
     const uniqueMemberIds = [...new Set(members)];
 
     if (uniqueMemberIds.length === 0) {
       throw new BadRequestException('At least one member is required');
     }
-
+    const tenantId = this.tenantContext.requireTenant();
+    const group = await groupRepository.findOne({
+      where: { id: groupId, tenant: { id: tenantId } } as any,
+    });
+    if (!group) {
+      throw new BadRequestException(
+        `Group ${groupId} does not exist for this tenant`,
+      );
+    }
     const existing = await repository.find({
       where: uniqueMemberIds.map((contactId) => ({ contactId, groupId })),
     });

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -15,6 +15,7 @@ import UpdateGroupMembershipDto from '../dto/membership/update-group-membership.
 import BatchGroupMembershipDto from '../dto/membership/batch-group-membership.dto';
 import { hasNoValue, hasValue } from '../../utils/validation';
 import Group from '../entities/group.entity';
+import Contact from '../../crm/entities/contact.entity';
 import { GroupRole } from '../enums/groupRole';
 import { AppLogger, ContextLogger } from 'src/utils/app-logger.service';
 import { TenantContext } from '../../shared/tenant/tenant-context';
@@ -23,6 +24,7 @@ import { TenantContext } from '../../shared/tenant/tenant-context';
 export class GroupsMembershipService {
   private readonly repository: Repository<GroupMembership>;
   private readonly groupRepository: Repository<Group>;
+  private readonly contactRepository: Repository<Contact>;
   private readonly connection: Connection;
   private readonly logger: ContextLogger;
 
@@ -33,6 +35,7 @@ export class GroupsMembershipService {
   ) {
     this.repository = connection.getRepository(GroupMembership);
     this.groupRepository = connection.getRepository(Group);
+    this.contactRepository = connection.getRepository(Contact);
     this.connection = connection;
     this.logger = this.appLogger.createContextLogger('GroupsMembershipService');
   }
@@ -210,6 +213,9 @@ export class GroupsMembershipService {
      const groupRepository = manager
       ? manager.getRepository(Group)
       : this.groupRepository;
+     const contactRepository = manager
+      ? manager.getRepository(Contact)
+      : this.contactRepository;
     const { groupId, members, role } = data;
     const uniqueMemberIds = [...new Set(members)];
 
@@ -223,6 +229,27 @@ export class GroupsMembershipService {
     if (!group) {
       throw new BadRequestException(
         `Group ${groupId} does not exist for this tenant`,
+      );
+    }
+    // Tenant-scoped contact validation — without this, a caller could
+    // supply a contactId belonging to a different tenant and attach it
+    // to a group in the current tenant, crossing tenant boundaries.
+    // Uses the transaction-scoped repository (when supplied) so a
+    // contact just saved earlier in the same transaction is visible
+    // here even though it isn't committed yet.
+    const tenantContacts = await contactRepository.find({
+      where: { id: In(uniqueMemberIds), tenant: { id: tenantId } } as any,
+      select: ['id'],
+    });
+    const tenantContactIds = new Set(tenantContacts.map((c) => c.id));
+    const foreignOrMissingIds = uniqueMemberIds.filter(
+      (id) => !tenantContactIds.has(id),
+    );
+    if (foreignOrMissingIds.length > 0) {
+      throw new BadRequestException(
+        `Contact(s) ${foreignOrMissingIds.join(
+          ', ',
+        )} do not exist for this tenant`,
       );
     }
     const existing = await repository.find({

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { Connection, In, Repository } from 'typeorm';
+import { Connection, EntityManager, In, Repository } from 'typeorm';
 import GroupMembership from '../entities/groupMembership.entity';
 import GroupMembershipDto from '../dto/membership/group-membership.dto';
 import { getPersonFullName } from '../../crm/crm.helpers';
@@ -181,7 +181,26 @@ export class GroupsMembershipService {
     } as GroupMembershipDto;
   }
 
-  async create(data: BatchGroupMembershipDto): Promise<number> {
+  /**
+   * Creates/reactivates group memberships. Accepts an optional `manager` so
+   * callers that run their own transaction (e.g. ContactsService.create()
+   * from within createMany()'s per-row transaction) can have this write
+   * participate in that same transaction. Without this, the membership
+   * insert would run against the default connection and either fail to see
+   * the just-saved, not-yet-committed contact row (foreign key violation),
+   * or commit independently of the contact save — breaking the per-row
+   * all-or-nothing rollback guarantee. When no manager is supplied, the
+   * service's default repository is used, preserving existing behavior for
+   * every other call site.
+   */
+  async create(
+    data: BatchGroupMembershipDto,
+    manager?: EntityManager,
+  ): Promise<number> {
+    const repository = manager
+      ? manager.getRepository(GroupMembership)
+      : this.repository;
+
     const { groupId, members, role } = data;
     const uniqueMemberIds = [...new Set(members)];
 
@@ -189,7 +208,7 @@ export class GroupsMembershipService {
       throw new BadRequestException('At least one member is required');
     }
 
-    const existing = await this.repository.find({
+    const existing = await repository.find({
       where: uniqueMemberIds.map((contactId) => ({ contactId, groupId })),
     });
     const existingByContactId = new Map(existing.map((m) => [m.contactId, m]));
@@ -222,12 +241,12 @@ export class GroupsMembershipService {
         // already active — skip
       } else {
         toCreate.push(
-          this.repository.create({ groupId, contactId, role, isActive: true }),
+          repository.create({ groupId, contactId, role, isActive: true }),
         );
       }
     }
 
-    const saved = await this.repository.save([...toReactivate, ...toCreate]);
+    const saved = await repository.save([...toReactivate, ...toCreate]);
 
     this.logger.business('log', 'Group memberships upserted', {
       resource: 'group_membership',

--- a/src/migrations/1783516200000-AddTenantScopedEmailUniqueConstraint.ts
+++ b/src/migrations/1783516200000-AddTenantScopedEmailUniqueConstraint.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTenantScopedEmailUniqueConstraint1783516200000
+  implements MigrationInterface
+{
+  name = 'AddTenantScopedEmailUniqueConstraint1783516200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Denormalize tenantId onto email so we can enforce a tenant-scoped
+    // uniqueness constraint at the DB level (email has no direct tenant
+    // column today — it's only reachable via email.contact.tenantId).
+    await queryRunner.query(
+      'ALTER TABLE "email" ADD COLUMN IF NOT EXISTS "tenantId" integer',
+    );
+
+    // Backfill from the owning contact.
+    await queryRunner.query(`
+      UPDATE "email" e
+      SET "tenantId" = c."tenantId"
+      FROM "contact" c
+      WHERE e."contactId" = c."id"
+        AND e."tenantId" IS NULL
+    `);
+
+    await queryRunner.query(
+      'ALTER TABLE "email" ALTER COLUMN "tenantId" SET NOT NULL',
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "email" ADD CONSTRAINT "FK_email_tenantId" FOREIGN KEY ("tenantId") REFERENCES "tenant"("id") ON DELETE CASCADE',
+    );
+
+    // Tenant-scoped, case/whitespace-insensitive uniqueness. Mirrors the
+    // normalization ContactsService.normalizeEmail()/assertEmailsAreUnique()
+    // already do in the application layer, so a race between two concurrent
+    // requests now fails at the DB with 23505 instead of both succeeding.
+    // Fail loudly with the offending pairs instead of a bare unique-violation
+    // if legacy data already contains tenant-scoped duplicates.
+    const duplicates = await queryRunner.query(`
+      SELECT "tenantId", LOWER(TRIM("value")) AS normalized, COUNT(*) AS count
+      FROM "email"
+      GROUP BY "tenantId", LOWER(TRIM("value"))
+      HAVING COUNT(*) > 1
+    `);
+    if (duplicates.length > 0) {
+      throw new Error(
+        `Cannot create IDX_email_tenant_normalized_value: ${duplicates.length} duplicate (tenantId, normalized email) groups exist. Resolve them before deploying.`,
+      );
+    }
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_email_tenant_normalized_value"
+      ON "email" (LOWER(TRIM("value")), "tenantId")
+      WHERE "value" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX "public"."IDX_email_tenant_normalized_value"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "email" DROP CONSTRAINT "FK_email_tenantId"',
+    );
+    await queryRunner.query('ALTER TABLE "email" DROP COLUMN "tenantId"');
+  }
+}

--- a/src/tenants/tenants.service.ts
+++ b/src/tenants/tenants.service.ts
@@ -73,6 +73,7 @@ export class TenantsService {
     const groupMembershipService = new GroupsMembershipService(
       this.connection,
       appLogger,
+      mockTenantContext,
     );
     const groupTreeService = new GroupTreeService(this.connection, null); // Pass null for cache manager in this context
 


### PR DESCRIPTION
## Summary of changes

Adds a stringent, tenant-scoped duplicate-email check across all contact creation and update paths in `ContactsService`, **and closes a gap in bulk upload where rows with an already-existing email were being silently imported/merged instead of rejected.**

**Service (`ContactsService`)**
- Introduced shared private helpers: `normalizeEmail`,   `findExistingEmails`, `assertEmailsAreUnique`. All email comparisons
  are trimmed, lower-cased, and scoped to `tenantId`.
- `createPerson()`: replaced the previous global, case-sensitive check   with the shared tenant-scoped helper. Removed leftover debug logs.
- `create()`: now validates incoming emails before saving (previously   had no check at all).
- `createMany(dataList, request)`: bulk-creation entry point with   intra-batch duplicate detection and sequential (non-parallel)
  per-row creation.
- `updatePartial()` / `updateWithGroups()`: same guard applied on   edits, using `excludeContactId` so a contact isn't blocked by its   own current email.
- `findByEmail()`: **fixed to be tenant-scoped and case/whitespace   normalized** — previously it did a raw, cross-tenant, case-sensitive   match, which is what allowed the bulk-upload gap described below.
- Standardized the rejection message to   `CONTACT ALREADY EXISTS WITH THAT EMAIL`.

**Bulk upload (`ContactImportController.uploadFile`)**
- **Fixed the actual reported bug:** rows with an email were   previously looked up via `findByEmail()` and, if found, silently
  reused/merged into the existing contact and reported as a   successful import. This bypassed the duplicate-email policy
  entirely. Emailed rows now go straight through `createPerson()`,   which enforces the same tenant-scoped, case-insensitive check as   every other path — a duplicate is rejected and reported as a   per-row error, exactly like any other validation failure, and is   **not** created or merged. 
- Contacts without an email (e.g. children) keep the existing   `(firstName, lastName, groupId)` fallback dedup, since there's no
  email to enforce uniqueness on. 
- Removed dead `class Entity` declaration and an unused variable   assignment in `uploadGroupLeaders()`.
- Added explicit typing (`Contact[]`, `Record<string, any>[]`) in   place of implicit `any[]` on the touched arrays.

## How this can be tested

**Duplicate-email guard (service-level, from before)**
1. Single create/update with a new email → succeeds.
2. Single create with a duplicate (same tenant) → `400    CONTACT ALREADY EXISTS WITH THAT EMAIL`.
3. Case/whitespace insensitivity: `Test@Example.com` vs    `  test@example.com ` → treated as the same email.
4. Cross-tenant isolation: same email under two different tenants →    both succeed independently.
5. Edit without touching email → succeeds, no false positive.
6. Edit re-saving the contact's own unchanged email → succeeds.
7. Edit changing to another contact's email → rejected.

**Bulk upload (new in this round)**
8. Upload a CSV containing one row whose email already exists for the    tenant → that row appears in `errors`, is **not** added to    `successfulRows`, and no group membership is created for it.
9. Upload a CSV with two rows sharing the same email → the first row    succeeds, the second is rejected as a duplicate (sequential   per-row processing means the second row's check sees the first    row's committed email).
10. Upload a CSV with an email that differs only by case/whitespace    from an existing contact's email → still rejected (previously this    exact case slipped through via `findByEmail()`'s case-sensitive     match).
11. Upload a CSV of entirely new, unique emails → all rows succeed as     before.
12. Upload a CSV of email-less child rows matching an existing     `(firstName, lastName, groupId)` combination → existing contact is     reused and added to the group, no duplicate created (unchanged     behavior).
13. `uploadGroupLeaders`: upload a CSV whose first row has a duplicate     email → request fails immediately with the duplicate-email     message, no rows are created (unchanged behavior, now backed by     the fixed tenant-scoped check).

## Note for reviewers

- The bulk-upload fix removes the previous "reuse existing contact by   email, just add them to the new group" behavior. If there's a   legitimate use case for re-importing an existing contact into an   additional group by email, that would need to be an explicit,   separate operation — not an implicit side effect of hitting a   duplicate email during import. Flagging this in case it's a used   workflow today.
- `findByEmail()` is now tenant-scoped and normalized. It's no longer   called from `uploadFile()`, but it's a public method and may be used   elsewhere, so it was corrected in place rather than removed.
- This remains an application-level check; two genuinely concurrent   API requests could still both pass validation before either   commits. A DB-level unique index scoped by tenant (e.g. on   `(tenant_id, lower(trim(email.value)))`) would close that gap fully   and is intentionally not included here.
- `createMany()` and the `uploadFile` loop both intentionally process   rows sequentially rather than in parallel — required for the   per-row DB check to see earlier rows in the same batch.
- `uploadGroupLeaders()` still stops the entire batch on the first   error (pre-existing behavior, unchanged), whereas `uploadFile()`   continues and reports per-row errors. Flagging the inconsistency in   case reviewers want them aligned in a follow-up.

## Out of scope

- DB-level unique constraint / migration for full concurrency safety.
- Deduplication or merge tooling for emails that already exist as   duplicates in production data prior to this change.
- Changes to phone or address uniqueness — this PR only addresses  email.
- Rate limiting or throttling of bulk upload requests.
- Frontend/UI changes to surface the new error message.
- Reconciling the differing error-handling strategies between   `uploadFile` (continue-on-error, per-row report) and   `uploadGroupLeaders` (stop-on-first-error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate contact emails within the same tenant, regardless of capitalization or surrounding whitespace.
  - Improved duplicate detection during contact creation, bulk imports, updates, and group assignments.
  - Ensured contact imports consistently reject duplicate email addresses while preserving deduplication for contacts without emails.
  - Improved email lookup accuracy and duplicate-error handling.
  - Prevented failed bulk-import records from affecting successfully processed records.
  - Added tenant validation for group membership changes.
  - Ensured failed email updates preserve the existing contact email.

- **New Features**
  - Bulk imports now report successful and failed records individually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->