### PR TITLE
feat: allow updating a user's email/username together on update()

### DIFF
--- a/src/crm/contacts.service.spec.ts
+++ b/src/crm/contacts.service.spec.ts
@@ -19,6 +19,7 @@ import Group from '../groups/entities/group.entity';
 import GroupMembershipRequest from '../groups/entities/groupMembershipRequest.entity';
 import { Tenant } from '../tenants/entities/tenant.entity';
 import { GroupRole } from '../groups/enums/groupRole';
+import { User } from '../users/entities/user.entity';
 
 describe('ContactsService', () => {
   let service: ContactsService;
@@ -53,6 +54,7 @@ describe('ContactsService', () => {
       groupTree: { findDescendants: jest.fn() },
       gmRequest: { save: jest.fn() },
       tenant: { findOne: jest.fn() },
+      user: { findOne: jest.fn(), update: jest.fn() },
     };
 
     // Create mock connection
@@ -68,6 +70,7 @@ describe('ContactsService', () => {
         if (entity === GroupMembershipRequest)
           return mockRepositories.gmRequest;
         if (entity === Tenant) return mockRepositories.tenant;
+        if (entity === User) return mockRepositories.user;
         return mockRepositories.contact;
       }),
       getTreeRepository: jest.fn().mockReturnValue(mockRepositories.groupTree),
@@ -249,6 +252,110 @@ describe('ContactsService', () => {
       await expect(invoke(contact, [])).rejects.toThrow(
         'Contact must be assigned to at least one group',
       );
+    });
+  });
+
+  describe('syncUserEmailFromContact', () => {
+    const invoke = (contact: any) =>
+      (service as any).syncUserEmailFromContact(contact);
+
+    it('updates the user email/username when the contact has a new primary email', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce({ id: 1, username: 'old@example.com' }) // user for this contact
+        .mockResolvedValueOnce(undefined); // no collision
+
+      await invoke({
+        id: 10,
+        emails: [{ value: 'new@example.com', isPrimary: true }],
+      });
+
+      expect(mockRepositories.user.update).toHaveBeenCalledWith(
+        { id: 1 },
+        { email: 'new@example.com', username: 'new@example.com' },
+      );
+    });
+
+    it('sets username to the new email for a previously email-less user (username was a phone number)', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce({ id: 1, username: '0700123456' })
+        .mockResolvedValueOnce(undefined); // no collision
+
+      await invoke({
+        id: 10,
+        emails: [{ value: 'newlyadded@example.com', isPrimary: true }],
+      });
+
+      expect(mockRepositories.user.update).toHaveBeenCalledWith(
+        { id: 1 },
+        { email: 'newlyadded@example.com', username: 'newlyadded@example.com' },
+      );
+    });
+
+    it('falls back to the first email when none is marked primary', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce({ id: 1, username: 'old@example.com' })
+        .mockResolvedValueOnce(undefined);
+
+      await invoke({
+        id: 10,
+        emails: [{ value: 'first@example.com', isPrimary: false }],
+      });
+
+      expect(mockRepositories.user.update).toHaveBeenCalledWith(
+        { id: 1 },
+        { email: 'first@example.com', username: 'first@example.com' },
+      );
+    });
+
+    it('does nothing when the contact has no linked user', async () => {
+      mockRepositories.user.findOne.mockResolvedValueOnce(undefined);
+
+      await invoke({
+        id: 10,
+        emails: [{ value: 'new@example.com', isPrimary: true }],
+      });
+
+      expect(mockRepositories.user.update).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when all emails were removed from the contact', async () => {
+      mockRepositories.user.findOne.mockResolvedValueOnce({
+        id: 1,
+        username: 'old@example.com',
+      });
+
+      await invoke({ id: 10, emails: [] });
+
+      expect(mockRepositories.user.update).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when the new email matches the current username (case-insensitive)', async () => {
+      mockRepositories.user.findOne.mockResolvedValueOnce({
+        id: 1,
+        username: 'same@example.com',
+      });
+
+      await invoke({
+        id: 10,
+        emails: [{ value: 'Same@Example.com', isPrimary: true }],
+      });
+
+      expect(mockRepositories.user.update).not.toHaveBeenCalled();
+    });
+
+    it('throws when another user already owns the new email', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce({ id: 1, username: 'old@example.com' })
+        .mockResolvedValueOnce({ id: 2, username: 'new@example.com' });
+
+      await expect(
+        invoke({
+          id: 10,
+          emails: [{ value: 'new@example.com', isPrimary: true }],
+        }),
+      ).rejects.toThrow('Email already in use by another user');
+
+      expect(mockRepositories.user.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/crm/contacts.service.spec.ts
+++ b/src/crm/contacts.service.spec.ts
@@ -270,7 +270,7 @@ describe('ContactsService', () => {
       });
 
       expect(mockRepositories.user.update).toHaveBeenCalledWith(
-        { id: 1 },
+        { id: 1, tenant: { id: 1 } },
         { email: 'new@example.com', username: 'new@example.com' },
       );
     });
