### PR TITLE
fix: align mca/weekly-summary week window with MC Attendance Report's…

### DIFF
--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1389,7 +1389,7 @@ describe('ReportsService', () => {
       expect(result.breakdown).toEqual([]);
     });
 
-    it("filters submissions by the current week's reportingPeriod, matching the displayed weekStart", async () => {
+    it("filters submissions by the current week's reportingPeriod, three days before the displayed Wednesday weekStart", async () => {
       const field = {
         id: 1,
         label: 'How many attended MC?',
@@ -1421,7 +1421,54 @@ describe('ReportsService', () => {
       const periodCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
         sql.includes('submission.reportingPeriod ='),
       );
-      expect(periodCall[1].period).toBe(result.weekStart);
+      // periodCall's period is the Sunday-anchored reportingPeriod key
+      // stored on submissions; the displayed weekStart is that same date
+      // shifted forward to the Wednesday it represents (see
+      // getDueDayAwarePeriodStart).
+      const queriedPeriod = new Date(periodCall[1].period + 'T00:00:00');
+      const displayedWeekStart = new Date(result.weekStart + 'T00:00:00');
+      const diffDays =
+        (displayedWeekStart.getTime() - queriedPeriod.getTime()) /
+        (1000 * 60 * 60 * 24);
+      expect(diffDays).toBe(3);
+      expect(displayedWeekStart.getDay()).toBe(3); // Wednesday
+    });
+
+    it("queries the previous reportingPeriod (last Sunday) when today is in the Sun-Tue catch-up window, while still displaying that period's Wednesday", async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-17T09:00:00')); // Monday
+      const field = {
+        id: 1,
+        label: 'How many attended MC?',
+        report: { id: 100 },
+      };
+      mockRepositories.reportField.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(field, 'getOne'),
+      );
+      mockRepositories.groupMembership.find.mockResolvedValue([
+        { groupId: 10 },
+      ]);
+      mockGroupTreeService.getGroupAndAllChildren = jest
+        .fn()
+        .mockResolvedValue([10]);
+
+      const submissionQb = makeQueryBuilder([]);
+      mockRepositories.reportSubmission.createQueryBuilder.mockReturnValue(
+        submissionQb,
+      );
+
+      const result = await service.getWeeklyMcaSummary(mockUser);
+
+      const periodCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
+        sql.includes('submission.reportingPeriod ='),
+      );
+      // Monday 2026-08-17 falls before this calendar week's Wednesday, so
+      // it's a catch-up submission for the period due last Wednesday
+      // (2026-08-12) -- stored under last Sunday, 2026-08-09.
+      expect(periodCall[1].period).toBe('2026-08-09');
+      expect(result.weekStart).toBe('2026-08-12');
+      expect(result.weekEnd).toBe('2026-08-18');
+
+      jest.useRealTimers();
     });
   });
   describe('getMcSubmissionCompliance', () => {

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1154,6 +1154,7 @@ describe('ReportsService', () => {
     ) => {
       const qb: any = {
         innerJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
         leftJoinAndSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -575,10 +575,10 @@ describe('ReportsService', () => {
     currentPeriodStart.setDate(
       currentPeriodStart.getDate() - currentPeriodStart.getDay(),
     );
-    const previousPeriodStart = new Date(currentPeriodStart);
-    previousPeriodStart.setDate(previousPeriodStart.getDate() - 7);
+    const nextPeriodStart = new Date(currentPeriodStart);
+    nextPeriodStart.setDate(nextPeriodStart.getDate() + 7);
     const currentPeriod = formatDateKey(currentPeriodStart);
-    const previousPeriod = formatDateKey(previousPeriodStart);
+    const nextPeriod = formatDateKey(nextPeriodStart);
 
     it('blocks a second submission of the same report for the same group in the same week', async () => {
       mockRepositories.groupTree.findOne.mockResolvedValue(
@@ -709,7 +709,7 @@ describe('ReportsService', () => {
         ['Monday', 1],
         ['Tuesday', 2],
       ])(
-        'targets the previous week when submitting on %s (catch-up window)',
+        'targets the current Sunday-anchored week when submitting on %s (catch-up window for last Wednesday)',
         async (_label, dayOffset) => {
           const day = new Date(currentPeriodStart);
           day.setDate(day.getDate() + dayOffset);
@@ -735,17 +735,17 @@ describe('ReportsService', () => {
           ).toHaveBeenCalledWith(
             expect.objectContaining({
               where: expect.objectContaining({
-                reportingPeriod: previousPeriod,
+                reportingPeriod: currentPeriod,
               }),
             }),
           );
           expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
-            expect.objectContaining({ reportingPeriod: previousPeriod }),
+            expect.objectContaining({ reportingPeriod: currentPeriod }),
           );
         },
       );
 
-      it('targets the current week when submitting on the Wednesday due day, even if last week was missed', async () => {
+      it('targets the upcoming Sunday-anchored cycle when submitting on the Wednesday due day, even if that cycle was never opened before', async () => {
         const thisWeekWednesday = new Date(currentPeriodStart);
         thisWeekWednesday.setDate(thisWeekWednesday.getDate() + 3);
         jest.useFakeTimers().setSystemTime(thisWeekWednesday);
@@ -753,9 +753,10 @@ describe('ReportsService', () => {
         mockRepositories.groupTree.findOne.mockResolvedValue(
           makeGroup(10, 'MC Nairobi'),
         );
-        // Current week is open; whether last week has a submission must
-        // not matter -- an on-time Wednesday submission always targets
-        // this week, never gets silently redirected to last week.
+        // The Wednesday due day starts a *new* cycle (keyed by the
+        // following Sunday), so whether the current Sunday-anchored week
+        // has a submission must not matter -- an on-time Wednesday
+        // submission always targets its own upcoming cycle.
         mockRepositories.reportSubmission.findOne.mockResolvedValue(null);
         mockRepositories.reportField.find.mockResolvedValue([
           { name: 'groupId' },
@@ -770,11 +771,11 @@ describe('ReportsService', () => {
         expect(result.status).toBe(200);
         expect(mockRepositories.reportSubmission.findOne).toHaveBeenCalledWith(
           expect.objectContaining({
-            where: expect.objectContaining({ reportingPeriod: currentPeriod }),
+            where: expect.objectContaining({ reportingPeriod: nextPeriod }),
           }),
         );
         expect(mockRepositories.reportSubmission.save).toHaveBeenCalledWith(
-          expect.objectContaining({ reportingPeriod: currentPeriod }),
+          expect.objectContaining({ reportingPeriod: nextPeriod }),
         );
       });
 
@@ -784,12 +785,12 @@ describe('ReportsService', () => {
         mockRepositories.groupTree.findOne.mockResolvedValue(
           makeGroup(10, 'MC Nairobi'),
         );
-        // Last week's (the catch-up target's) slot is already filled.
+        // The catch-up target (this Sunday-anchored week) is already filled.
         mockRepositories.reportSubmission.findOne.mockResolvedValue({
           id: 54,
           report: { id: 1 },
           group: { id: 10 },
-          reportingPeriod: previousPeriod,
+          reportingPeriod: currentPeriod,
         });
 
         await expect(
@@ -799,7 +800,7 @@ describe('ReportsService', () => {
         expect(mockRepositories.reportSubmission.save).not.toHaveBeenCalled();
       });
 
-      it('a Sunday catch-up followed by an on-time Wednesday submission covers two distinct weeks, not one', async () => {
+      it('a Sunday catch-up followed by an on-time Wednesday submission covers two distinct cycles, not one', async () => {
         // End-to-end sequence for the exact frustration this feature fixes:
         // forgetting last Wednesday, catching up on Sunday, then still
         // being able to submit on time this Wednesday.
@@ -811,8 +812,8 @@ describe('ReportsService', () => {
           { name: 'groupId' },
         ]);
 
-        // Step 1: catch-up submission on this week's Sunday. Nothing on
-        // file yet for either period.
+        // Step 1: catch-up submission on this week's Sunday, closing out
+        // last Wednesday's cycle. Nothing on file yet for either period.
         jest.useFakeTimers().setSystemTime(currentPeriodStart);
         mockRepositories.reportSubmission.findOne.mockResolvedValueOnce(null);
         const firstResult = await service.submitReport(
@@ -823,12 +824,12 @@ describe('ReportsService', () => {
         expect(firstResult.status).toBe(200);
         expect(mockRepositories.reportSubmission.save).toHaveBeenNthCalledWith(
           1,
-          expect.objectContaining({ reportingPeriod: previousPeriod }),
+          expect.objectContaining({ reportingPeriod: currentPeriod }),
         );
 
-        // Step 2: on-time submission on this week's Wednesday. The
-        // catch-up above only filled previousPeriod, so currentPeriod is
-        // still open.
+        // Step 2: on-time submission on this week's Wednesday opens the
+        // *next* cycle. The catch-up above only filled currentPeriod, so
+        // nextPeriod is still open.
         const thisWeekWednesday = new Date(currentPeriodStart);
         thisWeekWednesday.setDate(thisWeekWednesday.getDate() + 3);
         jest.useFakeTimers().setSystemTime(thisWeekWednesday);
@@ -841,7 +842,7 @@ describe('ReportsService', () => {
         expect(secondResult.status).toBe(200);
         expect(mockRepositories.reportSubmission.save).toHaveBeenNthCalledWith(
           2,
-          expect.objectContaining({ reportingPeriod: currentPeriod }),
+          expect.objectContaining({ reportingPeriod: nextPeriod }),
         );
       });
     });
@@ -1389,7 +1390,7 @@ describe('ReportsService', () => {
       expect(result.breakdown).toEqual([]);
     });
 
-    it("filters submissions by the current week's reportingPeriod, three days before the displayed Wednesday weekStart", async () => {
+    it("filters submissions by the current week's reportingPeriod, four days after the displayed Wednesday weekStart", async () => {
       const field = {
         id: 1,
         label: 'How many attended MC?',
@@ -1422,19 +1423,20 @@ describe('ReportsService', () => {
         sql.includes('submission.reportingPeriod ='),
       );
       // periodCall's period is the Sunday-anchored reportingPeriod key
-      // stored on submissions; the displayed weekStart is that same date
-      // shifted forward to the Wednesday it represents (see
-      // getDueDayAwarePeriodStart).
+      // stored on submissions -- the Sunday that falls *inside* the
+      // Wed..Tue cycle, 4 days after the Wednesday it represents (see
+      // getDueDayAwarePeriodStart) -- so the displayed weekStart is that
+      // same date shifted *back* to the Wednesday.
       const queriedPeriod = new Date(periodCall[1].period + 'T00:00:00');
       const displayedWeekStart = new Date(result.weekStart + 'T00:00:00');
       const diffDays =
         (displayedWeekStart.getTime() - queriedPeriod.getTime()) /
         (1000 * 60 * 60 * 24);
-      expect(diffDays).toBe(3);
+      expect(diffDays).toBe(-4);
       expect(displayedWeekStart.getDay()).toBe(3); // Wednesday
     });
 
-    it("queries the previous reportingPeriod (last Sunday) when today is in the Sun-Tue catch-up window, while still displaying that period's Wednesday", async () => {
+    it("queries the current reportingPeriod (this Sunday-anchored week) when today is in the Sun-Tue catch-up window, while still displaying last Wednesday's window", async () => {
       jest.useFakeTimers().setSystemTime(new Date('2026-08-17T09:00:00')); // Monday
       const field = {
         id: 1,
@@ -1461,10 +1463,11 @@ describe('ReportsService', () => {
       const periodCall = submissionQb.andWhere.mock.calls.find(([sql]) =>
         sql.includes('submission.reportingPeriod ='),
       );
-      // Monday 2026-08-17 falls before this calendar week's Wednesday, so
-      // it's a catch-up submission for the period due last Wednesday
-      // (2026-08-12) -- stored under last Sunday, 2026-08-09.
-      expect(periodCall[1].period).toBe('2026-08-09');
+      // Monday 2026-08-17 is a catch-up submission for the cycle due last
+      // Wednesday (2026-08-12), which is keyed by the Sunday inside that
+      // cycle (2026-08-12 + 4 = 2026-08-16) -- this calendar week's own
+      // Sunday-anchored start, unchanged by the catch-up.
+      expect(periodCall[1].period).toBe('2026-08-16');
       expect(result.weekStart).toBe('2026-08-12');
       expect(result.weekEnd).toBe('2026-08-18');
 

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -377,14 +377,18 @@ export class ReportsService {
     //
     // For weekly reports with a known due day (see
     // REPORT_DUE_DAY_OF_WEEK -- currently only MC Attendance Report,
-    // due Wednesdays), the target period is chosen by where "today" sits
-    // relative to that due day: days before it in the current Sun-Sat
-    // week are a catch-up window for last week's due day, so they target
-    // the *previous* period; days on/after it target the current period.
-    // This is deliberately day-aware, not "whichever period happens to be
-    // empty" -- an on-time Wednesday submission always targets the
-    // current week even if last week was never submitted, and a late
-    // catch-up never eats the slot for the upcoming on-time submission.
+    // due Wednesdays), a reporting "cycle" runs due-day..due-day+6 (e.g.
+    // Wed..Tue) and is keyed by the Sunday that falls *inside* that cycle
+    // -- always due-day-of-week + 4 days later, never the Sunday that
+    // precedes the due day. Concretely, for Wednesday: a submission on
+    // Wed/Thu/Fri/Sat targets the Sunday ahead (the one that closes out
+    // this cycle); a submission on Sun/Mon/Tue is the catch-up tail of the
+    // *previous* cycle, so it targets the current Sunday-anchored week
+    // unchanged. This is deliberately day-aware, not "whichever period
+    // happens to be empty" -- an on-time Wednesday submission always
+    // targets its own upcoming cycle even if the previous one was never
+    // submitted, and a late catch-up never eats the slot for the next
+    // on-time submission.
     // Reports with no configured due day (Sunday Service, Weekly Oikos,
     // daily/monthly reports, etc.) don't get this treatment since their
     // expected day isn't known -- they simply target the current period.
@@ -779,19 +783,19 @@ export class ReportsService {
     }
   }
 
-  private getPreviousPeriodStart(periodStart: Date, frequency: string): Date {
-    const previous = new Date(periodStart);
+  private getNextPeriodStart(periodStart: Date, frequency: string): Date {
+    const next = new Date(periodStart);
     switch (frequency) {
       case 'daily':
-        previous.setDate(previous.getDate() - 1);
-        return previous;
+        next.setDate(next.getDate() + 1);
+        return next;
       case 'monthly':
-        previous.setMonth(previous.getMonth() - 1);
-        return previous;
+        next.setMonth(next.getMonth() + 1);
+        return next;
       case 'weekly':
       default:
-        previous.setDate(previous.getDate() - 7);
-        return previous;
+        next.setDate(next.getDate() + 7);
+        return next;
     }
   }
 
@@ -802,6 +806,13 @@ export class ReportsService {
   // display) so the two can never disagree about which period "now" falls
   // in. Always Sunday-anchored, even for reports whose due day isn't
   // Sunday -- see getStartOfWeek.
+  //
+  // The period key is the Sunday *inside* the due-day..due-day+6 cycle
+  // (due-day-of-week + 4 days), not the Sunday that precedes the due day.
+  // So on/after the due day (e.g. Wed/Thu/Fri/Sat) rolls forward to next
+  // week's Sunday -- that cycle's own key -- while before the due day
+  // (Sun/Mon/Tue, the catch-up tail of the *previous* cycle) stays on the
+  // current Sunday-anchored week, which is that previous cycle's key.
   private getDueDayAwarePeriodStart(
     now: Date,
     reportName: string,
@@ -813,8 +824,8 @@ export class ReportsService {
         ? ReportsService.REPORT_DUE_DAY_OF_WEEK[reportName?.toLowerCase()]
         : undefined;
 
-    return dueDayOfWeek !== undefined && now.getDay() < dueDayOfWeek
-      ? this.getPreviousPeriodStart(currentPeriodStart, 'weekly')
+    return dueDayOfWeek !== undefined && now.getDay() >= dueDayOfWeek
+      ? this.getNextPeriodStart(currentPeriodStart, 'weekly')
       : currentPeriodStart;
   }
 
@@ -1847,17 +1858,18 @@ export class ReportsService {
     // The MC Attendance Report's actual reporting week runs Wednesday to
     // the following Tuesday (due Wednesdays, with a Sun-Tue catch-up
     // window for the Wednesday that just passed -- see
-    // REPORT_DUE_DAY_OF_WEEK). reportingPeriod is always stored
-    // Sunday-anchored regardless, so periodStart is what we query by,
-    // while weekStart/weekEnd (its Wednesday..Tuesday equivalent) is what
-    // gets displayed to the user.
+    // REPORT_DUE_DAY_OF_WEEK). reportingPeriod is stored as the Sunday
+    // that falls *inside* that cycle -- 4 days after its Wednesday, not
+    // the Sunday before it -- so periodStart is what we query by, while
+    // weekStart/weekEnd (its Wednesday..Tuesday equivalent, periodStart
+    // minus 4 days) is what gets displayed to the user.
     const periodStart = this.getDueDayAwarePeriodStart(
       new Date(),
       ReportsService.MCA_REPORT_NAME,
       'weekly',
     );
     const weekStart = new Date(periodStart);
-    weekStart.setDate(weekStart.getDate() + 3);
+    weekStart.setDate(weekStart.getDate() - 4);
     const weekEnd = new Date(weekStart);
     weekEnd.setDate(weekEnd.getDate() + 6);
 

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -394,19 +394,11 @@ export class ReportsService {
     const now = new Date();
     let targetPeriod: string | undefined = undefined;
     if (report.submissionFrequency !== 'custom') {
-      const currentPeriodStart = this.getPeriodStart(
+      const periodStart = this.getDueDayAwarePeriodStart(
         now,
+        report.name,
         report.submissionFrequency,
       );
-      const dueDayOfWeek =
-        report.submissionFrequency === 'weekly'
-          ? ReportsService.REPORT_DUE_DAY_OF_WEEK[report.name?.toLowerCase()]
-          : undefined;
-
-      const periodStart =
-        dueDayOfWeek !== undefined && now.getDay() < dueDayOfWeek
-          ? this.getPreviousPeriodStart(currentPeriodStart, 'weekly')
-          : currentPeriodStart;
       targetPeriod = this.formatDateKey(periodStart);
 
       const periodScopeWhere: any = {
@@ -801,6 +793,29 @@ export class ReportsService {
         previous.setDate(previous.getDate() - 7);
         return previous;
     }
+  }
+
+  // The reportingPeriod a submission made "now" would be assigned to, for
+  // reports with a configured due day (see REPORT_DUE_DAY_OF_WEEK). Shared
+  // by submitReport (to pick the target period for a new submission) and
+  // getWeeklyMcaSummary (to query the period that's currently "live" for
+  // display) so the two can never disagree about which period "now" falls
+  // in. Always Sunday-anchored, even for reports whose due day isn't
+  // Sunday -- see getStartOfWeek.
+  private getDueDayAwarePeriodStart(
+    now: Date,
+    reportName: string,
+    frequency: string,
+  ): Date {
+    const currentPeriodStart = this.getPeriodStart(now, frequency);
+    const dueDayOfWeek =
+      frequency === 'weekly'
+        ? ReportsService.REPORT_DUE_DAY_OF_WEEK[reportName?.toLowerCase()]
+        : undefined;
+
+    return dueDayOfWeek !== undefined && now.getDay() < dueDayOfWeek
+      ? this.getPreviousPeriodStart(currentPeriodStart, 'weekly')
+      : currentPeriodStart;
   }
 
   async getReport(reportId: number): Promise<Report> {
@@ -1828,7 +1843,21 @@ export class ReportsService {
     reportFound: boolean;
   }> {
     const tenantId = this.tenantContext.requireTenant();
-    const weekStart = this.getStartOfWeek(new Date());
+
+    // The MC Attendance Report's actual reporting week runs Wednesday to
+    // the following Tuesday (due Wednesdays, with a Sun-Tue catch-up
+    // window for the Wednesday that just passed -- see
+    // REPORT_DUE_DAY_OF_WEEK). reportingPeriod is always stored
+    // Sunday-anchored regardless, so periodStart is what we query by,
+    // while weekStart/weekEnd (its Wednesday..Tuesday equivalent) is what
+    // gets displayed to the user.
+    const periodStart = this.getDueDayAwarePeriodStart(
+      new Date(),
+      ReportsService.MCA_REPORT_NAME,
+      'weekly',
+    );
+    const weekStart = new Date(periodStart);
+    weekStart.setDate(weekStart.getDate() + 3);
     const weekEnd = new Date(weekStart);
     weekEnd.setDate(weekEnd.getDate() + 6);
 
@@ -1895,7 +1924,7 @@ export class ReportsService {
       .where('submission.report = :reportId', { reportId })
       .andWhere('group.id IN (:...groupIds)', { groupIds })
       .andWhere('submission.reportingPeriod = :period', {
-        period: this.formatDateKey(weekStart),
+        period: this.formatDateKey(periodStart),
       })
       .getMany();
 

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1927,6 +1927,7 @@ export class ReportsService {
     const submissions = await this.reportSubmissionRepository
       .createQueryBuilder('submission')
       .innerJoinAndSelect('submission.group', 'group')
+      .innerJoin('submission.report', 'submissionReport')
       .innerJoinAndSelect(
         'submission.submissionData',
         'submissionData',
@@ -1938,6 +1939,8 @@ export class ReportsService {
       .andWhere('submission.reportingPeriod = :period', {
         period: this.formatDateKey(periodStart),
       })
+      .andWhere('submissionReport.tenant = :tenantId', { tenantId })
+      .andWhere('group.tenant = :tenantId', { tenantId })
       .getMany();
 
     let total = 0;


### PR DESCRIPTION
… Wednesday due day

getWeeklyMcaSummary computed a plain Sunday-Saturday window, while submitReport assigns reportingPeriod using Wednesday-due-day-aware catch-up logic (Sun-Tue submissions roll into last Wednesday's period). The mismatch meant the summary queried the wrong period, most visibly showing stale/zero totals on Sunday through Tuesday.

Extract the due-day period calculation into a shared getDueDayAwarePeriodStart helper used by both call sites, and have getWeeklyMcaSummary query by the Sunday-anchored reportingPeriod key while displaying the Wednesday-to-Tuesday window it represents.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekly report period selection for Sunday–Tuesday catch-up scenarios.
  * Corrected weekly MCA summaries to display the appropriate Wednesday–Tuesday date range.
  * Improved duplicate report checks by aligning them with the correct reporting period.
  * Ensured sequential catch-up and on-time submissions are handled across distinct reporting cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->