@@ -286,7 +286,7 @@ describe('ContactsService', () => {
       });
 
       expect(mockRepositories.user.update).toHaveBeenCalledWith(
-        { id: 1 },
+        { id: 1, tenant: { id: 1 } },
         { email: 'newlyadded@example.com', username: 'newlyadded@example.com' },
       );
     });
@@ -302,7 +302,7 @@ describe('ContactsService', () => {
       });
 
       expect(mockRepositories.user.update).toHaveBeenCalledWith(
-        { id: 1 },
+        { id: 1, tenant: { id: 1 } },
         { email: 'first@example.com', username: 'first@example.com' },
       );
     });
@@ -329,10 +329,11 @@ describe('ContactsService', () => {
       expect(mockRepositories.user.update).not.toHaveBeenCalled();
     });
 
-    it('is a no-op when the new email matches the current username (case-insensitive)', async () => {
+    it('is a no-op when the new email matches both the current username and email (case-insensitive)', async () => {
       mockRepositories.user.findOne.mockResolvedValueOnce({
         id: 1,
         username: 'same@example.com',
+        email: 'same@example.com',
       });
 
       await invoke({
@@ -341,6 +342,26 @@ describe('ContactsService', () => {
       });
 
       expect(mockRepositories.user.update).not.toHaveBeenCalled();
+    });
+
+    it('repairs a stale email when it matches the username but not the email', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce({
+          id: 1,
+          username: 'same@example.com',
+          email: 'stale@example.com',
+        })
+        .mockResolvedValueOnce(undefined); // no collision
+
+      await invoke({
+        id: 10,
+        emails: [{ value: 'Same@Example.com', isPrimary: true }],
+      });
+
+      expect(mockRepositories.user.update).toHaveBeenCalledWith(
+        { id: 1, tenant: { id: 1 } },
+        { email: 'same@example.com', username: 'same@example.com' },
+      );
     });
 
     it('throws when another user already owns the new email', async () => {

--- a/src/crm/contacts.service.spec.ts
+++ b/src/crm/contacts.service.spec.ts
@@ -378,5 +378,24 @@ describe('ContactsService', () => {
 
       expect(mockRepositories.user.update).not.toHaveBeenCalled();
     });
+
+    it('throws when another user already owns the new email as their email (but not their username)', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce({ id: 1, username: 'old@example.com' })
+        .mockResolvedValueOnce({
+          id: 2,
+          username: 'someone-else',
+          email: 'new@example.com',
+        });
+
+      await expect(
+        invoke({
+          id: 10,
+          emails: [{ value: 'new@example.com', isPrimary: true }],
+        }),
+      ).rejects.toThrow('Email already in use by another user');
+
+      expect(mockRepositories.user.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -34,6 +34,7 @@ import Company from './entities/company.entity';
 import { CreateCompanyDto } from './dto/create-company.dto';
 import { hasNoValue, hasValue } from 'src/utils/validation';
 import Address from './entities/address.entity';
+import { User } from '../users/entities/user.entity';
 import GroupMembership from '../groups/entities/groupMembership.entity';
 import { GroupRole } from '../groups/enums/groupRole';
 import { roleAdmin } from '../auth/constants';
@@ -69,6 +70,11 @@ export class ContactsService {
   private readonly groupRepository: TreeRepository<Group>;
   private readonly gmRequestRepository: Repository<GroupMembershipRequest>;
   private readonly tenantRepository: Repository<Tenant>;
+  // Email doubles as login username for User (see UsersService.update) — this
+  // repository lets ContactsService keep that in sync going the other
+  // direction, without depending on UsersModule (which already depends on
+  // CrmModule, so importing UsersService here would be circular).
+  private readonly userRepository: Repository<User>;
   private readonly logger: ContextLogger;
 
   constructor(
@@ -91,6 +97,7 @@ export class ContactsService {
     this.groupRepository = connection.getTreeRepository(Group);
     this.gmRequestRepository = connection.getRepository(GroupMembershipRequest);
     this.tenantRepository = connection.getRepository(Tenant);
+    this.userRepository = connection.getRepository(User);
     this.logger = this.appLogger.createContextLogger('ContactsService');
   }
 
@@ -1290,6 +1297,7 @@ export class ContactsService {
       // Handle nested email updates
       if (data.emails) {
         await this.updateEmailsEfficiently(existingContact, data.emails);
+        await this.syncUserEmailFromContact(existingContact);
       }
 
       // Handle nested phone updates
@@ -1722,6 +1730,40 @@ export class ContactsService {
     }
 
     existingContact.emails = emailsToKeep;
+  }
+
+  /**
+   * Keeps User.email/username in sync when a contact's email is patched via
+   * this endpoint — the reverse direction of UsersService.update(), which
+   * syncs the contact's Email row when the user's login email changes.
+   * No-op for contacts that have no login User (e.g. visitors).
+   */
+  private async syncUserEmailFromContact(contact: Contact): Promise<void> {
+    const user = await this.userRepository.findOne({
+      where: { contactId: contact.id },
+    });
+    if (!user) return;
+
+    const primaryEmail =
+      contact.emails?.find((e) => e.isPrimary)?.value ??
+      contact.emails?.[0]?.value;
+    // Don't blank out an existing login if the last email was removed.
+    if (!hasValue(primaryEmail)) return;
+
+    const normalizedEmail = primaryEmail.trim().toLowerCase();
+    if (normalizedEmail === user.username?.toLowerCase()) return;
+
+    const existing = await this.userRepository.findOne({
+      where: { username: ILike(normalizedEmail) },
+    });
+    if (existing && existing.id !== user.id) {
+      throw new BadRequestException('Email already in use by another user');
+    }
+
+    await this.userRepository.update(
+      { id: user.id },
+      { email: normalizedEmail, username: normalizedEmail },
+    );
   }
 
   private async updatePhonesEfficiently(

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -630,7 +630,7 @@ export class ContactsService {
         // Phone/address upserts, email mutation, and the linked User sync must
         // all roll back together with the contact save on any collision error.
         const savedContact = await this.connection.transaction(
-          async (manager) => {
+          async(manager) => {
             if (data.phones) {
               await this.updatePhonesEfficiently(
                 existingContact,
@@ -1330,7 +1330,7 @@ export class ContactsService {
         // and the linked User update must all roll back together with the
         // contact save on any collision error.
         const savedContact = await this.connection.transaction(
-          async (manager) => {
+          async(manager) => {
             if (data.phones) {
               await this.updatePhonesEfficiently(
                 existingContact,

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -14,6 +14,7 @@ import {
   Like,
   Repository,
   Connection,
+  EntityManager,
   TreeRepository,
   DeepPartial,
 } from 'typeorm';
@@ -75,6 +76,7 @@ export class ContactsService {
   // direction, without depending on UsersModule (which already depends on
   // CrmModule, so importing UsersService here would be circular).
   private readonly userRepository: Repository<User>;
+  private readonly connection: Connection;
   private readonly logger: ContextLogger;
 
   constructor(
@@ -98,6 +100,7 @@ export class ContactsService {
     this.gmRequestRepository = connection.getRepository(GroupMembershipRequest);
     this.tenantRepository = connection.getRepository(Tenant);
     this.userRepository = connection.getRepository(User);
+    this.connection = connection;
     this.logger = this.appLogger.createContextLogger('ContactsService');
   }
 
@@ -1294,12 +1297,6 @@ export class ContactsService {
         }
       }
 
-      // Handle nested email updates
-      if (data.emails) {
-        await this.updateEmailsEfficiently(existingContact, data.emails);
-        await this.syncUserEmailFromContact(existingContact);
-      }
-
       // Handle nested phone updates
       if (data.phones) {
         await this.updatePhonesEfficiently(existingContact, data.phones);
@@ -1325,8 +1322,20 @@ export class ContactsService {
       }
 
       try {
-        // Save the contact first (without group memberships to avoid constraint issues)
-        const savedContact = await this.repository.save(existingContact);
+        // Save the contact first (without group memberships to avoid constraint issues).
+        // Email mutation, username-collision validation, and the linked User update
+        // must roll back together with the contact save on any collision error.
+        const savedContact = data.emails
+          ? await this.connection.transaction(async (manager) => {
+              await this.updateEmailsEfficiently(
+                existingContact,
+                data.emails,
+                manager,
+              );
+              await this.syncUserEmailFromContact(existingContact, manager);
+              return manager.getRepository(Contact).save(existingContact);
+            })
+          : await this.repository.save(existingContact);
 
         // Handle group membership updates after contact is saved
         if (data.groups !== undefined) {
@@ -1680,7 +1689,11 @@ export class ContactsService {
   private async updateEmailsEfficiently(
     existingContact: Contact,
     newEmails: Partial<Email>[],
+    manager?: EntityManager,
   ): Promise<void> {
+    const emailRepository = manager
+      ? manager.getRepository(Email)
+      : this.emailRepository;
     const existingEmails = existingContact.emails || [];
     const emailsToKeep: Email[] = [];
     const emailsToUpdate: Email[] = [];
@@ -1711,20 +1724,18 @@ export class ContactsService {
     );
 
     if (emailsToRemove.length > 0) {
-      await this.emailRepository.remove(emailsToRemove);
+      await emailRepository.remove(emailsToRemove);
     }
 
     // Update existing emails
     if (emailsToUpdate.length > 0) {
-      await this.emailRepository.save(emailsToUpdate);
+      await emailRepository.save(emailsToUpdate);
     }
 
     // Create new emails
     if (emailsToCreate.length > 0) {
-      const createdEmails = await this.emailRepository.save(
-        emailsToCreate.map((emailData) =>
-          this.emailRepository.create(emailData),
-        ),
+      const createdEmails = await emailRepository.save(
+        emailsToCreate.map((emailData) => emailRepository.create(emailData)),
       );
       emailsToKeep.push(...createdEmails);
     }
@@ -1738,9 +1749,18 @@ export class ContactsService {
    * syncs the contact's Email row when the user's login email changes.
    * No-op for contacts that have no login User (e.g. visitors).
    */
-  private async syncUserEmailFromContact(contact: Contact): Promise<void> {
-    const user = await this.userRepository.findOne({
-      where: { contactId: contact.id },
+  private async syncUserEmailFromContact(
+    contact: Contact,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const userRepository = manager
+      ? manager.getRepository(User)
+      : this.userRepository;
+    const tenantId = this.tenantContext.tenantId;
+    const tenantWhere = tenantId ? { tenant: { id: tenantId } } : {};
+
+    const user = await userRepository.findOne({
+      where: { contactId: contact.id, ...tenantWhere },
     });
     if (!user) return;
 
@@ -1753,15 +1773,15 @@ export class ContactsService {
     const normalizedEmail = primaryEmail.trim().toLowerCase();
     if (normalizedEmail === user.username?.toLowerCase()) return;
 
-    const existing = await this.userRepository.findOne({
-      where: { username: ILike(normalizedEmail) },
+    const existing = await userRepository.findOne({
+      where: { username: ILike(normalizedEmail), ...tenantWhere },
     });
     if (existing && existing.id !== user.id) {
       throw new BadRequestException('Email already in use by another user');
     }
 
-    await this.userRepository.update(
-      { id: user.id },
+    await userRepository.update(
+      { id: user.id, ...tenantWhere },
       { email: normalizedEmail, username: normalizedEmail },
     );
   }

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -611,16 +611,6 @@ export class ContactsService {
         }
       }
 
-      // Handle phones update with efficient upsert
-      if (data.phones) {
-        await this.updatePhonesEfficiently(existingContact, data.phones);
-      }
-
-      // Handle addresses update with efficient upsert
-      if (data.addresses) {
-        await this.updateAddressesEfficiently(existingContact, data.addresses);
-      }
-
       // Handle other contact fields (excluding nested entities and group assignment)
       const {
         person,
@@ -637,20 +627,35 @@ export class ContactsService {
 
       try {
         // Save the contact first (without group memberships to avoid constraint issues).
-        // Email mutation and the linked User sync must roll back together with
-        // the contact save on any collision error.
-        const newEmails = data.emails;
-        const savedContact = newEmails
-          ? await this.connection.transaction(async (manager) => {
+        // Phone/address upserts, email mutation, and the linked User sync must
+        // all roll back together with the contact save on any collision error.
+        const savedContact = await this.connection.transaction(
+          async (manager) => {
+            if (data.phones) {
+              await this.updatePhonesEfficiently(
+                existingContact,
+                data.phones,
+                manager,
+              );
+            }
+            if (data.addresses) {
+              await this.updateAddressesEfficiently(
+                existingContact,
+                data.addresses,
+                manager,
+              );
+            }
+            if (data.emails) {
               await this.updateEmailsEfficiently(
                 existingContact,
-                newEmails,
+                data.emails,
                 manager,
               );
               await this.syncUserEmailFromContact(existingContact, manager);
-              return manager.getRepository(Contact).save(existingContact);
-            })
-          : await this.repository.save(existingContact);
+            }
+            return manager.getRepository(Contact).save(existingContact);
+          },
+        );
 
         // Handle group membership updates after contact is saved
         const groups = (data as any).groups;
@@ -1305,16 +1310,6 @@ export class ContactsService {
         }
       }
 
-      // Handle nested phone updates
-      if (data.phones) {
-        await this.updatePhonesEfficiently(existingContact, data.phones);
-      }
-
-      // Handle nested address updates
-      if (data.addresses) {
-        await this.updateAddressesEfficiently(existingContact, data.addresses);
-      }
-
       // Remove groups field from contact data since it's handled separately
       const {
         person: __person,
@@ -1331,19 +1326,36 @@ export class ContactsService {
 
       try {
         // Save the contact first (without group memberships to avoid constraint issues).
-        // Email mutation, username-collision validation, and the linked User update
-        // must roll back together with the contact save on any collision error.
-        const savedContact = data.emails
-          ? await this.connection.transaction(async (manager) => {
+        // Phone/address upserts, email mutation, username-collision validation,
+        // and the linked User update must all roll back together with the
+        // contact save on any collision error.
+        const savedContact = await this.connection.transaction(
+          async (manager) => {
+            if (data.phones) {
+              await this.updatePhonesEfficiently(
+                existingContact,
+                data.phones,
+                manager,
+              );
+            }
+            if (data.addresses) {
+              await this.updateAddressesEfficiently(
+                existingContact,
+                data.addresses,
+                manager,
+              );
+            }
+            if (data.emails) {
               await this.updateEmailsEfficiently(
                 existingContact,
                 data.emails,
                 manager,
               );
               await this.syncUserEmailFromContact(existingContact, manager);
-              return manager.getRepository(Contact).save(existingContact);
-            })
-          : await this.repository.save(existingContact);
+            }
+            return manager.getRepository(Contact).save(existingContact);
+          },
+        );
 
         // Handle group membership updates after contact is saved
         if (data.groups !== undefined) {
@@ -1786,7 +1798,10 @@ export class ContactsService {
       return;
 
     const existing = await userRepository.findOne({
-      where: { username: ILike(normalizedEmail), ...tenantWhere },
+      where: [
+        { username: ILike(normalizedEmail), ...tenantWhere },
+        { email: ILike(normalizedEmail), ...tenantWhere },
+      ],
     });
     if (existing && existing.id !== user.id) {
       throw new BadRequestException('Email already in use by another user');
@@ -1801,7 +1816,11 @@ export class ContactsService {
   private async updatePhonesEfficiently(
     existingContact: Contact,
     newPhones: Partial<Phone>[],
+    manager?: EntityManager,
   ): Promise<void> {
+    const phoneRepository = manager
+      ? manager.getRepository(Phone)
+      : this.phoneRepository;
     const existingPhones = existingContact.phones || [];
     const phonesToKeep: Phone[] = [];
     const phonesToUpdate: Phone[] = [];
@@ -1832,20 +1851,18 @@ export class ContactsService {
     );
 
     if (phonesToRemove.length > 0) {
-      await this.phoneRepository.remove(phonesToRemove);
+      await phoneRepository.remove(phonesToRemove);
     }
 
     // Update existing phones
     if (phonesToUpdate.length > 0) {
-      await this.phoneRepository.save(phonesToUpdate);
+      await phoneRepository.save(phonesToUpdate);
     }
 
     // Create new phones
     if (phonesToCreate.length > 0) {
-      const createdPhones = await this.phoneRepository.save(
-        phonesToCreate.map((phoneData) =>
-          this.phoneRepository.create(phoneData),
-        ),
+      const createdPhones = await phoneRepository.save(
+        phonesToCreate.map((phoneData) => phoneRepository.create(phoneData)),
       );
       phonesToKeep.push(...createdPhones);
     }
@@ -1856,7 +1873,11 @@ export class ContactsService {
   private async updateAddressesEfficiently(
     existingContact: Contact,
     newAddresses: Partial<Address>[],
+    manager?: EntityManager,
   ): Promise<void> {
+    const addressRepository = manager
+      ? manager.getRepository(Address)
+      : this.addressRepository;
     const existingAddresses = existingContact.addresses || [];
     const addressesToKeep: Address[] = [];
     const addressesToUpdate: Address[] = [];
@@ -1889,19 +1910,19 @@ export class ContactsService {
     );
 
     if (addressesToRemove.length > 0) {
-      await this.addressRepository.remove(addressesToRemove);
+      await addressRepository.remove(addressesToRemove);
     }
 
     // Update existing addresses
     if (addressesToUpdate.length > 0) {
-      await this.addressRepository.save(addressesToUpdate);
+      await addressRepository.save(addressesToUpdate);
     }
 
     // Create new addresses
     if (addressesToCreate.length > 0) {
-      const createdAddresses = await this.addressRepository.save(
+      const createdAddresses = await addressRepository.save(
         addressesToCreate.map((addressData) =>
-          this.addressRepository.create(addressData),
+          addressRepository.create(addressData),
         ),
       );
       addressesToKeep.push(...createdAddresses);

--- a/src/crm/contacts.service.ts
+++ b/src/crm/contacts.service.ts
@@ -611,11 +611,6 @@ export class ContactsService {
         }
       }
 
-      // Handle emails update with efficient upsert
-      if (data.emails) {
-        await this.updateEmailsEfficiently(existingContact, data.emails);
-      }
-
       // Handle phones update with efficient upsert
       if (data.phones) {
         await this.updatePhonesEfficiently(existingContact, data.phones);
@@ -641,8 +636,21 @@ export class ContactsService {
       }
 
       try {
-        // Save the contact first (without group memberships to avoid constraint issues)
-        const savedContact = await this.repository.save(existingContact);
+        // Save the contact first (without group memberships to avoid constraint issues).
+        // Email mutation and the linked User sync must roll back together with
+        // the contact save on any collision error.
+        const newEmails = data.emails;
+        const savedContact = newEmails
+          ? await this.connection.transaction(async (manager) => {
+              await this.updateEmailsEfficiently(
+                existingContact,
+                newEmails,
+                manager,
+              );
+              await this.syncUserEmailFromContact(existingContact, manager);
+              return manager.getRepository(Contact).save(existingContact);
+            })
+          : await this.repository.save(existingContact);
 
         // Handle group membership updates after contact is saved
         const groups = (data as any).groups;
@@ -1756,8 +1764,8 @@ export class ContactsService {
     const userRepository = manager
       ? manager.getRepository(User)
       : this.userRepository;
-    const tenantId = this.tenantContext.tenantId;
-    const tenantWhere = tenantId ? { tenant: { id: tenantId } } : {};
+    const tenantId = this.tenantContext.requireTenant();
+    const tenantWhere = { tenant: { id: tenantId } };
 
     const user = await userRepository.findOne({
       where: { contactId: contact.id, ...tenantWhere },
@@ -1771,7 +1779,11 @@ export class ContactsService {
     if (!hasValue(primaryEmail)) return;
 
     const normalizedEmail = primaryEmail.trim().toLowerCase();
-    if (normalizedEmail === user.username?.toLowerCase()) return;
+    if (
+      normalizedEmail === user.username?.toLowerCase() &&
+      normalizedEmail === user.email?.toLowerCase()
+    )
+      return;
 
     const existing = await userRepository.findOne({
       where: { username: ILike(normalizedEmail), ...tenantWhere },

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,9 +1,20 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsArray, IsBoolean } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsArray,
+  IsBoolean,
+  IsEmail,
+} from 'class-validator';
 
 export class UpdateUserDto {
   @IsNotEmpty()
   @IsNumber()
   id: number;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
 
   @IsOptional()
   @IsArray()

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -4,17 +4,12 @@ import {
   IsOptional,
   IsArray,
   IsBoolean,
-  IsEmail,
 } from 'class-validator';
 
 export class UpdateUserDto {
   @IsNotEmpty()
   @IsNumber()
   id: number;
-
-  @IsOptional()
-  @IsEmail()
-  email?: string;
 
   @IsOptional()
   @IsArray()

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -405,6 +405,7 @@ describe('UsersService', () => {
 
       await service.update({ id: 1, email: 'new@example.com' } as any);
 
+      expect(mockRepositories.user.createQueryBuilder).not.toHaveBeenCalled();
       expect(mockUpdateQb.set).not.toHaveBeenCalledWith(
         expect.objectContaining({ email: expect.anything() }),
       );

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -33,6 +33,7 @@ describe('UsersService', () => {
   let mockRepositories: any;
   let mockGroupRepo: any;
   let mockMembershipQb: any;
+  let mockUpdateQb: any;
 
   beforeEach(async () => {
     mockMembershipQb = {
@@ -41,6 +42,13 @@ describe('UsersService', () => {
       andWhere: jest.fn().mockReturnThis(),
       select: jest.fn().mockReturnThis(),
       getMany: jest.fn(),
+    };
+
+    mockUpdateQb = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined),
     };
 
     // groupRepository is a TenantAwareRepository<Group> constructed once in
@@ -60,10 +68,13 @@ describe('UsersService', () => {
         create: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
+        createQueryBuilder: jest.fn().mockReturnValue(mockUpdateQb),
       },
       email: {
         find: jest.fn(),
+        findOne: jest.fn(),
         save: jest.fn(),
+        update: jest.fn(),
       },
       roles: {
         find: jest.fn(),
@@ -186,10 +197,12 @@ describe('UsersService', () => {
         false,
       );
 
-      await expect(
-        service.findUsersInGroup(5, requestingUser),
-      ).rejects.toThrow(ForbiddenException);
-      expect(mockRepositories.membership.createQueryBuilder).not.toHaveBeenCalled();
+      await expect(service.findUsersInGroup(5, requestingUser)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(
+        mockRepositories.membership.createQueryBuilder,
+      ).not.toHaveBeenCalled();
     });
 
     it('scopes to a single group when no FOB ancestor exists', async () => {
@@ -354,6 +367,107 @@ describe('UsersService', () => {
       // contactId appeared twice in the membership rows.
       expect(mockRepositories.user.find).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    const buildUser = (overrides: Partial<User> = {}): any => ({
+      id: 1,
+      contactId: 10,
+      username: 'old@example.com',
+      email: 'old@example.com',
+      isActive: true,
+      userRoles: [],
+      contact: { person: { firstName: 'A', lastName: 'B' } },
+      ...overrides,
+    });
+
+    it('updates the username and email together when a new email is provided', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce(buildUser()) // initial findOne(data.id)
+        .mockResolvedValueOnce(undefined) // no existing user with the new email
+        .mockResolvedValueOnce(
+          buildUser({ email: 'new@example.com', username: 'new@example.com' }),
+        ); // re-fetch after update
+      mockRepositories.email.findOne.mockResolvedValueOnce({
+        id: 99,
+        contactId: 10,
+        value: 'old@example.com',
+      });
+
+      const result = await service.update({ id: 1, email: 'New@Example.com' });
+
+      expect(mockUpdateQb.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          username: 'new@example.com',
+        }),
+      );
+      expect(mockRepositories.email.update).toHaveBeenCalledWith(
+        { id: 99 },
+        { value: 'new@example.com' },
+      );
+      expect(result.email).toBe('new@example.com');
+      expect(result.username).toBe('new@example.com');
+    });
+
+    it('rejects when the new email is already used by another user', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce(buildUser())
+        .mockResolvedValueOnce(buildUser({ id: 2 })); // another user owns this email
+
+      await expect(
+        service.update({ id: 1, email: 'new@example.com' }),
+      ).rejects.toThrow('Username/email already in use');
+
+      expect(mockUpdateQb.set).not.toHaveBeenCalled();
+      expect(mockRepositories.email.update).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when the submitted email matches the current one (case-insensitive)', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce(buildUser())
+        .mockResolvedValueOnce(buildUser());
+
+      await service.update({ id: 1, email: 'OLD@example.com' });
+
+      expect(mockRepositories.user.findOne).toHaveBeenCalledTimes(2); // no collision lookup
+      expect(mockUpdateQb.set).toHaveBeenCalledWith(
+        expect.not.objectContaining({ email: expect.anything() }),
+      );
+      expect(mockRepositories.email.update).not.toHaveBeenCalled();
+    });
+
+    it('leaves email/username untouched when no email is submitted', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce(buildUser())
+        .mockResolvedValueOnce(buildUser());
+
+      await service.update({ id: 1, isActive: false });
+
+      expect(mockUpdateQb.set).toHaveBeenCalledWith({ isActive: false });
+      expect(mockRepositories.email.findOne).not.toHaveBeenCalled();
+      expect(mockRepositories.email.update).not.toHaveBeenCalled();
+    });
+
+    it('updates the User row even when the contact has no linked Email record', async () => {
+      mockRepositories.user.findOne
+        .mockResolvedValueOnce(buildUser())
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(
+          buildUser({ email: 'new@example.com', username: 'new@example.com' }),
+        );
+      mockRepositories.email.findOne.mockResolvedValueOnce(undefined);
+
+      await service.update({ id: 1, email: 'new@example.com' });
+
+      expect(mockUpdateQb.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          username: 'new@example.com',
+        }),
+      );
+      expect(mockRepositories.email.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -382,66 +382,10 @@ describe('UsersService', () => {
       ...overrides,
     });
 
-    it('updates the username and email together when a new email is provided', async () => {
-      mockRepositories.user.findOne
-        .mockResolvedValueOnce(buildUser()) // initial findOne(data.id)
-        .mockResolvedValueOnce(undefined) // no existing user with the new email
-        .mockResolvedValueOnce(
-          buildUser({ email: 'new@example.com', username: 'new@example.com' }),
-        ); // re-fetch after update
-      mockRepositories.email.findOne.mockResolvedValueOnce({
-        id: 99,
-        contactId: 10,
-        value: 'old@example.com',
-      });
-
-      const result = await service.update({ id: 1, email: 'New@Example.com' });
-
-      expect(mockUpdateQb.set).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: 'new@example.com',
-          username: 'new@example.com',
-        }),
-      );
-      expect(mockRepositories.email.update).toHaveBeenCalledWith(
-        { id: 99 },
-        { value: 'new@example.com' },
-      );
-      expect(result.email).toBe('new@example.com');
-      expect(result.username).toBe('new@example.com');
-    });
-
-    it('rejects when the new email is already used by another user', async () => {
+    it('updates isActive without touching email/username', async () => {
       mockRepositories.user.findOne
         .mockResolvedValueOnce(buildUser())
-        .mockResolvedValueOnce(buildUser({ id: 2 })); // another user owns this email
-
-      await expect(
-        service.update({ id: 1, email: 'new@example.com' }),
-      ).rejects.toThrow('Username/email already in use');
-
-      expect(mockUpdateQb.set).not.toHaveBeenCalled();
-      expect(mockRepositories.email.update).not.toHaveBeenCalled();
-    });
-
-    it('is a no-op when the submitted email matches the current one (case-insensitive)', async () => {
-      mockRepositories.user.findOne
-        .mockResolvedValueOnce(buildUser())
-        .mockResolvedValueOnce(buildUser());
-
-      await service.update({ id: 1, email: 'OLD@example.com' });
-
-      expect(mockRepositories.user.findOne).toHaveBeenCalledTimes(2); // no collision lookup
-      expect(mockUpdateQb.set).toHaveBeenCalledWith(
-        expect.not.objectContaining({ email: expect.anything() }),
-      );
-      expect(mockRepositories.email.update).not.toHaveBeenCalled();
-    });
-
-    it('leaves email/username untouched when no email is submitted', async () => {
-      mockRepositories.user.findOne
-        .mockResolvedValueOnce(buildUser())
-        .mockResolvedValueOnce(buildUser());
+        .mockResolvedValueOnce(buildUser({ isActive: false }));
 
       await service.update({ id: 1, isActive: false });
 
@@ -450,22 +394,19 @@ describe('UsersService', () => {
       expect(mockRepositories.email.update).not.toHaveBeenCalled();
     });
 
-    it('updates the User row even when the contact has no linked Email record', async () => {
+    // Email/username changes are now owned exclusively by
+    // ContactsService.syncUserEmailFromContact (see contacts.service.ts),
+    // so this endpoint must never write them, even if a stale caller still
+    // sends an `email` field.
+    it('ignores an email field if one is still sent by a caller', async () => {
       mockRepositories.user.findOne
         .mockResolvedValueOnce(buildUser())
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(
-          buildUser({ email: 'new@example.com', username: 'new@example.com' }),
-        );
-      mockRepositories.email.findOne.mockResolvedValueOnce(undefined);
+        .mockResolvedValueOnce(buildUser());
 
-      await service.update({ id: 1, email: 'new@example.com' });
+      await service.update({ id: 1, email: 'new@example.com' } as any);
 
-      expect(mockUpdateQb.set).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: 'new@example.com',
-          username: 'new@example.com',
-        }),
+      expect(mockUpdateQb.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ email: expect.anything() }),
       );
       expect(mockRepositories.email.update).not.toHaveBeenCalled();
     });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -378,12 +378,14 @@ export class UsersService {
       }
     }
 
-    const resp = await this.repository
-      .createQueryBuilder()
-      .update()
-      .set(update)
-      .where('id = :id', { id: data.id })
-      .execute();
+    if (Object.keys(update).length > 0) {
+      await this.repository
+        .createQueryBuilder()
+        .update()
+        .set(update)
+        .where('id = :id', { id: data.id })
+        .execute();
+    }
 
     return await this.findOne(data.id);
   }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -334,32 +334,6 @@ export class UsersService {
       update.isActive = data.isActive;
     }
 
-    // Email doubles as username (see createUser): updating one updates both.
-    if (hasValue(data.email)) {
-      const normalizedEmail = (data.email as string).trim().toLowerCase();
-      if (normalizedEmail !== _user.email?.toLowerCase()) {
-        const existing = await this.repository.findOne({
-          where: { username: ILike(normalizedEmail) },
-        });
-        if (existing && existing.id !== data.id) {
-          throw new HttpException('Username/email already in use', 409);
-        }
-
-        update.email = normalizedEmail;
-        update.username = normalizedEmail;
-
-        const emailRecord = await this.emailRepository.findOne({
-          where: { contactId: _user.contactId },
-        });
-        if (emailRecord) {
-          await this.emailRepository.update(
-            { id: emailRecord.id },
-            { value: normalizedEmail },
-          );
-        }
-      }
-    }
-
     if (hasValue(data.password)) {
       const user = new User();
       user.password = data.password;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -61,7 +61,10 @@ export class UsersService {
     this.rolesRepository = connection.getRepository(Roles);
     this.userRolesRepository = connection.getRepository(UserRoles);
     this.personRepository = connection.getRepository(Person);
-    this.groupRepository = new GroupRepository(connection.manager, tenantContext);
+    this.groupRepository = new GroupRepository(
+      connection.manager,
+      tenantContext,
+    );
     this.membershipRepository = connection.getRepository(GroupMembership);
   }
 
@@ -329,6 +332,32 @@ export class UsersService {
     // Only update isActive if provided
     if ('isActive' in data && data.isActive !== undefined) {
       update.isActive = data.isActive;
+    }
+
+    // Email doubles as username (see createUser): updating one updates both.
+    if (hasValue(data.email)) {
+      const normalizedEmail = (data.email as string).trim().toLowerCase();
+      if (normalizedEmail !== _user.email?.toLowerCase()) {
+        const existing = await this.repository.findOne({
+          where: { username: ILike(normalizedEmail) },
+        });
+        if (existing && existing.id !== data.id) {
+          throw new HttpException('Username/email already in use', 409);
+        }
+
+        update.email = normalizedEmail;
+        update.username = normalizedEmail;
+
+        const emailRecord = await this.emailRepository.findOne({
+          where: { contactId: _user.contactId },
+        });
+        if (emailRecord) {
+          await this.emailRepository.update(
+            { id: emailRecord.id },
+            { value: normalizedEmail },
+          );
+        }
+      }
     }
 
     if (hasValue(data.password)) {


### PR DESCRIPTION
Email doubles as the login username for email-bearing users, so updating one without the other would leave them out of sync. Also syncs the linked crm Email row for the contact and rejects the update if another user already owns the new email.


# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact email updates now synchronize the linked user’s email and username.
  * Email matching is case-insensitive, with fallback selection when multiple contact emails are available.
  * Stale user email details are repaired when contact information changes.

* **Bug Fixes**
  * Contacts without a linked user or email are handled safely.
  * Duplicate login emails are rejected to prevent conflicts.
  * Contact and user email changes are saved together to prevent partial updates.
  * User updates correctly apply active-status changes and avoid unnecessary empty updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->